### PR TITLE
bricks/_common/micropython: Fix program stop message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@
   calling `super().__init(...)` on uninitialized objects ([support#777]).
 - Reverted Pybricks Code stop button raises `SystemAbort` instead of
   `SystemExit` ([support#834]).
+- Improved stop message raised on `SystemExit` and `SystemAbort` ([support#836]).
 
 [support#777]: https://github.com/pybricks/support/issues/777
 [support#805]: https://github.com/pybricks/support/issues/805
 [support#826]: https://github.com/pybricks/support/issues/826
 [support#834]: https://github.com/pybricks/support/issues/834
+[support#834]: https://github.com/pybricks/support/issues/836
 
 
 ## [3.2.0b6] - 2022-12-02

--- a/bricks/_common/micropython.c
+++ b/bricks/_common/micropython.c
@@ -93,7 +93,8 @@ static void print_final_exception(mp_obj_t exc) {
     // Handle graceful stop with button or shutdown.
     if (mp_obj_exception_match(exc, &mp_type_SystemAbort) ||
         mp_obj_exception_match(exc, &mp_type_SystemExit)) {
-        mp_printf(&mp_plat_print, "Stop button pressed.\n");
+        mp_printf(&mp_plat_print, "The program was stopped (%q).\n",
+            ((mp_obj_exception_t *)MP_OBJ_TO_PTR(exc))->base.type->name);
         return;
     }
 


### PR DESCRIPTION
This avoids mentioning the stop button so that it is correct for all SystemExit or SystemAbort exceptions.

Fixes https://github.com/pybricks/support/issues/836