### PR TITLE
pbio/platform/prime_hub: change dual boot button

### DIFF
--- a/lib/pbio/platform/prime_hub/platform.c
+++ b/lib/pbio/platform/prime_hub/platform.c
@@ -692,7 +692,7 @@ void SystemInit(void) {
 
     HAL_RCC_ClockConfig(&clk_init, FLASH_LATENCY_5);
 
-    // If we are running dual boot, jump to other firmware if no buttons are pressed
+    // Check button logic to select which firmware to boot.
     pbio_platform_dual_boot();
 
     // enable 8-byte stack alignment for IRQ handlers, in accord with EABI


### PR DESCRIPTION
Previously, we required Center + Right buttons to be pressed to boot Pybricks.

This simplifies it to use *only* the center button:
Short press = stock firmware; long press = Pybricks.

This makes it easier to operate the buttons with one hand, which is especially convenient if the hub is built into a large robot. Also, most hubs (Technic / City) have only one button, so this theoretically lets us keep it consistent across hubs, even though we probably won't ever have enough free space on those hubs.