### PR TITLE
bricks/stm32: Force exit when shutdown requested.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@
 ### Added
 - Added support for `PBIO_PYBRICKS_COMMAND_REBOOT_TO_UPDATE_MODE` Pybricks Profile BLE command.
 
+### Changed
+- The Pybricks Code stop button will force the program to exit even if the user
+  catches the `SystemExit` exception ([pybricks-micropython#117]).
+
 ### Fixed
 - Fixed connecting `Remote` on BOOST move hub ([support#793]).
 
 ### Removed
 - Removed `hub.system.reset()` method.
 
+[pybricks-micropython#117]: https://github.com/pybricks/pybricks-micropython/pull/117
 [support#793]: https://github.com/pybricks/support/issues/793
 
 ## [3.2.0b5] - 2022-11-11

--- a/bricks/_common/micropython.c
+++ b/bricks/_common/micropython.c
@@ -32,6 +32,17 @@
 #include "py/stackctrl.h"
 #include "py/stream.h"
 
+// Implementation for MICROPY_EVENT_POLL_HOOK
+void pb_event_poll_hook(void) {
+    while (pbio_do_one_event()) {
+    }
+
+    mp_handle_pending(true);
+
+    // Platform-specific code to run on completing the poll hook.
+    pb_event_poll_hook_leave();
+}
+
 // callback for when stop button is pressed in IDE or on hub
 void pbsys_main_stop_program(void) {
 

--- a/bricks/_common/micropython.c
+++ b/bricks/_common/micropython.c
@@ -32,23 +32,11 @@
 #include "py/stackctrl.h"
 #include "py/stream.h"
 
-// Outermost nlr buffer.
-nlr_buf_t nlr_main;
-
 // Implementation for MICROPY_EVENT_POLL_HOOK
 void pb_event_poll_hook(void) {
-    while (pbio_do_one_event()) {
-    }
 
-    // On forced exit, pop back to outer nlr buffer so the exception will
-    // always be raised and the application program exits cleanly. We also need
-    // MP_STATE_THREAD(mp_pending_exception) to be the system exit exception
-    // but we don't check it because it is set along with pyexec_system_exit.
-    if (pyexec_system_exit == PYEXEC_FORCED_EXIT) {
-        while (MP_STATE_MAIN_THREAD(nlr_top) != &nlr_main) {
-            nlr_pop();
-        }
-        pyexec_system_exit = 0;
+    // Drive pbio event loop.
+    while (pbio_do_one_event()) {
     }
 
     mp_handle_pending(true);
@@ -68,7 +56,7 @@ void pbsys_main_stop_program(bool force_stop) {
     static mp_obj_exception_t system_exit;
 
     // Schedule SystemExit exception.
-    system_exit.base.type = &mp_type_SystemExit;
+    system_exit.base.type = force_stop ? &mp_type_SystemAbort : &mp_type_SystemExit;
     system_exit.traceback_alloc = 0;
     system_exit.traceback_len = 0;
     system_exit.traceback_data = NULL;
@@ -79,11 +67,6 @@ void pbsys_main_stop_program(bool force_stop) {
         MP_STATE_VM(sched_state) = MP_SCHED_PENDING;
     }
     #endif
-
-    // IDE stop button and long-press power button will force an exit.
-    if (force_stop) {
-        pyexec_system_exit = PYEXEC_FORCED_EXIT;
-    }
 }
 
 bool pbsys_main_stdin_event(uint8_t c) {
@@ -128,7 +111,8 @@ static void mp_vfs_map_minimal_new_reader(mp_reader_t *reader, mp_vfs_map_minima
 static void run_repl() {
     // Reset REPL history.
     readline_init0();
-    if (nlr_push(&nlr_main) == 0) {
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
         // Run the REPL.
         pyexec_friendly_repl();
         nlr_pop();
@@ -136,7 +120,7 @@ static void run_repl() {
         // clear any pending exceptions (and run any callbacks).
         mp_handle_pending(false);
         // Print which exception triggered this.
-        mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr_main.ret_val);
+        mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
     }
 }
 #endif
@@ -224,7 +208,8 @@ static mpy_info_t *mpy_data_find(qstr name) {
  */
 static void run_user_program(void) {
 
-    if (nlr_push(&nlr_main) == 0) {
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
         mpy_info_t *info = mpy_data_find(MP_QSTR___main__);
 
         if (!info) {
@@ -255,11 +240,11 @@ static void run_user_program(void) {
         mp_handle_pending(false);
 
         // Print which exception triggered this.
-        mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr_main.ret_val);
+        mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
 
         #if PYBRICKS_OPT_COMPILER
         // On KeyboardInterrupt, drop to REPL for debugging.
-        if (mp_obj_exception_match((mp_obj_t)nlr_main.ret_val, &mp_type_KeyboardInterrupt)) {
+        if (mp_obj_exception_match((mp_obj_t)nlr.ret_val, &mp_type_KeyboardInterrupt)) {
 
             // The global scope is preserved to facilitate debugging, but we
             // stop active resources like motors and sounds. They are stopped

--- a/bricks/_common/mphalport.h
+++ b/bricks/_common/mphalport.h
@@ -9,3 +9,6 @@ void mp_hal_set_interrupt_char(int c);
 #define mp_hal_ticks_cpu() 0
 #define mp_hal_delay_us pbdrv_clock_delay_us
 void pb_stack_get_info(char **sstack, char **estack);
+
+// Platform-specific code to run on completing the poll hook.
+void pb_event_poll_hook_leave(void);

--- a/bricks/_common_stm32/mpconfigport.h
+++ b/bricks/_common_stm32/mpconfigport.h
@@ -55,8 +55,8 @@ static inline mp_uint_t disable_irq(void) {
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void pb_poll(void); \
-        pb_poll(); \
+        extern void pb_event_poll_hook(void); \
+        pb_event_poll_hook(); \
     } while (0);
 
 // We need to provide a declaration/definition of alloca()

--- a/bricks/_common_stm32/mphalport.c
+++ b/bricks/_common_stm32/mphalport.c
@@ -24,13 +24,7 @@ void pb_stack_get_info(char **sstack, char **estack) {
     *estack = (char *)&_estack;
 }
 
-// Implementation for MICROPY_EVENT_POLL_HOOK
-void pb_poll(void) {
-    while (pbio_do_one_event()) {
-    }
-
-    mp_handle_pending(true);
-
+void pb_event_poll_hook_leave(void) {
     // There is a possible race condition where an interrupt occurs and sets the
     // Contiki poll_requested flag after all events have been processed. So we
     // have a critical section where we disable interrupts and check see if there

--- a/bricks/ev3rt/mpconfigport.h
+++ b/bricks/ev3rt/mpconfigport.h
@@ -101,8 +101,8 @@ static inline mp_uint_t disable_irq(void) {
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void pb_poll(void); \
-        pb_poll(); \
+        extern void pb_event_poll_hook(void); \
+        pb_event_poll_hook(); \
     } while (0);
 
 // We need to provide a declaration/definition of alloca()

--- a/bricks/ev3rt/mphalport.c
+++ b/bricks/ev3rt/mphalport.c
@@ -18,13 +18,7 @@
 #include "kernel_cfg.h"
 #include "kernel/task.h"
 
-
-// Implementation for MICROPY_EVENT_POLL_HOOK
-void pb_poll(void) {
-    while (pbio_do_one_event()) {
-    }
-
-    mp_handle_pending(true);
+void pb_event_poll_hook_leave(void) {
 }
 
 // Runs MicroPython with the given program data.

--- a/bricks/nxt/mpconfigport.h
+++ b/bricks/nxt/mpconfigport.h
@@ -84,10 +84,8 @@ typedef long mp_off_t;
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
-        mp_handle_pending(true); \
-        extern int pbio_do_one_event(void); \
-        while (pbio_do_one_event()) { } \
+        extern void pb_event_poll_hook(void); \
+        pb_event_poll_hook(); \
     } while (0);
 
 #define MP_STATE_PORT MP_STATE_VM

--- a/bricks/nxt/mphalport.c
+++ b/bricks/nxt/mphalport.c
@@ -19,6 +19,9 @@
 #include <base/drivers/bt.h>
 #include "base/display.h"
 
+void pb_event_poll_hook_leave(void) {
+}
+
 void pb_stack_get_info(char **sstack, char **estack) {
     extern uint32_t __stack_start__;
     extern uint32_t __stack_end__;

--- a/bricks/virtualhub/mp_port.c
+++ b/bricks/virtualhub/mp_port.c
@@ -34,7 +34,7 @@
 #define FORCED_EXIT (0x100)
 
 // callback for when stop button is pressed in IDE or on hub
-void pbsys_main_stop_program(void) {
+void pbsys_main_stop_program(bool force_stop) {
     static const mp_rom_obj_tuple_t args = {
         .base = { .type = &mp_type_tuple },
         .len = 2,

--- a/lib/pbio/include/pbsys/main.h
+++ b/lib/pbio/include/pbsys/main.h
@@ -52,8 +52,12 @@ void pbsys_main_run_program(pbsys_main_program_t *program);
  * Stops (cancels) the main application program.
  *
  * This should be provided by the application running on top of pbio.
+ *
+ * @param [in]  force_stop  Whether to force stop the program instead of asking
+ *                          nicely. This is true when the application must stop
+ *                          on shutdown.
  */
-void pbsys_main_stop_program(void);
+void pbsys_main_stop_program(bool force_stop);
 
 /**
  * Handles standard input.
@@ -68,7 +72,7 @@ bool pbsys_main_stdin_event(uint8_t c);
 
 #else
 
-static inline void pbsys_main_stop_program(void) {
+static inline void pbsys_main_stop_program(bool force_stop) {
 }
 
 static inline bool pbsys_main_stdin_event(uint8_t c) {

--- a/lib/pbio/sys/command.c
+++ b/lib/pbio/sys/command.c
@@ -23,7 +23,7 @@ pbio_pybricks_error_t pbsys_command(const uint8_t *data, uint32_t size) {
 
     switch (cmd) {
         case PBIO_PYBRICKS_COMMAND_STOP_USER_PROGRAM:
-            pbsys_program_stop();
+            pbsys_program_stop(false);
             return PBIO_PYBRICKS_ERROR_OK;
         case PBIO_PYBRICKS_COMMAND_START_USER_PROGRAM:
             return pbio_pybricks_error_from_pbio_error(pbsys_program_load_start_user_program());

--- a/lib/pbio/sys/command.c
+++ b/lib/pbio/sys/command.c
@@ -23,7 +23,7 @@ pbio_pybricks_error_t pbsys_command(const uint8_t *data, uint32_t size) {
 
     switch (cmd) {
         case PBIO_PYBRICKS_COMMAND_STOP_USER_PROGRAM:
-            pbsys_program_stop(false);
+            pbsys_program_stop(true);
             return PBIO_PYBRICKS_ERROR_OK;
         case PBIO_PYBRICKS_COMMAND_START_USER_PROGRAM:
             return pbio_pybricks_error_from_pbio_error(pbsys_program_load_start_user_program());

--- a/lib/pbio/sys/program_stop.c
+++ b/lib/pbio/sys/program_stop.c
@@ -22,10 +22,14 @@ static bool program_stop_on_shutdown_requested;
 /**
  * Request the user program to stop. For example, in MicroPython, this may raise
  * a SystemExit exception.
+ *
+ * @param [in]  force_stop  Whether to force stop the program instead of asking
+ *                          nicely. This is true when the application must stop
+ *                          on shutdown.
  */
-void pbsys_program_stop(void) {
+void pbsys_program_stop(bool force_stop) {
     if (pbsys_status_test(PBIO_PYBRICKS_STATUS_USER_PROGRAM_RUNNING)) {
-        pbsys_main_stop_program();
+        pbsys_main_stop_program(force_stop);
     }
 }
 
@@ -48,7 +52,7 @@ void pbsys_program_stop_poll(void) {
         // Should not request stop more than once.
         return;
     } else if (pbsys_status_test(PBIO_PYBRICKS_STATUS_SHUTDOWN_REQUEST)) {
-        pbsys_program_stop();
+        pbsys_program_stop(true);
         program_stop_on_shutdown_requested = true;
         return;
     }
@@ -63,7 +67,7 @@ void pbsys_program_stop_poll(void) {
     if ((btn & stop_buttons) == stop_buttons) {
         if (!stop_button_pressed) {
             stop_button_pressed = true;
-            pbsys_program_stop();
+            pbsys_program_stop(false);
         }
     } else {
         stop_button_pressed = false;

--- a/lib/pbio/sys/program_stop.h
+++ b/lib/pbio/sys/program_stop.h
@@ -5,6 +5,6 @@
 #define _PBSYS_SYS_USER_PROGRAM_H_
 
 void pbsys_program_stop_poll(void);
-void pbsys_program_stop(void);
+void pbsys_program_stop(bool force_stop);
 
 #endif // _PBSYS_SYS_USER_PROGRAM_H_


### PR DESCRIPTION
If a user catches the `SystemExit` exception indefinitely, there is currently not a way to power off the hub.

This PR makes the following program exit normally so we can still de-init pbsys and do a clean power off.

```python
from pybricks.tools import wait

while True:
    try:
        wait(10)
    except SystemExit:
        print("nope!")
```

I'm not merging this yet because there may be a cleaner way to exit MicroPython using `PYEXEC_FORCED_EXIT` and / or various available hooks.