### PR TITLE
bricks/stm32: Removed obsolete `deploy-dfu` targets.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,11 @@ $env:PATH="C:\cygwin64\bin;C:\Program Files (x86)\GNU Arm Embedded Toolchain\10 
 
 [cygwin]: https://www.cygwin.com/
 
+#### macOS
+
+    brew install uncrustify
+    brew instal libusb   
+    brew install --cask gcc-arm-embedded
 
 ### Get the code
 
@@ -301,3 +306,24 @@ Then in the `pybricks-micropython` directory:
     yarn build:debug
 
 [wasm]: https://webassembly.org/
+
+Build and deploy firmware
+-------------------------
+
+### Build the firmware
+
+Pick your Hub from the `bricks` sub-directory you want to compile.
+
+    poetry shell
+    make mpy-cross -j8
+    make -C bricks/primehub -j8
+       
+### Deploy the firmware to a hub
+
+1. Follow the guide to prepare your Hub for Pybricks firmware installation:
+   1. https://pybricks.com/install, or 
+   2. https://dfu.pybricks.com for Spike Prime or Mindstorms Inventor    
+2. Execute the deployment:
+    ```shell
+    make -C bricks/primehub -j8 deploy
+    ```

--- a/bricks/stm32/stm32.mk
+++ b/bricks/stm32/stm32.mk
@@ -685,12 +685,6 @@ $(BUILD)/%.dfu: $(BUILD)/%.bin
 deploy: $(BUILD)/firmware.zip
 	$(Q)$(PYBRICKSDEV) flash $< --name $(PBIO_PLATFORM)
 
-deploy-dfu-%: $(BUILD)/%.dfu
-	$(ECHO) "Writing $< to the board"
-	$(Q)$(PYTHON) $(PYDFU) -u $< $(if $(DFU_VID),--vid $(DFU_VID)) $(if $(DFU_PID),--pid $(DFU_PID))
-
-deploy-dfu: deploy-dfu-firmware
-
 deploy-openocd: $(BUILD)/firmware-no-checksum.bin
 	$(ECHO) "Writing $< to the board via ST-LINK using OpenOCD"
 	$(Q)$(OPENOCD) -f $(OPENOCD_CONFIG) -c "stm_flash $< $(TEXT0_ADDR)"


### PR DESCRIPTION
The `deploy` target can deploy to any Hub as opposed to `deploy-dfu` that did not work for Inventor Hub without explicitly specifying `DFU_PID=0x0011`.