### PR TITLE
Move Hub module optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Removed
 - Removed `hub.system.reset()` method.
+- Disabled `micropython` module on Move Hub.
 
 [pybricks-micropython#117]: https://github.com/pybricks/pybricks-micropython/pull/117
 [support#409]: https://github.com/pybricks/support/issues/409

--- a/bricks/_common/mpconfigport.h
+++ b/bricks/_common/mpconfigport.h
@@ -17,6 +17,7 @@
 // Enabled modules
 #define MICROPY_PY_IO                           (PYBRICKS_OPT_EXTRA_MOD)
 #define MICROPY_PY_MATH                         (PYBRICKS_OPT_FLOAT)
+#define MICROPY_PY_MICROPYTHON                  (PYBRICKS_OPT_EXTRA_MOD)
 #define MICROPY_PY_STRUCT                       (PYBRICKS_OPT_EXTRA_MOD)
 #define MICROPY_PY_SYS                          (PYBRICKS_OPT_EXTRA_MOD)
 #define MICROPY_PY_UERRNO                       (1)


### PR DESCRIPTION
This saves more than 2KB of build size. If we do this, it would be good to do this now, in time for V3.2.

The `micropython` module seems mostly useful for advanced users. For most users, having room for 2KB extra user code (or upcoming Bluetooth features) seems more useful. This module is made optional in https://github.com/micropython/micropython/pull/10131

Removing `uerrno` means a minor loss in clarity for error messages on Move Hub. But the terse errors are unclear to begin with, so something like https://github.com/pybricks/support/issues/817 could be done to improve it independent of this change.