### PR TITLE
Cleaner handling of object attributes

### DIFF
--- a/bricks/ev3dev/pb_type_ev3dev_font.c
+++ b/bricks/ev3dev/pb_type_ev3dev_font.c
@@ -16,6 +16,8 @@
 
 #include "pb_ev3dev_types.h"
 
+#include <pybricks/util_mp/pb_obj_helper.h>
+
 typedef struct _ev3dev_Font_obj_t {
     mp_obj_base_t base;
     GrxFont *font;
@@ -133,13 +135,18 @@ STATIC mp_obj_t ev3dev_Font_text_height(mp_obj_t self_in, mp_obj_t text_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(ev3dev_Font_text_height_obj, ev3dev_Font_text_height);
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(ev3dev_Font_obj_t, MP_QSTR_family, family),
+    PB_DEFINE_CONST_ATTR_RO(ev3dev_Font_obj_t, MP_QSTR_style, style),
+    PB_DEFINE_CONST_ATTR_RO(ev3dev_Font_obj_t, MP_QSTR_width, width),
+    PB_DEFINE_CONST_ATTR_RO(ev3dev_Font_obj_t, MP_QSTR_height, height),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 STATIC const mp_rom_map_elem_t ev3dev_Font_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_DEFAULT), MP_ROM_PTR(&pb_const_ev3dev_Font_DEFAULT_obj) },
     { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&ev3dev_Font___del___obj) },
-    { MP_ROM_QSTR(MP_QSTR_family), MP_ROM_ATTRIBUTE_OFFSET(ev3dev_Font_obj_t, family) },
-    { MP_ROM_QSTR(MP_QSTR_style), MP_ROM_ATTRIBUTE_OFFSET(ev3dev_Font_obj_t, style) },
-    { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_ATTRIBUTE_OFFSET(ev3dev_Font_obj_t, width) },
-    { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_ATTRIBUTE_OFFSET(ev3dev_Font_obj_t, height) },
     { MP_ROM_QSTR(MP_QSTR_text_width), MP_ROM_PTR(&ev3dev_Font_text_width_obj) },
     { MP_ROM_QSTR(MP_QSTR_text_height), MP_ROM_PTR(&ev3dev_Font_text_height_obj) },
 };
@@ -149,6 +156,7 @@ const mp_obj_type_t pb_type_ev3dev_Font = {
     { &mp_type_type },
     .name = MP_QSTR_Font,
     .make_new = ev3dev_Font_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&ev3dev_Font_locals_dict,
 };
 

--- a/bricks/ev3dev/pb_type_ev3dev_image.c
+++ b/bricks/ev3dev/pb_type_ev3dev_image.c
@@ -547,7 +547,14 @@ STATIC mp_obj_t ev3dev_Image_save(mp_obj_t self_in, mp_obj_t filename_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(ev3dev_Image_save_obj, ev3dev_Image_save);
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(ev3dev_Image_obj_t, MP_QSTR_width, width),
+    PB_DEFINE_CONST_ATTR_RO(ev3dev_Image_obj_t, MP_QSTR_height, height),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 STATIC const mp_rom_map_elem_t ev3dev_Image_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_empty),       MP_ROM_PTR(&ev3dev_Image_empty_obj)                    },
     { MP_ROM_QSTR(MP_QSTR___del__),     MP_ROM_PTR(&ev3dev_Image___del___obj)                  },
     { MP_ROM_QSTR(MP_QSTR_clear),       MP_ROM_PTR(&ev3dev_Image_clear_obj)                    },
@@ -561,8 +568,6 @@ STATIC const mp_rom_map_elem_t ev3dev_Image_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_set_font),    MP_ROM_PTR(&ev3dev_Image_set_font_obj)                 },
     { MP_ROM_QSTR(MP_QSTR_print),       MP_ROM_PTR(&ev3dev_Image_print_obj)                    },
     { MP_ROM_QSTR(MP_QSTR_save),        MP_ROM_PTR(&ev3dev_Image_save_obj)                     },
-    { MP_ROM_QSTR(MP_QSTR_width),       MP_ROM_ATTRIBUTE_OFFSET(ev3dev_Image_obj_t, width)     },
-    { MP_ROM_QSTR(MP_QSTR_height),      MP_ROM_ATTRIBUTE_OFFSET(ev3dev_Image_obj_t, height)    },
 };
 STATIC MP_DEFINE_CONST_DICT(ev3dev_Image_locals_dict, ev3dev_Image_locals_dict_table);
 
@@ -570,5 +575,6 @@ const mp_obj_type_t pb_type_ev3dev_Image = {
     { &mp_type_type },
     .name = MP_QSTR_Image,
     .make_new = ev3dev_Image_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&ev3dev_Image_locals_dict,
 };

--- a/pybricks/common/pb_type_control.c
+++ b/pybricks/common/pb_type_control.c
@@ -231,8 +231,17 @@ STATIC mp_obj_t common_Control_stalled(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(common_Control_stalled_obj, common_Control_stalled);
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(common_Control_obj_t, MP_QSTR_scale, scale),
+    #if PYBRICKS_PY_COMMON_LOGGER
+    PB_DEFINE_CONST_ATTR_RO(common_Control_obj_t, MP_QSTR_log, logger),
+    #endif // PYBRICKS_PY_COMMON_LOGGER
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 // dir(pybricks.common.Control)
 STATIC const mp_rom_map_elem_t common_Control_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_limits), MP_ROM_PTR(&common_Control_limits_obj) },
     { MP_ROM_QSTR(MP_QSTR_pid), MP_ROM_PTR(&common_Control_pid_obj) },
     { MP_ROM_QSTR(MP_QSTR_target_tolerances), MP_ROM_PTR(&common_Control_target_tolerances_obj) },
