### PR TITLE
fix export path in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,7 @@ sure that the cross-compiler can be found. This can be done by adding it to the
 `PATH` environment variable as described in the ARM Embedded Toolchain
 `readme.txt` file:
 
-    export PATH=$PATH:$install_dir/gcc-arm-none-eabi-*/bin/*
+    export PATH=$PATH:$install_dir/gcc-arm-none-eabi-*/bin
 
 Or by setting the `CROSS_COMPILE` environment variable:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,11 +175,11 @@ sure that the cross-compiler can be found. This can be done by adding it to the
 `PATH` environment variable as described in the ARM Embedded Toolchain
 `readme.txt` file:
 
-    export PATH=$PATH:$install_dir/gcc-arm-none-eabi-*/bin
+    export PATH=$PATH:$install_dir/gcc-arm-none-eabi-*/bin/*
 
 Or by setting the `CROSS_COMPILE` environment variable:
 
-    export CROSS_COMPILE=$install_dir/gcc-arm-none-eabi-*/bin
+    export CROSS_COMPILE=$install_dir/gcc-arm-none-eabi-*/bin/*
 
 `$install_dir` needs to be replaced with the actual directory where you
 actually installed the toolchain.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ sure that the cross-compiler can be found. This can be done by adding it to the
 
 Or by setting the `CROSS_COMPILE` environment variable:
 
-    export CROSS_COMPILE=$install_dir/gcc-arm-none-eabi-*/bin/*
+    export CROSS_COMPILE=$install_dir/gcc-arm-none-eabi-*/bin/arm-none-eabi-
 
 `$install_dir` needs to be replaced with the actual directory where you
 actually installed the toolchain.


### PR DESCRIPTION
exporting the path that was suggested before I get

FileNotFoundError: [Errno 2] No such file or directory: '/home/bene/lego/gcc-arm-none-eabi-*/bingcc'

when the correct path would be

/home/bene/lego/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-gcc