### PR TITLE
pbsys/program_load: Add read/write access to user data.

### DIFF
--- a/lib/pbio/include/pbsys/program_load.h
+++ b/lib/pbio/include/pbsys/program_load.h
@@ -53,9 +53,23 @@ typedef struct _pbsys_program_load_data_header_t {
 
 #define PBSYS_PROGRAM_LOAD_MAX_PROGRAM_SIZE (PBSYS_CONFIG_PROGRAM_LOAD_ROM_SIZE - sizeof(pbsys_program_load_data_header_t))
 
+pbio_error_t pbsys_program_load_set_user_data(uint32_t offset, const uint8_t *data, uint32_t size);
+
+pbio_error_t pbsys_program_load_get_user_data(uint32_t offset, uint8_t **data, uint32_t size);
+
 #else
 
 #define PBSYS_PROGRAM_LOAD_MAX_PROGRAM_SIZE (0)
+
+static inline pbio_error_t pbsys_program_load_set_user_data(uint32_t offset, const uint8_t *data, uint32_t size) {
+    return PBIO_ERROR_NOT_SUPPORTED;
+}
+
+static inline pbio_error_t pbsys_program_load_get_user_data(uint32_t offset, uint8_t **data, uint32_t size) {
+    *data = NULL;
+    return PBIO_ERROR_NOT_SUPPORTED;
+}
+
 
 #endif // PBSYS_CONFIG_PROGRAM_LOAD
 

--- a/lib/pbio/include/pbsys/program_load.h
+++ b/lib/pbio/include/pbsys/program_load.h
@@ -28,9 +28,9 @@
  */
 typedef struct _pbsys_program_load_data_header_t {
     /**
-     * How much to write on shutdown. This is reset to 0 on load, and should be
-     * set whenever any data is updated. This must always remain the first
-     * element of this structure.
+     * How much to write on shutdown (and how much to load on boot). This is
+     * reset to 0 in RAM on load, and should be set whenever any data is
+     * updated. This must always remain the first element of this structure.
      */
     uint32_t write_size;
     #if PBSYS_CONFIG_PROGRAM_LOAD_OVERLAPS_BOOTLOADER_CHECKSUM

--- a/lib/pbio/sys/program_load.c
+++ b/lib/pbio/sys/program_load.c
@@ -38,6 +38,14 @@ typedef struct {
 data_map_t pbsys_user_ram_data_map __attribute__((section(".noinit"), used));
 static data_map_t *map = &pbsys_user_ram_data_map;
 
+/**
+ * Sets write size to how much data must be written on shutdown. This is not
+ * simply a boolean flag because it is also used as the load size on boot.
+ */
+static void update_write_size(void) {
+    map->header.write_size = sizeof(pbsys_program_load_data_header_t) + map->header.program_size;
+}
+
 static bool pbsys_program_load_start_user_program_requested;
 static bool pbsys_program_load_start_repl_requested;
 
@@ -87,9 +95,11 @@ pbio_error_t pbsys_program_load_set_program_size(uint32_t size) {
         return PBIO_ERROR_BUSY;
     }
 
+    // Update program size.
     map->header.program_size = size;
-    // Data was updated, so set the write size.
-    map->header.write_size = size + sizeof(pbsys_program_load_data_header_t);
+
+    // Program size was updated, so set the write size.
+    update_write_size();
 
     return PBIO_SUCCESS;
 }

--- a/lib/pbio/sys/program_load.c
+++ b/lib/pbio/sys/program_load.c
@@ -46,6 +46,42 @@ static void update_write_size(void) {
     map->header.write_size = sizeof(pbsys_program_load_data_header_t) + map->header.program_size;
 }
 
+/**
+ * Saves user data. This will be saved during power off, like program data.
+ *
+ * @param [in]  offset  Offset from the base address.
+ * @param [in]  data    The data to be stored (copied).
+ * @param [in]  size    Data size.
+ * @returns             ::PBIO_ERROR_INVALID_ARG if the data won't fit.
+ *                      Otherwise, ::PBIO_SUCCESS.
+ */
+pbio_error_t pbsys_program_load_set_user_data(uint32_t offset, const uint8_t *data, uint32_t size) {
+    if (offset + size > sizeof(map->header.user_data)) {
+        return PBIO_ERROR_INVALID_ARG;
+    }
+    // Update data and write size to request write on poweroff.
+    memcpy(map->header.user_data + offset, data, size);
+    update_write_size();
+    return PBIO_SUCCESS;
+}
+
+/**
+ * Gets pointer to user data.
+ *
+ * @param [in]  offset  Offset from the base address.
+ * @param [in]  data    The data reference.
+ * @param [in]  size    Data size.
+ * @returns             ::PBIO_ERROR_INVALID_ARG if reading out of range.
+ *                      Otherwise, ::PBIO_SUCCESS.
+ */
+pbio_error_t pbsys_program_load_get_user_data(uint32_t offset, uint8_t **data, uint32_t size) {
+    if (offset + size > sizeof(map->header.user_data)) {
+        return PBIO_ERROR_INVALID_ARG;
+    }
+    *data = map->header.user_data + offset;
+    return PBIO_SUCCESS;
+}
+
 static bool pbsys_program_load_start_user_program_requested;
 static bool pbsys_program_load_start_repl_requested;
 


### PR DESCRIPTION
This feature has been requested many times (e.g. [here](https://www.eurobricks.com/forum/index.php?/forums/topic/186132-pybricks-qa/), [here](https://github.com/orgs/pybricks/discussions/623), or [here](https://github.com/pybricks/support/issues/85)). Now that we have enabled storage to save programs, we might as well add some storage for user data.

Proposed API:

```python
# To write some data:
hub.system.storage(offset=5, write=b"Hello, world!")

# To read some data:
data = hub.system.storage(offset=12, read=6)
print(data) # This will print b"world!"
```
Appropriate errors are be raised so read/write access is always safe.

We could also add a `storage_view` later on for hubs that can support it, but this should cover the basics.