@@ -241,10 +250,6 @@ STATIC const mp_rom_map_elem_t common_Control_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_done), MP_ROM_PTR(&common_Control_done_obj) },
     { MP_ROM_QSTR(MP_QSTR_load), MP_ROM_PTR(&common_Control_load_obj) },
     { MP_ROM_QSTR(MP_QSTR_stalled), MP_ROM_PTR(&common_Control_stalled_obj) },
-    { MP_ROM_QSTR(MP_QSTR_scale), MP_ROM_ATTRIBUTE_OFFSET(common_Control_obj_t, scale) },
-    #if PYBRICKS_PY_COMMON_LOGGER
-    { MP_ROM_QSTR(MP_QSTR_log), MP_ROM_ATTRIBUTE_OFFSET(common_Control_obj_t, logger) },
-    #endif // PYBRICKS_PY_COMMON_LOGGER
 };
 STATIC MP_DEFINE_CONST_DICT(common_Control_locals_dict, common_Control_locals_dict_table);
 
@@ -252,6 +257,7 @@ STATIC MP_DEFINE_CONST_DICT(common_Control_locals_dict, common_Control_locals_di
 const mp_obj_type_t pb_type_Control = {
     { &mp_type_type },
     .name = MP_QSTR_Control,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&common_Control_locals_dict,
 };
 

--- a/pybricks/common/pb_type_motor.c
+++ b/pybricks/common/pb_type_motor.c
@@ -345,8 +345,19 @@ STATIC mp_obj_t common_Motor_stalled(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(common_Motor_stalled_obj, common_Motor_stalled);
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    #if PYBRICKS_PY_COMMON_CONTROL
+    PB_DEFINE_CONST_ATTR_RO(common_Motor_obj_t, MP_QSTR_control, control),
+    #endif
+    #if PYBRICKS_PY_COMMON_LOGGER
+    PB_DEFINE_CONST_ATTR_RO(common_Motor_obj_t, MP_QSTR_log, logger),
+    #endif
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 // dir(pybricks.builtins.Motor)
 STATIC const mp_rom_map_elem_t common_Motor_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     //
     // Methods common to DC motors and encoded motors
     //
@@ -369,12 +380,6 @@ STATIC const mp_rom_map_elem_t common_Motor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_track_target), MP_ROM_PTR(&common_Motor_track_target_obj) },
     { MP_ROM_QSTR(MP_QSTR_busy), MP_ROM_PTR(&common_Motor_busy_obj) },
     { MP_ROM_QSTR(MP_QSTR_stalled), MP_ROM_PTR(&common_Motor_stalled_obj) },
-    #if PYBRICKS_PY_COMMON_CONTROL
-    { MP_ROM_QSTR(MP_QSTR_control), MP_ROM_ATTRIBUTE_OFFSET(common_Motor_obj_t, control) },
-    #endif
-    #if PYBRICKS_PY_COMMON_LOGGER
-    { MP_ROM_QSTR(MP_QSTR_log), MP_ROM_ATTRIBUTE_OFFSET(common_Motor_obj_t, logger) },
-    #endif
 };
 MP_DEFINE_CONST_DICT(common_Motor_locals_dict, common_Motor_locals_dict_table);
 
@@ -384,6 +389,7 @@ const mp_obj_type_t pb_type_Motor = {
     .name = MP_QSTR_Motor,
     .print = common_DCMotor_print,
     .make_new = common_Motor_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&common_Motor_locals_dict,
 };
 

--- a/pybricks/hubs/pb_type_cityhub.c
+++ b/pybricks/hubs/pb_type_cityhub.c
@@ -11,6 +11,8 @@
 #include <pybricks/common.h>
 #include <pybricks/hubs.h>
 
+#include <pybricks/util_mp/pb_obj_helper.h>
+
 typedef struct _hubs_CityHub_obj_t {
     mp_obj_base_t base;
     mp_obj_t button;
@@ -29,10 +31,15 @@ STATIC mp_obj_t hubs_CityHub_make_new(const mp_obj_type_t *type, size_t n_args, 
     return MP_OBJ_FROM_PTR(self);
 }
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(hubs_CityHub_obj_t, MP_QSTR_button, button),
+    PB_DEFINE_CONST_ATTR_RO(hubs_CityHub_obj_t, MP_QSTR_light, light),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 STATIC const mp_rom_map_elem_t hubs_CityHub_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_battery),     MP_ROM_PTR(&pb_module_battery)    },
-    { MP_ROM_QSTR(MP_QSTR_button),      MP_ROM_ATTRIBUTE_OFFSET(hubs_CityHub_obj_t, button)},
-    { MP_ROM_QSTR(MP_QSTR_light),       MP_ROM_ATTRIBUTE_OFFSET(hubs_CityHub_obj_t, light) },
     { MP_ROM_QSTR(MP_QSTR_system),      MP_ROM_PTR(&pb_type_System) },
 };
 STATIC MP_DEFINE_CONST_DICT(hubs_CityHub_locals_dict, hubs_CityHub_locals_dict_table);
@@ -41,6 +48,7 @@ const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = MP_QSTR_CityHub,
     .make_new = hubs_CityHub_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&hubs_CityHub_locals_dict,
 };
 

--- a/pybricks/hubs/pb_type_essentialhub.c
+++ b/pybricks/hubs/pb_type_essentialhub.c
@@ -18,6 +18,7 @@
 #include <pbio/button.h>
 
 #include <pybricks/util_mp/pb_kwarg_helper.h>
+#include <pybricks/util_mp/pb_obj_helper.h>
 
 #include <pybricks/common.h>
 #include <pybricks/geometry.h>
