### PR TITLE
github: fix build each commit for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     - '**'
     tags-ignore:
     - '@pybricks/**'
-  pull_request_target:
+  pull_request:
 
 env:
   MAKEOPTS: -j2
@@ -200,15 +200,18 @@ jobs:
         python-version: '3.8'
     - name: Install Python packages
       run:  python -m pip install azure-cosmosdb-table GitPython
-    - name: Build firmware
-      if: ${{ github.ref != 'refs/heads/master' }}
+    - name: Build firmware (pull request)
+      if: ${{ github.base_ref != null }}
+      run: .github/build-each-commit.py ${{ matrix.hub }} ${{ github.sha }}
+    - name: Build firmware (non-master branch)
+      if: ${{ github.base_ref == null && github.ref != 'refs/heads/master' }}
       env:
         STORAGE_ACCOUNT: ${{ secrets.STORAGE_ACCOUNT }}
         STORAGE_KEY: ${{ secrets.STORAGE_KEY }}
         FIRMWARE_SIZE_TABLE: ${{ secrets.FIRMWARE_SIZE_TABLE }}
-      run: .github/build-each-commit.py ${{ matrix.hub }} origin/master ${{ github.ref }}
-    - name: Build firmware
-      if: ${{ github.ref == 'refs/heads/master' }}
+      run: .github/build-each-commit.py ${{ matrix.hub }} ${{ github.ref_name }}
+    - name: Build firmware (master branch)
+      if: ${{ github.base_ref == null && github.ref == 'refs/heads/master' }}
       run: make -C bricks/${{ matrix.hub }}
     - name: Extract firmware.zip for upload
       if: ${{ success() && matrix.hub != 'nxt' }}


### PR DESCRIPTION
The `pull_request_target` trigger causes github actions to check out the master branch instead of the pull request branch. This is done for security reasons since `pull_request_target` is allowed access to secrets.

This modifies the build-each-commit.py script to be able to run without secrets so that it can be used for pull requests and adds a new conditional in the workflow to handle this case.

This should also fix building pull requests that are not based on the master branch.