### PR TITLE
micropython: Rebase to upstream master branch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
   settings will not take effect until a new motor command is given.
 - Disabled `Motor.control` and `Motor.log` on Move Hub to save space.
 - Changed LED color calibration on Prime hub to make yellow less green.
+- Updated to upstream MicroPython v1.18.
 
 ### Fixed
 - Fixed color calibration on Powered Up remote control ([support#424]).

--- a/bricks/ev3dev/Makefile
+++ b/bricks/ev3dev/Makefile
@@ -39,10 +39,8 @@ USER_C_MODULES = ../..
 -include mpconfigport.mk
 include ../../micropython/py/mkenv.mk
 
-# use FROZEN_MANIFEST for new projects, others are legacy
+# Frozen Python code
 FROZEN_MANIFEST ?= manifest.py
-FROZEN_DIR =
-FROZEN_MPY_DIR =
 
 # define main target
 PROG = pybricks-micropython
@@ -73,17 +71,19 @@ INC += -I$(TOP)/ports/unix
 
 # compiler settings
 CWARN = -Wall -Werror
-CWARN += -Wpointer-arith -Wuninitialized -Wdouble-promotion -Wsign-compare -Wfloat-conversion
+CWARN += -Wextra -Wno-unused-parameter -Wpointer-arith -Wdouble-promotion -Wfloat-conversion
 CFLAGS += $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
 
 # Debugging/Optimization
 ifdef DEBUG
-COPT ?= -O0
+COPT ?= -Og
 else
 COPT ?= -Os
-COPT += -fdata-sections -ffunction-sections
 COPT += -DNDEBUG
 endif
+
+# Remove unused sections.
+COPT += -fdata-sections -ffunction-sections
 
 # Always enable symbols -- They're occasionally useful, and don't make it into the
 # final .bin/.hex/.dfu so the extra size doesn't matter.
@@ -139,7 +139,7 @@ LDFLAGS += $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
 LDFLAGS += -lpthread
 
 ifeq ($(MICROPY_USE_READLINE),1)
-INC +=  -I$(TOP)/shared/readline
+INC += -I$(TOP)/shared/readline
 CFLAGS_MOD += -DMICROPY_USE_READLINE=1
 SHARED_SRC_C_EXTRA += readline/readline.c
 endif
@@ -198,7 +198,7 @@ endif
 # if we don't do it this way. So we need to be very careful about name clashes
 # between the top level directory and the micropython/ subdirectory.
 
-SRC_C = $(addprefix ports/unix/,\
+SRC_C += $(addprefix ports/unix/,\
 	alloc.c \
 	coverage.c \
 	gccollect.c \
@@ -216,7 +216,7 @@ SRC_C = $(addprefix ports/unix/,\
 
 SRC_C += $(SRC_MOD)
 
-SHARED_SRC_C = $(addprefix shared/,\
+SHARED_SRC_C += $(addprefix shared/,\
 	runtime/gchelper_generic.c \
 	runtime/pyexec.c \
 	timeutils/timeutils.c \
@@ -270,12 +270,12 @@ PYBRICKS_PYBRICKS_SRC_C = $(addprefix pybricks/,\
 	parameters/pb_type_icon.c \
 	nxtdevices/pb_module_nxtdevices.c \
 	nxtdevices/pb_type_nxtdevices_colorsensor.c \
-    nxtdevices/pb_type_nxtdevices_energymeter.c \
-    nxtdevices/pb_type_nxtdevices_lightsensor.c \
-    nxtdevices/pb_type_nxtdevices_soundsensor.c \
-    nxtdevices/pb_type_nxtdevices_temperaturesensor.c \
-    nxtdevices/pb_type_nxtdevices_touchsensor.c \
-    nxtdevices/pb_type_nxtdevices_ultrasonicsensor.c \
+	nxtdevices/pb_type_nxtdevices_energymeter.c \
+	nxtdevices/pb_type_nxtdevices_lightsensor.c \
+	nxtdevices/pb_type_nxtdevices_soundsensor.c \
+	nxtdevices/pb_type_nxtdevices_temperaturesensor.c \
+	nxtdevices/pb_type_nxtdevices_touchsensor.c \
+	nxtdevices/pb_type_nxtdevices_ultrasonicsensor.c \
 	parameters/pb_module_parameters.c \
 	parameters/pb_type_button.c \
 	parameters/pb_type_color.c \
@@ -352,20 +352,17 @@ SRC_QSTR += $(SRC_C) $(SHARED_SRC_C) $(EXTMOD_SRC_C) $(PYBRICKS_SRC_C) $(PYBRICK
 # SRC_QSTR
 SRC_QSTR_AUTO_DEPS +=
 
-ifneq ($(FROZEN_MANIFEST)$(FROZEN_MPY_DIR),)
+ifneq ($(FROZEN_MANIFEST),)
 # To use frozen code create a manifest.py file with a description of files to
 # freeze, then invoke make with FROZEN_MANIFEST=manifest.py (be sure to build from scratch).
 CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
 CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
 CFLAGS += -DMPZ_DIG_SIZE=16 # force 16 bits to work on both 32 and 64 bit archs
-MPY_CROSS_FLAGS += -mcache-lookup-bc
 endif
 
-ifneq ($(FROZEN_MANIFEST)$(FROZEN_DIR),)
+ifneq ($(FROZEN_MANIFEST),)
 CFLAGS += -DMICROPY_MODULE_FROZEN_STR
 endif
-
-RUN_TESTS_MPY_CROSS_FLAGS = --mpy-cross-flags='-mcache-lookup-bc'
 
 include $(TOP)/py/mkrules.mk
 
@@ -401,6 +398,14 @@ test: $(PROG) $(TOP)/tests/run-tests.py $(GRX_TEST_PLUGIN_LIB)
 		GRX_PLUGIN_PATH=$(realpath $(BUILD)) GRX_DRIVER=test \
 		./run-tests.py
 
+# Value of configure's --host= option (required for cross-compilation).
+# Deduce it from CROSS_COMPILE by default, but can be overridden.
+ifneq ($(CROSS_COMPILE),)
+CROSS_COMPILE_HOST = --host=$(patsubst %-,%,$(CROSS_COMPILE))
+else
+CROSS_COMPILE_HOST =
+endif
+
 PREFIX = /usr/local
 BINDIR = $(DESTDIR)$(PREFIX)/bin
 
@@ -410,11 +415,3 @@ install: $(PROG)
 
 uninstall:
 	-rm $(BINDIR)/$(PROG)
-
-# Value of configure's --host= option (required for cross-compilation).
-# Deduce it from CROSS_COMPILE by default, but can be overridden.
-ifneq ($(CROSS_COMPILE),)
-CROSS_COMPILE_HOST = --host=$(patsubst %-,%,$(CROSS_COMPILE))
-else
-CROSS_COMPILE_HOST =
-endif

--- a/bricks/ev3dev/Makefile
+++ b/bricks/ev3dev/Makefile
@@ -397,7 +397,7 @@ test-ev3dev: $(PROG) $(TOP)/tests/run-tests.py $(GRX_TEST_PLUGIN_LIB)
 
 test: $(PROG) $(TOP)/tests/run-tests.py $(GRX_TEST_PLUGIN_LIB)
 	$(eval DIRNAME=../bricks/$(notdir $(CURDIR)))
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(PROG) \
+	cd $(TOP)/tests && MICROPY_MICROPYTHON="../../tests/ev3dev/test-wrapper.sh" \
 		GRX_PLUGIN_PATH=$(realpath $(BUILD)) GRX_DRIVER=test \
 		./run-tests.py
 

--- a/bricks/ev3dev/pb_type_ev3dev_image.c
+++ b/bricks/ev3dev/pb_type_ev3dev_image.c
@@ -72,7 +72,7 @@ STATIC mp_obj_t ev3dev_Image_new(GrxContext *context) {
 STATIC mp_obj_t ev3dev_Image_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     enum { ARG_source, ARG_sub, ARG_x1, ARG_y1, ARG_x2, ARG_y2 };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_source, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_source, MP_ARG_REQUIRED | MP_ARG_OBJ, { } },
         { MP_QSTR_sub, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = FALSE} },
         { MP_QSTR_x1, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_y1, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },

--- a/lib/contiki-core/sys/lc-switch.h
+++ b/lib/contiki-core/sys/lc-switch.h
@@ -63,11 +63,17 @@
 /** \hideinitializer */
 typedef unsigned short lc_t;
 
+#if defined(__GNUC__) && __GNUC__ >= 7
+#define LC_FALLTHROUGH __attribute__((fallthrough));
+#else
+#define LC_FALLTHROUGH
+#endif
+
 #define LC_INIT(s) s = 0;
 
 #define LC_RESUME(s) switch(s) { case 0:
 
-#define LC_SET(s) s = __LINE__; case __LINE__:
+#define LC_SET(s) s = __LINE__; LC_FALLTHROUGH; case __LINE__:
 
 #define LC_END(s) }
 

--- a/lib/contiki-core/sys/process.h
+++ b/lib/contiki-core/sys/process.h
@@ -303,12 +303,14 @@ static PT_THREAD(process_thread_##name(struct pt *process_pt,	\
 #define PROCESS(name, strname)				\
   PROCESS_THREAD(name, ev, data);			\
   struct process name = { NULL,		        \
-                          process_thread_##name }
+                          process_thread_##name, \
+                          { }, 0, 0 }
 #else
 #define PROCESS(name, strname)				\
   PROCESS_THREAD(name, ev, data);			\
   struct process name = { NULL, strname,		\
-                          process_thread_##name }
+                          process_thread_##name, \
+                          { }, 0, 0 }
 #endif
 
 /** @} */

--- a/lib/pbio/drv/button/button_linux_ev3.c
+++ b/lib/pbio/drv/button/button_linux_ev3.c
@@ -15,7 +15,7 @@
 #include <pbio/config.h>
 #include <pbio/error.h>
 
-static uint8_t f_btn = -1; // Button file descriptor
+static int f_btn = -1; // Button file descriptor
 
 void _pbdrv_button_init(void) {
     f_btn = open("/dev/input/by-path/platform-gpio_keys-event", O_RDONLY);

--- a/pybricks/parameters/pb_type_color.c
+++ b/pybricks/parameters/pb_type_color.c
@@ -249,6 +249,7 @@ STATIC mp_obj_t pb_type_Color_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_o
         case MP_BINARY_OP_LSHIFT:
             // lshift is negative rshift, so negate and fall through to rshift
             rhs_in = mp_obj_new_int(-pb_obj_get_int(rhs_in));
+            MP_FALLTHROUGH
         case MP_BINARY_OP_RSHIFT:
             // Color shifting shifts the hue
             return pb_type_Color_make_new_helper(

--- a/pybricks/robotics/pb_type_drivebase.c
+++ b/pybricks/robotics/pb_type_drivebase.c
@@ -276,10 +276,10 @@ STATIC mp_obj_t robotics_DriveBase_settings(size_t n_args, const mp_obj_t *pos_a
     }
 
     // If some values are given, set them, bound by the control limits
-    self->straight_speed = min(straight_speed_limit, abs(pb_obj_get_default_int(straight_speed_in, self->straight_speed)));
-    self->turn_rate = min(turn_rate_limit, abs(pb_obj_get_default_int(turn_rate_in, self->turn_rate)));
-    straight_acceleration = abs(pb_obj_get_default_int(straight_acceleration_in, straight_acceleration));
-    turn_acceleration = abs(pb_obj_get_default_int(turn_acceleration_in, turn_acceleration));
+    self->straight_speed = min(straight_speed_limit, abs((int)pb_obj_get_default_int(straight_speed_in, self->straight_speed)));
+    self->turn_rate = min(turn_rate_limit, abs((int)pb_obj_get_default_int(turn_rate_in, self->turn_rate)));
+    straight_acceleration = abs((int)pb_obj_get_default_int(straight_acceleration_in, straight_acceleration));
+    turn_acceleration = abs((int)pb_obj_get_default_int(turn_acceleration_in, turn_acceleration));
     pbio_control_settings_set_limits(&self->db->control_distance.settings, self->straight_speed, straight_acceleration, straight_torque);
     pbio_control_settings_set_limits(&self->db->control_heading.settings, self->turn_rate, turn_acceleration, turn_torque);
 

--- a/pybricks/util_mp/pb_kwarg_helper.h
+++ b/pybricks/util_mp/pb_kwarg_helper.h
@@ -42,7 +42,11 @@
 
 // Generate table entry from an argument name, its requirements, and its default value
 #define GET_ARG_NAME(name, required, value) name##_in
-#define GET_ARG_SPEC(name, required, value) {MAKE_QSTR(name), required, value}
+#define GET_ARG_SPEC(name, required, value) { \
+        .qst = MAKE_QSTR(name), \
+        .flags = required, \
+        .defval = value, \
+}
 
 // Unpack a table entry into three arguments
 #define PB_ARG_DO(IDX, arg_spec) GET_ARG_SPEC arg_spec,
@@ -77,7 +81,7 @@
     PB_PARSE_GENERIC(n_args, pos_and_kw_args, &kw_args, 0, __VA_ARGS__)
 
 // Required argument
-#define PB_ARG_REQUIRED(name) (name, MP_ARG_OBJ | MP_ARG_REQUIRED, )
+#define PB_ARG_REQUIRED(name) (name, MP_ARG_OBJ | MP_ARG_REQUIRED, { })
 
 // Optional keyword argument with default integer value
 #define PB_ARG_DEFAULT_INT(name, value) (name, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_INT(value)})


### PR DESCRIPTION
Several of our upstream pull requests have been merged so we can drop the respective patches from our fork:

- py/gc: Add hook for events during garbage collect.  https://github.com/pybricks/micropython/commit/ba58e957343fab0cd9dc62c95eb380f9e09de7ee

- pybricks: STM32 UART fixes for BTStack https://github.com/pybricks/micropython/commit/ebf92a34a13e1511dec8e86092b597d2903b88af

- py/runtime: Init dest[1] in convert_member_lookup. https://github.com/pybricks/micropython/commit/c8a0ccb08619f1aa2e21863bfb9ee9692b036d81

- py/runtime: Optional lookup if type->attr fails. https://github.com/pybricks/micropython/commit/16a2a96e928046ea3dac4a9870731407fba355b3

- py/runtime: Return obj->attr for obj.attr if attr has offset type. https://github.com/pybricks/micropython/commit/a98265f6a4108b6fbe5145f0d7532293ea05ca70

Additionally, there were breaking changes to py/builtinimport and mpy-tool, so it is better to upgrade sooner than later.

- py/builtinimport.c: Support builtin-package as nested modules. https://github.com/pybricks/micropython/commit/2a02929521419495227dac0f4b3728bd2c8ef932 broke via https://github.com/micropython/micropython/commit/a7fa18c203a241f670f12ab507aa8b349fcd45a1. It is now fixed via https://github.com/pybricks/micropython/commit/a0e10dde02336031c5544d5f1d4761f845d6d01c

Once we fix all issues, rebasing later should be a bit easier. We can settle on a particular MicroPython version (e.g. v1.18)
when we get closer to Pybricks v3.2.