@@ -49,12 +50,17 @@ STATIC mp_obj_t hubs_EssentialHub_make_new(const mp_obj_type_t *type, size_t n_a
     return MP_OBJ_FROM_PTR(self);
 }
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(hubs_EssentialHub_obj_t, MP_QSTR_button, buttons),
+    PB_DEFINE_CONST_ATTR_RO(hubs_EssentialHub_obj_t, MP_QSTR_charger, charger),
+    PB_DEFINE_CONST_ATTR_RO(hubs_EssentialHub_obj_t, MP_QSTR_imu, imu),
+    PB_DEFINE_CONST_ATTR_RO(hubs_EssentialHub_obj_t, MP_QSTR_light, light),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 STATIC const mp_rom_map_elem_t hubs_EssentialHub_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_battery), MP_ROM_PTR(&pb_module_battery)    },
-    { MP_ROM_QSTR(MP_QSTR_button), MP_ROM_ATTRIBUTE_OFFSET(hubs_EssentialHub_obj_t, buttons) },
-    { MP_ROM_QSTR(MP_QSTR_charger), MP_ROM_ATTRIBUTE_OFFSET(hubs_EssentialHub_obj_t, charger) },
-    { MP_ROM_QSTR(MP_QSTR_imu), MP_ROM_ATTRIBUTE_OFFSET(hubs_EssentialHub_obj_t, imu) },
-    { MP_ROM_QSTR(MP_QSTR_light), MP_ROM_ATTRIBUTE_OFFSET(hubs_EssentialHub_obj_t, light) },
     { MP_ROM_QSTR(MP_QSTR_system), MP_ROM_PTR(&pb_type_System) },
 };
 STATIC MP_DEFINE_CONST_DICT(hubs_EssentialHub_locals_dict, hubs_EssentialHub_locals_dict_table);
@@ -63,6 +69,7 @@ const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = PYBRICKS_HUB_CLASS_NAME,
     .make_new = hubs_EssentialHub_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&hubs_EssentialHub_locals_dict,
 };
 

--- a/pybricks/hubs/pb_type_ev3brick.c
+++ b/pybricks/hubs/pb_type_ev3brick.c
@@ -4,12 +4,14 @@
 #include "py/mpconfig.h"
 
 #if PYBRICKS_PY_HUBS && PYBRICKS_HUB_EV3BRICK
+#include <pbio/util.h>
 
 #include <pybricks/common.h>
 #include <pybricks/hubs.h>
-#include <pbio/util.h>
+#include <pybricks/util_mp/pb_obj_helper.h>
 
 #include "pb_ev3dev_types.h"
+
 
 // defined in pbio/platform/ev3dev_stretch/status_light.c
 extern pbio_color_light_t *ev3dev_status_light;
@@ -46,12 +48,17 @@ STATIC mp_obj_t hubs_EV3Brick_make_new(const mp_obj_type_t *type, size_t n_args,
     return MP_OBJ_FROM_PTR(self);
 }
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(hubs_EV3Brick_obj_t, MP_QSTR_buttons, buttons),
+    PB_DEFINE_CONST_ATTR_RO(hubs_EV3Brick_obj_t, MP_QSTR_light, light),
+    PB_DEFINE_CONST_ATTR_RO(hubs_EV3Brick_obj_t, MP_QSTR_screen, screen),
+    PB_DEFINE_CONST_ATTR_RO(hubs_EV3Brick_obj_t, MP_QSTR_speaker, speaker),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 STATIC const mp_rom_map_elem_t hubs_EV3Brick_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_battery),     MP_ROM_PTR(&pb_module_battery)      },
-    { MP_ROM_QSTR(MP_QSTR_buttons),     MP_ROM_ATTRIBUTE_OFFSET(hubs_EV3Brick_obj_t, buttons) },
-    { MP_ROM_QSTR(MP_QSTR_light),       MP_ROM_ATTRIBUTE_OFFSET(hubs_EV3Brick_obj_t, light)   },
-    { MP_ROM_QSTR(MP_QSTR_screen),      MP_ROM_ATTRIBUTE_OFFSET(hubs_EV3Brick_obj_t, screen)  },
-    { MP_ROM_QSTR(MP_QSTR_speaker),     MP_ROM_ATTRIBUTE_OFFSET(hubs_EV3Brick_obj_t, speaker) },
     { MP_ROM_QSTR(MP_QSTR_system),      MP_ROM_PTR(&pb_type_System)                           },
 };
 STATIC MP_DEFINE_CONST_DICT(hubs_EV3Brick_locals_dict, hubs_EV3Brick_locals_dict_table);
@@ -60,6 +67,7 @@ const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = PYBRICKS_HUB_CLASS_NAME,
     .make_new = hubs_EV3Brick_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&hubs_EV3Brick_locals_dict,
 };
 

--- a/pybricks/hubs/pb_type_movehub.c
+++ b/pybricks/hubs/pb_type_movehub.c
@@ -14,6 +14,8 @@
 #include <pybricks/common.h>
 #include <pybricks/hubs.h>
 
+#include <pybricks/util_mp/pb_obj_helper.h>
+
 // LIS3DH motion sensor
 
 #include "stm32f070xb.h"
@@ -198,6 +200,7 @@ STATIC MP_DEFINE_CONST_DICT(hubs_MoveHub_IMU_locals_dict, hubs_MoveHub_IMU_local
 STATIC const mp_obj_type_t hubs_MoveHub_IMU_type = {
     { &mp_type_type },
     .name = MP_QSTR_Motion,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&hubs_MoveHub_IMU_locals_dict,
 };
 
@@ -260,11 +263,16 @@ STATIC mp_obj_t hubs_MoveHub_make_new(const mp_obj_type_t *type, size_t n_args, 
     return MP_OBJ_FROM_PTR(self);
 }
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(hubs_MoveHub_obj_t, MP_QSTR_button, button),
+    PB_DEFINE_CONST_ATTR_RO(hubs_MoveHub_obj_t, MP_QSTR_imu, imu),
+    PB_DEFINE_CONST_ATTR_RO(hubs_MoveHub_obj_t, MP_QSTR_light, light),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 STATIC const mp_rom_map_elem_t hubs_MoveHub_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_battery),     MP_ROM_PTR(&pb_module_battery)    },
-    { MP_ROM_QSTR(MP_QSTR_button),      MP_ROM_ATTRIBUTE_OFFSET(hubs_MoveHub_obj_t, button)},
-    { MP_ROM_QSTR(MP_QSTR_imu),         MP_ROM_ATTRIBUTE_OFFSET(hubs_MoveHub_obj_t, imu)   },
-    { MP_ROM_QSTR(MP_QSTR_light),       MP_ROM_ATTRIBUTE_OFFSET(hubs_MoveHub_obj_t, light) },
     { MP_ROM_QSTR(MP_QSTR_system),      MP_ROM_PTR(&pb_type_System)                        },
 };
 STATIC MP_DEFINE_CONST_DICT(hubs_MoveHub_locals_dict, hubs_MoveHub_locals_dict_table);
