### PR TITLE
Fixes gyro read using the wrong scaling and data indices for IMU data (angular_rate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+### Fixed
+- Fixed `imu.angular_velocity` returning the values of `imu.acceleration`.
+
+[support#885]: https://github.com/pybricks/support/issues/885
+
 ## [3.2.0] - 2022-12-20
 
 ### Changed

--- a/lib/pbio/drv/imu/imu_lsm6ds3tr_c_stm32.c
+++ b/lib/pbio/drv/imu/imu_lsm6ds3tr_c_stm32.c
@@ -292,9 +292,9 @@ void pbdrv_imu_gyro_read(pbdrv_imu_dev_t *imu_dev, float *values) {
     // Output is signed such that we have a right handed coordinate system
     // consistent with the coordinate system above. Positive rotations along
     // those axes then follow the right hand rule.
-    values[0] = PBDRV_CONFIG_IMU_LSM6S3TR_C_STM32_SIGN_X * imu_dev->data[0] * imu_dev->accel_scale;
-    values[1] = PBDRV_CONFIG_IMU_LSM6S3TR_C_STM32_SIGN_Y * imu_dev->data[1] * imu_dev->accel_scale;
-    values[2] = PBDRV_CONFIG_IMU_LSM6S3TR_C_STM32_SIGN_Z * imu_dev->data[2] * imu_dev->accel_scale;
+    values[0] = PBDRV_CONFIG_IMU_LSM6S3TR_C_STM32_SIGN_X * imu_dev->data[3] * imu_dev->gyro_scale;
+    values[1] = PBDRV_CONFIG_IMU_LSM6S3TR_C_STM32_SIGN_Y * imu_dev->data[4] * imu_dev->gyro_scale;
+    values[2] = PBDRV_CONFIG_IMU_LSM6S3TR_C_STM32_SIGN_Z * imu_dev->data[5] * imu_dev->gyro_scale;
 }
 
 float pbdrv_imu_temperature_read(pbdrv_imu_dev_t *imu_dev) {


### PR DESCRIPTION
The code found here:
https://github.com/pybricks/pybricks-micropython/blob/af76eecd6bfaff97c9e6435ed16d4bc97b9a946e/lib/pbio/drv/imu/imu_lsm6ds3tr_c_stm32.c#L283-L298
is sourcing both the accel and gyro values from the same source.

The original code was using the accel scaling and the data from the accelerometer, indices 0-2, while the gyro data is stored in indices 3-5 as notated here:
[pybricks-micropython/lib/pbi](https://github.com/pybricks/pybricks-micropython/blob/af76eecd6bfaff97c9e6435ed16d4bc97b9a946e/lib/pbio/drv/imu/imu_lsm6ds3tr_c_stm32.c#L240-L246)

This fork fixes the angular_rate function for all hubs to return the correct value in deg/s