@@ -273,6 +281,7 @@ const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = PYBRICKS_HUB_CLASS_NAME,
     .make_new = hubs_MoveHub_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&hubs_MoveHub_locals_dict,
 };
 

--- a/pybricks/hubs/pb_type_nxtbrick.c
+++ b/pybricks/hubs/pb_type_nxtbrick.c
@@ -10,6 +10,8 @@
 #include <pybricks/common.h>
 #include <pybricks/hubs.h>
 
+#include <pybricks/util_mp/pb_obj_helper.h>
+
 typedef struct _hubs_NXTBrick_obj_t {
     mp_obj_base_t base;
     mp_obj_t buttons;
@@ -28,8 +30,13 @@ STATIC mp_obj_t hubs_NXTBrick_make_new(const mp_obj_type_t *type, size_t n_args,
     return MP_OBJ_FROM_PTR(self);
 }
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(hubs_NXTBrick_obj_t, MP_QSTR_buttons, buttons),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 STATIC const mp_rom_map_elem_t hubs_NXTBrick_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_buttons),     MP_ROM_ATTRIBUTE_OFFSET(hubs_NXTBrick_obj_t, buttons) },
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_battery),     MP_ROM_PTR(&pb_module_battery)                        },
     { MP_ROM_QSTR(MP_QSTR_system),      MP_ROM_PTR(&pb_type_System)                           },
 };
@@ -39,6 +46,7 @@ const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = PYBRICKS_HUB_CLASS_NAME,
     .make_new = hubs_NXTBrick_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&hubs_NXTBrick_locals_dict,
 };
 

--- a/pybricks/hubs/pb_type_primehub.c
+++ b/pybricks/hubs/pb_type_primehub.c
@@ -17,6 +17,7 @@
 
 #include <pbio/button.h>
 
+#include <pybricks/util_mp/pb_obj_helper.h>
 #include <pybricks/util_mp/pb_kwarg_helper.h>
 
 #include <pybricks/common.h>
@@ -56,15 +57,20 @@ STATIC mp_obj_t hubs_PrimeHub_make_new(const mp_obj_type_t *type, size_t n_args,
     return MP_OBJ_FROM_PTR(self);
 }
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(hubs_PrimeHub_obj_t, MP_QSTR_buttons, buttons),
+    PB_DEFINE_CONST_ATTR_RO(hubs_PrimeHub_obj_t, MP_QSTR_charger, charger),
+    PB_DEFINE_CONST_ATTR_RO(hubs_PrimeHub_obj_t, MP_QSTR_display, display),
+    PB_DEFINE_CONST_ATTR_RO(hubs_PrimeHub_obj_t, MP_QSTR_imu, imu),
+    PB_DEFINE_CONST_ATTR_RO(hubs_PrimeHub_obj_t, MP_QSTR_light, light),
+    PB_DEFINE_CONST_ATTR_RO(hubs_PrimeHub_obj_t, MP_QSTR_speaker, speaker),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 STATIC const mp_rom_map_elem_t hubs_PrimeHub_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_battery),     MP_ROM_PTR(&pb_module_battery)    },
-    { MP_ROM_QSTR(MP_QSTR_buttons),     MP_ROM_ATTRIBUTE_OFFSET(hubs_PrimeHub_obj_t, buttons) },
-    { MP_ROM_QSTR(MP_QSTR_charger),     MP_ROM_ATTRIBUTE_OFFSET(hubs_PrimeHub_obj_t, charger) },
-    { MP_ROM_QSTR(MP_QSTR_display),     MP_ROM_ATTRIBUTE_OFFSET(hubs_PrimeHub_obj_t, display) },
-    { MP_ROM_QSTR(MP_QSTR_imu),         MP_ROM_ATTRIBUTE_OFFSET(hubs_PrimeHub_obj_t, imu)     },
-    { MP_ROM_QSTR(MP_QSTR_light),       MP_ROM_ATTRIBUTE_OFFSET(hubs_PrimeHub_obj_t, light)   },
-    { MP_ROM_QSTR(MP_QSTR_speaker),     MP_ROM_ATTRIBUTE_OFFSET(hubs_PrimeHub_obj_t, speaker) },
-    { MP_ROM_QSTR(MP_QSTR_system),      MP_ROM_PTR(&pb_type_System)                           },
+    PB_ATTRIBUTE_TABLE(attribute_dict),
+    { MP_ROM_QSTR(MP_QSTR_battery),     MP_ROM_PTR(&pb_module_battery)},
+    { MP_ROM_QSTR(MP_QSTR_system),      MP_ROM_PTR(&pb_type_System)   },
 };
 STATIC MP_DEFINE_CONST_DICT(hubs_PrimeHub_locals_dict, hubs_PrimeHub_locals_dict_table);
 
@@ -72,6 +78,7 @@ const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = PYBRICKS_HUB_CLASS_NAME,
     .make_new = hubs_PrimeHub_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&hubs_PrimeHub_locals_dict,
 };
 

--- a/pybricks/hubs/pb_type_technichub.c
+++ b/pybricks/hubs/pb_type_technichub.c
@@ -9,6 +9,7 @@
 #include <pbsys/light.h>
 
 #include <pybricks/util_mp/pb_kwarg_helper.h>
+#include <pybricks/util_mp/pb_obj_helper.h>
 
 #include <pybricks/common.h>
 #include <pybricks/geometry.h>
@@ -38,11 +39,16 @@ STATIC mp_obj_t hubs_TechnicHub_make_new(const mp_obj_type_t *type, size_t n_arg
     return MP_OBJ_FROM_PTR(self);
 }
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(hubs_TechnicHub_obj_t, MP_QSTR_button, button),
+    PB_DEFINE_CONST_ATTR_RO(hubs_TechnicHub_obj_t, MP_QSTR_imu, imu),
+    PB_DEFINE_CONST_ATTR_RO(hubs_TechnicHub_obj_t, MP_QSTR_light, light),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 STATIC const mp_rom_map_elem_t hubs_TechnicHub_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_battery),     MP_ROM_PTR(&pb_module_battery)    },
-    { MP_ROM_QSTR(MP_QSTR_button),      MP_ROM_ATTRIBUTE_OFFSET(hubs_TechnicHub_obj_t, button)},
-    { MP_ROM_QSTR(MP_QSTR_imu),         MP_ROM_ATTRIBUTE_OFFSET(hubs_TechnicHub_obj_t, imu)   },
-    { MP_ROM_QSTR(MP_QSTR_light),       MP_ROM_ATTRIBUTE_OFFSET(hubs_TechnicHub_obj_t, light) },
     { MP_ROM_QSTR(MP_QSTR_system),      MP_ROM_PTR(&pb_type_System)                           },
 };
 STATIC MP_DEFINE_CONST_DICT(hubs_TechnicHub_locals_dict, hubs_TechnicHub_locals_dict_table);
@@ -51,6 +57,7 @@ const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = PYBRICKS_HUB_CLASS_NAME,
     .make_new = hubs_TechnicHub_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&hubs_TechnicHub_locals_dict,
 };
 

--- a/pybricks/iodevices/pb_type_iodevices_ev3devsensor.c
+++ b/pybricks/iodevices/pb_type_iodevices_ev3devsensor.c
@@ -73,11 +73,16 @@ STATIC mp_obj_t iodevices_Ev3devSensor_read(size_t n_args, const mp_obj_t *pos_a
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_Ev3devSensor_read_obj, 1, iodevices_Ev3devSensor_read);
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(iodevices_Ev3devSensor_obj_t, MP_QSTR_sensor_index, sensor_index),
+    PB_DEFINE_CONST_ATTR_RO(iodevices_Ev3devSensor_obj_t, MP_QSTR_port_index, port_index),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 // dir(pybricks.iodevices.Ev3devSensor)
 STATIC const mp_rom_map_elem_t iodevices_Ev3devSensor_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_read),         MP_ROM_PTR(&iodevices_Ev3devSensor_read_obj)                        },
-    { MP_ROM_QSTR(MP_QSTR_sensor_index), MP_ROM_ATTRIBUTE_OFFSET(iodevices_Ev3devSensor_obj_t, sensor_index) },
-    { MP_ROM_QSTR(MP_QSTR_port_index),   MP_ROM_ATTRIBUTE_OFFSET(iodevices_Ev3devSensor_obj_t, port_index)   },
 };
 STATIC MP_DEFINE_CONST_DICT(iodevices_Ev3devSensor_locals_dict, iodevices_Ev3devSensor_locals_dict_table);
 
@@ -85,6 +90,7 @@ STATIC MP_DEFINE_CONST_DICT(iodevices_Ev3devSensor_locals_dict, iodevices_Ev3dev
 const mp_obj_type_t pb_type_iodevices_Ev3devSensor = {
     { &mp_type_type },
     .make_new = iodevices_Ev3devSensor_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&iodevices_Ev3devSensor_locals_dict,
 };
 

--- a/pybricks/iodevices/pb_type_iodevices_lumpdevice.c
+++ b/pybricks/iodevices/pb_type_iodevices_lumpdevice.c
@@ -93,11 +93,16 @@ STATIC mp_obj_t iodevices_LUMPDevice_write(size_t n_args, const mp_obj_t *pos_ar
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_LUMPDevice_write_obj, 1, iodevices_LUMPDevice_write);
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(iodevices_LUMPDevice_obj_t, MP_QSTR_ID, id),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 // dir(pybricks.iodevices.LUMPDevice)
 STATIC const mp_rom_map_elem_t iodevices_LUMPDevice_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_read),       MP_ROM_PTR(&iodevices_LUMPDevice_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_write),      MP_ROM_PTR(&iodevices_LUMPDevice_write_obj)},
-    { MP_ROM_QSTR(MP_QSTR_ID),         MP_ROM_ATTRIBUTE_OFFSET(iodevices_LUMPDevice_obj_t, id) },
 };
 STATIC MP_DEFINE_CONST_DICT(iodevices_LUMPDevice_locals_dict, iodevices_LUMPDevice_locals_dict_table);
 
@@ -105,6 +110,7 @@ STATIC MP_DEFINE_CONST_DICT(iodevices_LUMPDevice_locals_dict, iodevices_LUMPDevi
 const mp_obj_type_t pb_type_iodevices_LUMPDevice = {
     { &mp_type_type },
     .make_new = iodevices_LUMPDevice_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&iodevices_LUMPDevice_locals_dict,
 };
 

--- a/pybricks/nxtdevices/pb_type_nxtdevices_colorsensor.c
+++ b/pybricks/nxtdevices/pb_type_nxtdevices_colorsensor.c
@@ -141,15 +141,20 @@ STATIC mp_obj_t nxtdevices_ColorSensor_color(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_ColorSensor_color_obj, nxtdevices_ColorSensor_color);
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(nxtdevices_ColorSensor_obj_t, MP_QSTR_light, light),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 // dir(pybricks.nxtdevices.ColorSensor)
 STATIC const mp_rom_map_elem_t nxtdevices_ColorSensor_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_hsv),        MP_ROM_PTR(&nxtdevices_ColorSensor_hsv_obj)                  },
     { MP_ROM_QSTR(MP_QSTR_rgb),        MP_ROM_PTR(&nxtdevices_ColorSensor_rgb_obj)                  },
     { MP_ROM_QSTR(MP_QSTR_ambient),    MP_ROM_PTR(&nxtdevices_ColorSensor_ambient_obj)              },
     { MP_ROM_QSTR(MP_QSTR_reflection), MP_ROM_PTR(&nxtdevices_ColorSensor_reflection_obj)           },
     { MP_ROM_QSTR(MP_QSTR_color),      MP_ROM_PTR(&nxtdevices_ColorSensor_color_obj)                },
     { MP_ROM_QSTR(MP_QSTR_detectable_colors),  MP_ROM_PTR(&pb_ColorSensor_detectable_colors_obj)                    },
-    { MP_ROM_QSTR(MP_QSTR_light),      MP_ROM_ATTRIBUTE_OFFSET(nxtdevices_ColorSensor_obj_t, light) },
 };
 STATIC MP_DEFINE_CONST_DICT(nxtdevices_ColorSensor_locals_dict, nxtdevices_ColorSensor_locals_dict_table);
 
@@ -158,6 +163,7 @@ const mp_obj_type_t pb_type_nxtdevices_ColorSensor = {
     { &mp_type_type },
     .name = MP_QSTR_ColorSensor,
     .make_new = nxtdevices_ColorSensor_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&nxtdevices_ColorSensor_locals_dict,
 };
 

--- a/pybricks/pupdevices/pb_type_pupdevices_colordistancesensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_colordistancesensor.c
@@ -149,15 +149,20 @@ STATIC mp_obj_t pupdevices_ColorDistanceSensor_hsv(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pupdevices_ColorDistanceSensor_hsv_obj, pupdevices_ColorDistanceSensor_hsv);
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(pupdevices_ColorDistanceSensor_obj_t, MP_QSTR_light, light),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 // dir(pybricks.pupdevices.ColorDistanceSensor)
 STATIC const mp_rom_map_elem_t pupdevices_ColorDistanceSensor_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_color),       MP_ROM_PTR(&pupdevices_ColorDistanceSensor_color_obj)                },
     { MP_ROM_QSTR(MP_QSTR_reflection),  MP_ROM_PTR(&pupdevices_ColorDistanceSensor_reflection_obj)           },
     { MP_ROM_QSTR(MP_QSTR_ambient),     MP_ROM_PTR(&pupdevices_ColorDistanceSensor_ambient_obj)              },
     { MP_ROM_QSTR(MP_QSTR_distance),    MP_ROM_PTR(&pupdevices_ColorDistanceSensor_distance_obj)             },
     { MP_ROM_QSTR(MP_QSTR_hsv),         MP_ROM_PTR(&pupdevices_ColorDistanceSensor_hsv_obj)                  },
     { MP_ROM_QSTR(MP_QSTR_detectable_colors),   MP_ROM_PTR(&pb_ColorSensor_detectable_colors_obj)                            },
-    { MP_ROM_QSTR(MP_QSTR_light),       MP_ROM_ATTRIBUTE_OFFSET(pupdevices_ColorDistanceSensor_obj_t, light) },
 };
 STATIC MP_DEFINE_CONST_DICT(pupdevices_ColorDistanceSensor_locals_dict, pupdevices_ColorDistanceSensor_locals_dict_table);
 
@@ -166,6 +171,7 @@ const mp_obj_type_t pb_type_pupdevices_ColorDistanceSensor = {
     { &mp_type_type },
     .name = MP_QSTR_ColorDistanceSensor,
     .make_new = pupdevices_ColorDistanceSensor_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&pupdevices_ColorDistanceSensor_locals_dict,
 };
 

--- a/pybricks/pupdevices/pb_type_pupdevices_colorsensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_colorsensor.c
@@ -152,9 +152,14 @@ STATIC mp_obj_t pupdevices_ColorSensor_ambient(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pupdevices_ColorSensor_ambient_obj, pupdevices_ColorSensor_ambient);
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(pupdevices_ColorSensor_obj_t, MP_QSTR_lights, lights),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 // dir(pybricks.pupdevices.ColorSensor)
 STATIC const mp_rom_map_elem_t pupdevices_ColorSensor_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_lights),      MP_ROM_ATTRIBUTE_OFFSET(pupdevices_ColorSensor_obj_t, lights)},
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_hsv),         MP_ROM_PTR(&pupdevices_ColorSensor_hsv_obj)                  },
     { MP_ROM_QSTR(MP_QSTR_color),       MP_ROM_PTR(&pupdevices_ColorSensor_color_obj)                },
     { MP_ROM_QSTR(MP_QSTR_reflection),  MP_ROM_PTR(&pupdevices_ColorSensor_reflection_obj)           },
@@ -168,6 +173,7 @@ const mp_obj_type_t pb_type_pupdevices_ColorSensor = {
     { &mp_type_type },
     .name = MP_QSTR_ColorSensor,
     .make_new = pupdevices_ColorSensor_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&pupdevices_ColorSensor_locals_dict,
 };
 

--- a/pybricks/pupdevices/pb_type_pupdevices_remote.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_remote.c
@@ -306,9 +306,14 @@ STATIC mp_obj_t remote_name(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(remote_name_obj, 1, 2, remote_name);
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(pb_type_pupdevices_Remote_obj_t, MP_QSTR_buttons, buttons),
+    PB_DEFINE_CONST_ATTR_RO(pb_type_pupdevices_Remote_obj_t, MP_QSTR_light, light),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 STATIC const mp_rom_map_elem_t pb_type_pupdevices_Remote_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_buttons), MP_ROM_ATTRIBUTE_OFFSET(pb_type_pupdevices_Remote_obj_t, buttons) },
-    { MP_ROM_QSTR(MP_QSTR_light), MP_ROM_ATTRIBUTE_OFFSET(pb_type_pupdevices_Remote_obj_t, light) },
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_name), MP_ROM_PTR(&remote_name_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(pb_type_pupdevices_Remote_locals_dict, pb_type_pupdevices_Remote_locals_dict_table);
@@ -317,6 +322,7 @@ const mp_obj_type_t pb_type_pupdevices_Remote = {
     { &mp_type_type },
     .name = MP_QSTR_Remote,
     .make_new = pb_type_pupdevices_Remote_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&pb_type_pupdevices_Remote_locals_dict,
 };
 

--- a/pybricks/pupdevices/pb_type_pupdevices_ultrasonicsensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_ultrasonicsensor.c
@@ -57,11 +57,16 @@ STATIC mp_obj_t pupdevices_UltrasonicSensor_presence(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(pupdevices_UltrasonicSensor_presence_obj, pupdevices_UltrasonicSensor_presence);
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(pupdevices_UltrasonicSensor_obj_t, MP_QSTR_lights, lights),
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 // dir(pybricks.pupdevices.UltrasonicSensor)
 STATIC const mp_rom_map_elem_t pupdevices_UltrasonicSensor_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_distance),     MP_ROM_PTR(&pupdevices_UltrasonicSensor_distance_obj)              },
     { MP_ROM_QSTR(MP_QSTR_presence),     MP_ROM_PTR(&pupdevices_UltrasonicSensor_presence_obj)              },
-    { MP_ROM_QSTR(MP_QSTR_lights),       MP_ROM_ATTRIBUTE_OFFSET(pupdevices_UltrasonicSensor_obj_t, lights) },
 };
 STATIC MP_DEFINE_CONST_DICT(pupdevices_UltrasonicSensor_locals_dict, pupdevices_UltrasonicSensor_locals_dict_table);
 
@@ -70,6 +75,7 @@ const mp_obj_type_t pb_type_pupdevices_UltrasonicSensor = {
     { &mp_type_type },
     .name = MP_QSTR_UltrasonicSensor,
     .make_new = pupdevices_UltrasonicSensor_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&pupdevices_UltrasonicSensor_locals_dict,
 };
 

--- a/pybricks/robotics/pb_type_drivebase.c
+++ b/pybricks/robotics/pb_type_drivebase.c
@@ -287,8 +287,19 @@ STATIC mp_obj_t robotics_DriveBase_settings(size_t n_args, const mp_obj_t *pos_a
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(robotics_DriveBase_settings_obj, 1, robotics_DriveBase_settings);
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(robotics_DriveBase_obj_t, MP_QSTR_left, left),
+    PB_DEFINE_CONST_ATTR_RO(robotics_DriveBase_obj_t, MP_QSTR_right, right),
+    #if PYBRICKS_PY_COMMON_CONTROL
+    PB_DEFINE_CONST_ATTR_RO(robotics_DriveBase_obj_t, MP_QSTR_heading_control, heading_control),
+    PB_DEFINE_CONST_ATTR_RO(robotics_DriveBase_obj_t, MP_QSTR_distance_control, distance_control),
+    #endif
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 // dir(pybricks.robotics.DriveBase)
 STATIC const mp_rom_map_elem_t robotics_DriveBase_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_curve),            MP_ROM_PTR(&robotics_DriveBase_curve_obj)    },
     { MP_ROM_QSTR(MP_QSTR_straight),         MP_ROM_PTR(&robotics_DriveBase_straight_obj) },
     { MP_ROM_QSTR(MP_QSTR_turn),             MP_ROM_PTR(&robotics_DriveBase_turn_obj)     },
@@ -300,12 +311,6 @@ STATIC const mp_rom_map_elem_t robotics_DriveBase_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_state),            MP_ROM_PTR(&robotics_DriveBase_state_obj)    },
     { MP_ROM_QSTR(MP_QSTR_reset),            MP_ROM_PTR(&robotics_DriveBase_reset_obj)    },
     { MP_ROM_QSTR(MP_QSTR_settings),         MP_ROM_PTR(&robotics_DriveBase_settings_obj) },
-    { MP_ROM_QSTR(MP_QSTR_left),             MP_ROM_ATTRIBUTE_OFFSET(robotics_DriveBase_obj_t, left)            },
-    { MP_ROM_QSTR(MP_QSTR_right),            MP_ROM_ATTRIBUTE_OFFSET(robotics_DriveBase_obj_t, right)           },
-    #if PYBRICKS_PY_COMMON_CONTROL
-    { MP_ROM_QSTR(MP_QSTR_heading_control),  MP_ROM_ATTRIBUTE_OFFSET(robotics_DriveBase_obj_t, heading_control) },
-    { MP_ROM_QSTR(MP_QSTR_distance_control), MP_ROM_ATTRIBUTE_OFFSET(robotics_DriveBase_obj_t, distance_control)},
-    #endif
 };
 STATIC MP_DEFINE_CONST_DICT(robotics_DriveBase_locals_dict, robotics_DriveBase_locals_dict_table);
 
@@ -314,6 +319,7 @@ const mp_obj_type_t pb_type_drivebase = {
     { &mp_type_type },
     .name = MP_QSTR_DriveBase,
     .make_new = robotics_DriveBase_make_new,
+    .attr = pb_attribute_handler,
     .locals_dict = (mp_obj_dict_t *)&robotics_DriveBase_locals_dict,
 };
 

--- a/pybricks/robotics/pb_type_spikebase.c
+++ b/pybricks/robotics/pb_type_spikebase.c
@@ -173,17 +173,24 @@ STATIC mp_obj_t robotics_SpikeBase_stop(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(robotics_SpikeBase_stop_obj, robotics_SpikeBase_stop);
 
+STATIC const mp_rom_map_elem_t attribute_table[] = {
+    PB_DEFINE_CONST_ATTR_RO(robotics_SpikeBase_obj_t, MP_QSTR_left, left),
+    PB_DEFINE_CONST_ATTR_RO(robotics_SpikeBase_obj_t, MP_QSTR_right, right),
+    #if PYBRICKS_PY_COMMON_CONTROL
+    PB_DEFINE_CONST_ATTR_RO(robotics_SpikeBase_obj_t, MP_QSTR_heading_control, heading_control),
+    PB_DEFINE_CONST_ATTR_RO(robotics_SpikeBase_obj_t, MP_QSTR_distance_control, distance_control),
+    #endif
+};
+STATIC MP_DEFINE_CONST_DICT(attribute_dict, attribute_table);
+
 // dir(pybricks.robotics.SpikeBase)
 STATIC const mp_rom_map_elem_t robotics_SpikeBase_locals_dict_table[] = {
+    PB_ATTRIBUTE_TABLE(attribute_dict),
     { MP_ROM_QSTR(MP_QSTR_tank_move_for_degrees),     MP_ROM_PTR(&robotics_SpikeBase_tank_move_for_degrees_obj)     },
     { MP_ROM_QSTR(MP_QSTR_tank_move_for_time),        MP_ROM_PTR(&robotics_SpikeBase_tank_move_for_time_obj)        },
     { MP_ROM_QSTR(MP_QSTR_tank_move_forever),         MP_ROM_PTR(&robotics_SpikeBase_drive_forever_obj)             },
     { MP_ROM_QSTR(MP_QSTR_steering_move_for_degrees), MP_ROM_PTR(&robotics_SpikeBase_steering_move_for_degrees_obj) },
     { MP_ROM_QSTR(MP_QSTR_stop),                      MP_ROM_PTR(&robotics_SpikeBase_stop_obj)                      },
-    { MP_ROM_QSTR(MP_QSTR_left),                      MP_ROM_ATTRIBUTE_OFFSET(robotics_SpikeBase_obj_t, left)            },
-    { MP_ROM_QSTR(MP_QSTR_right),                     MP_ROM_ATTRIBUTE_OFFSET(robotics_SpikeBase_obj_t, right)           },
-    { MP_ROM_QSTR(MP_QSTR_heading_control),           MP_ROM_ATTRIBUTE_OFFSET(robotics_SpikeBase_obj_t, heading_control) },
-    { MP_ROM_QSTR(MP_QSTR_distance_control),          MP_ROM_ATTRIBUTE_OFFSET(robotics_SpikeBase_obj_t, distance_control)},
 };
 STATIC MP_DEFINE_CONST_DICT(robotics_SpikeBase_locals_dict, robotics_SpikeBase_locals_dict_table);
 

--- a/pybricks/util_mp/pb_obj_helper.h
+++ b/pybricks/util_mp/pb_obj_helper.h
@@ -36,4 +36,26 @@ mp_obj_t pb_obj_get_base_class_obj(mp_obj_t obj, const mp_obj_type_t *type);
 // Raise error on unexpected type
 void pb_assert_type(mp_obj_t obj, const mp_obj_type_t *type);
 
+// Read/write/delete flags for constant attributes in custom types
+enum {
+    PB_ATTR_READABLE = (1 << 16),  /**< Attribute can be read */
+    PB_ATTR_WRITABLE = (1 << 17),  /**< Attribute can be assigned a new object */
+    PB_ATTR_DELETABLE = (1 << 18), /**< Attribute can be deleted with del */
+    PB_ATTR_OFFSET_MASK = 0xFFFF,  /**< Internal use. Mask for the offset value stored in the LSB bytes */
+};
+
+// Generic entry of the attributes dictionary.
+#define PB_DEFINE_CONST_ATTR(type, name, field, flags) \
+    { MP_ROM_QSTR(name), MP_ROM_PTR(&(mp_uint_t) {offsetof(type, field) | (flags)}) }
+
+// Read-only entry of the attributes dictionary. Dedicated macro because we use it so often.
+#define PB_DEFINE_CONST_ATTR_RO(type, name, field) \
+    PB_DEFINE_CONST_ATTR(type, name, field, PB_ATTR_READABLE)
+
+// Points to attributes dictionary. MUST be first entry of locals_dict.
+#define PB_ATTRIBUTE_TABLE(offset_dict) { MP_ROM_QSTR(MP_QSTR__attr), MP_ROM_PTR(&offset_dict)}
+
+// Attribute handler for any object that has an attribute dictionary.
+void pb_attribute_handler(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
+
 #endif // PYBRICKS_INCLUDED_PBOBJ_H


### PR DESCRIPTION
This implements lookups for attributes like `hub.speaker` in Pybricks, without relying on [this patch](https://github.com/pybricks/micropython/commit/a98265f6a4108b6fbe5145f0d7532293ea05ca70) to upstream MicroPython.

It works with an attribute handler function instead of a special offset type in the `local_dict`.

Attribute offsets are stored in a static table. The attributes can be read/write/delete as needed. We only need read so far, but this is potentially more generic as well.

The size increase for the attribute handler function is fairly minimal since we get to drop the aforementioned patch as well. Still, it means we have to populate the `.attr` field on the respective types, so all in all this is about +152 bytes for Move Hub.

It also means we do an extra lookup in these types when accessing a regular method: It looks in the attribute table first, and, if nothing is found, proceeds to look in the `locals_dict`.

If that's worth the trade-off, we could use this.

