### PR TITLE
pybricks/util_mp/pb_obj_helper: fix crash caused by PB_ATTRIBUTE_TABLE

### DIFF
--- a/bricks/ev3dev/pb_type_ev3dev_font.c
+++ b/bricks/ev3dev/pb_type_ev3dev_font.c
@@ -140,6 +140,7 @@ STATIC const pb_attr_dict_entry_t ev3dev_Font_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_style, ev3dev_Font_obj_t, style),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_width, ev3dev_Font_obj_t, width),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_height, ev3dev_Font_obj_t, height),
+    PB_ATTR_DICT_SENTINEL
 };
 
 STATIC const mp_rom_map_elem_t ev3dev_Font_locals_dict_table[] = {
@@ -147,7 +148,6 @@ STATIC const mp_rom_map_elem_t ev3dev_Font_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&ev3dev_Font___del___obj) },
     { MP_ROM_QSTR(MP_QSTR_text_width), MP_ROM_PTR(&ev3dev_Font_text_width_obj) },
     { MP_ROM_QSTR(MP_QSTR_text_height), MP_ROM_PTR(&ev3dev_Font_text_height_obj) },
-    PB_ATTRIBUTE_TABLE(ev3dev_Font_attr_dict),
 };
 STATIC MP_DEFINE_CONST_DICT(ev3dev_Font_locals_dict, ev3dev_Font_locals_dict_table);
 
@@ -156,6 +156,7 @@ const mp_obj_type_t pb_type_ev3dev_Font = {
     .name = MP_QSTR_Font,
     .make_new = ev3dev_Font_make_new,
     .attr = pb_attribute_handler,
+    .protocol = ev3dev_Font_attr_dict,
     .locals_dict = (mp_obj_dict_t *)&ev3dev_Font_locals_dict,
 };
 

--- a/bricks/ev3dev/pb_type_ev3dev_image.c
+++ b/bricks/ev3dev/pb_type_ev3dev_image.c
@@ -550,6 +550,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(ev3dev_Image_save_obj, ev3dev_Image_save);
 STATIC const pb_attr_dict_entry_t ev3dev_Image_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_width, ev3dev_Image_obj_t, width),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_height, ev3dev_Image_obj_t, height),
+    PB_ATTR_DICT_SENTINEL
 };
 
 STATIC const mp_rom_map_elem_t ev3dev_Image_locals_dict_table[] = {
@@ -566,7 +567,6 @@ STATIC const mp_rom_map_elem_t ev3dev_Image_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_set_font),    MP_ROM_PTR(&ev3dev_Image_set_font_obj)                 },
     { MP_ROM_QSTR(MP_QSTR_print),       MP_ROM_PTR(&ev3dev_Image_print_obj)                    },
     { MP_ROM_QSTR(MP_QSTR_save),        MP_ROM_PTR(&ev3dev_Image_save_obj)                     },
-    PB_ATTRIBUTE_TABLE(ev3dev_Image_attr_dict),
 };
 STATIC MP_DEFINE_CONST_DICT(ev3dev_Image_locals_dict, ev3dev_Image_locals_dict_table);
 
@@ -575,5 +575,6 @@ const mp_obj_type_t pb_type_ev3dev_Image = {
     .name = MP_QSTR_Image,
     .make_new = ev3dev_Image_make_new,
     .attr = pb_attribute_handler,
+    .protocol = ev3dev_Image_attr_dict,
     .locals_dict = (mp_obj_dict_t *)&ev3dev_Image_locals_dict,
 };

--- a/pybricks/common/pb_type_control.c
+++ b/pybricks/common/pb_type_control.c
@@ -270,6 +270,7 @@ STATIC const pb_attr_dict_entry_t common_Control_attr_dict[] = {
     #if PYBRICKS_PY_COMMON_LOGGER
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_log, common_Control_obj_t, logger),
     #endif // PYBRICKS_PY_COMMON_LOGGER
+    PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.common.Control)
@@ -282,7 +283,6 @@ STATIC const mp_rom_map_elem_t common_Control_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_done), MP_ROM_PTR(&common_Control_done_obj) },
     { MP_ROM_QSTR(MP_QSTR_load), MP_ROM_PTR(&common_Control_load_obj) },
     { MP_ROM_QSTR(MP_QSTR_stalled), MP_ROM_PTR(&common_Control_stalled_obj) },
-    PB_ATTRIBUTE_TABLE(common_Control_attr_dict),
 };
 STATIC MP_DEFINE_CONST_DICT(common_Control_locals_dict, common_Control_locals_dict_table);
 
@@ -291,6 +291,7 @@ const mp_obj_type_t pb_type_Control = {
     { &mp_type_type },
     .name = MP_QSTR_Control,
     .attr = pb_attribute_handler,
+    .protocol = common_Control_attr_dict,
     .locals_dict = (mp_obj_dict_t *)&common_Control_locals_dict,
 };
 

--- a/pybricks/common/pb_type_motor.c
+++ b/pybricks/common/pb_type_motor.c
@@ -371,6 +371,7 @@ STATIC mp_obj_t common_Motor_load(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(common_Motor_load_obj, common_Motor_load);
 
+#if PYBRICKS_PY_COMMON_CONTROL | PYBRICKS_PY_COMMON_LOGGER
 STATIC const pb_attr_dict_entry_t common_Motor_attr_dict[] = {
     #if PYBRICKS_PY_COMMON_CONTROL
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_control, common_Motor_obj_t, control),
@@ -378,7 +379,9 @@ STATIC const pb_attr_dict_entry_t common_Motor_attr_dict[] = {
     #if PYBRICKS_PY_COMMON_LOGGER
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_log, common_Motor_obj_t, logger),
     #endif
+    PB_ATTR_DICT_SENTINEL
 };
+#endif // PYBRICKS_PY_COMMON_CONTROL | PYBRICKS_PY_COMMON_LOGGER
 
 // dir(pybricks.builtins.Motor)
 STATIC const mp_rom_map_elem_t common_Motor_locals_dict_table[] = {
@@ -406,7 +409,6 @@ STATIC const mp_rom_map_elem_t common_Motor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_done), MP_ROM_PTR(&common_Motor_done_obj) },
     { MP_ROM_QSTR(MP_QSTR_track_target), MP_ROM_PTR(&common_Motor_track_target_obj) },
     { MP_ROM_QSTR(MP_QSTR_load), MP_ROM_PTR(&common_Motor_load_obj) },
-    PB_ATTRIBUTE_TABLE(common_Motor_attr_dict),
 };
 MP_DEFINE_CONST_DICT(common_Motor_locals_dict, common_Motor_locals_dict_table);
 
@@ -416,7 +418,10 @@ const mp_obj_type_t pb_type_Motor = {
     .name = MP_QSTR_Motor,
     .print = common_DCMotor_print,
     .make_new = common_Motor_make_new,
+    #if PYBRICKS_PY_COMMON_CONTROL | PYBRICKS_PY_COMMON_LOGGER
     .attr = pb_attribute_handler,
+    .protocol = common_Motor_attr_dict,
+    #endif
     .locals_dict = (mp_obj_dict_t *)&common_Motor_locals_dict,
 };
 

--- a/pybricks/hubs/pb_type_cityhub.c
+++ b/pybricks/hubs/pb_type_cityhub.c
@@ -40,19 +40,15 @@ STATIC const pb_attr_dict_entry_t hubs_CityHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_button, hubs_CityHub_obj_t, button),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, hubs_CityHub_obj_t, light),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_system, hubs_CityHub_obj_t, system),
+    PB_ATTR_DICT_SENTINEL
 };
-
-STATIC const mp_rom_map_elem_t hubs_CityHub_locals_dict_table[] = {
-    PB_ATTRIBUTE_TABLE(hubs_CityHub_attr_dict),
-};
-STATIC MP_DEFINE_CONST_DICT(hubs_CityHub_locals_dict, hubs_CityHub_locals_dict_table);
 
 const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = MP_QSTR_CityHub,
     .make_new = hubs_CityHub_make_new,
     .attr = pb_attribute_handler,
-    .locals_dict = (mp_obj_dict_t *)&hubs_CityHub_locals_dict,
+    .protocol = hubs_CityHub_attr_dict,
 };
 
 #endif // PYBRICKS_PY_HUBS && PYBRICKS_HUB_CITYHUB

--- a/pybricks/hubs/pb_type_essentialhub.c
+++ b/pybricks/hubs/pb_type_essentialhub.c
@@ -61,19 +61,15 @@ STATIC const pb_attr_dict_entry_t hubs_EssentialHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_imu, hubs_EssentialHub_obj_t, imu),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, hubs_EssentialHub_obj_t, light),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_system, hubs_EssentialHub_obj_t, system),
+    PB_ATTR_DICT_SENTINEL
 };
-
-STATIC const mp_rom_map_elem_t hubs_EssentialHub_locals_dict_table[] = {
-    PB_ATTRIBUTE_TABLE(hubs_EssentialHub_attr_dict),
-};
-STATIC MP_DEFINE_CONST_DICT(hubs_EssentialHub_locals_dict, hubs_EssentialHub_locals_dict_table);
 
 const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = PYBRICKS_HUB_CLASS_NAME,
     .make_new = hubs_EssentialHub_make_new,
     .attr = pb_attribute_handler,
-    .locals_dict = (mp_obj_dict_t *)&hubs_EssentialHub_locals_dict,
+    .protocol = hubs_EssentialHub_attr_dict,
 };
 
 #endif // PYBRICKS_PY_HUBS && PYBRICKS_HUB_ESSENTIALHUB

--- a/pybricks/hubs/pb_type_ev3brick.c
+++ b/pybricks/hubs/pb_type_ev3brick.c
@@ -56,19 +56,15 @@ STATIC const pb_attr_dict_entry_t hubs_EV3Brick_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_screen, hubs_EV3Brick_obj_t, screen),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_speaker, hubs_EV3Brick_obj_t, speaker),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_system, hubs_EV3Brick_obj_t, system),
+    PB_ATTR_DICT_SENTINEL
 };
-
-STATIC const mp_rom_map_elem_t hubs_EV3Brick_locals_dict_table[] = {
-    PB_ATTRIBUTE_TABLE(hubs_EV3Brick_attr_dict),
-};
-STATIC MP_DEFINE_CONST_DICT(hubs_EV3Brick_locals_dict, hubs_EV3Brick_locals_dict_table);
 
 const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = PYBRICKS_HUB_CLASS_NAME,
     .make_new = hubs_EV3Brick_make_new,
     .attr = pb_attribute_handler,
-    .locals_dict = (mp_obj_dict_t *)&hubs_EV3Brick_locals_dict,
+    .protocol = hubs_EV3Brick_attr_dict,
 };
 
 #endif // PYBRICKS_PY_HUBS && PYBRICKS_HUB_EV3BRICK

--- a/pybricks/hubs/pb_type_movehub.c
+++ b/pybricks/hubs/pb_type_movehub.c
@@ -273,19 +273,15 @@ STATIC const pb_attr_dict_entry_t hubs_MoveHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_imu, hubs_MoveHub_obj_t, imu),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, hubs_MoveHub_obj_t, light),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_system, hubs_MoveHub_obj_t, system),
+    PB_ATTR_DICT_SENTINEL
 };
-
-STATIC const mp_rom_map_elem_t hubs_MoveHub_locals_dict_table[] = {
-    PB_ATTRIBUTE_TABLE(hubs_MoveHub_attr_dict),
-};
-STATIC MP_DEFINE_CONST_DICT(hubs_MoveHub_locals_dict, hubs_MoveHub_locals_dict_table);
 
 const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = PYBRICKS_HUB_CLASS_NAME,
     .make_new = hubs_MoveHub_make_new,
     .attr = pb_attribute_handler,
-    .locals_dict = (mp_obj_dict_t *)&hubs_MoveHub_locals_dict,
+    .protocol = hubs_MoveHub_attr_dict,
 };
 
 #endif // PYBRICKS_PY_HUBS && PYBRICKS_HUB_MOVEHUB

--- a/pybricks/hubs/pb_type_nxtbrick.c
+++ b/pybricks/hubs/pb_type_nxtbrick.c
@@ -38,20 +38,15 @@ STATIC const pb_attr_dict_entry_t hubs_NXTBrick_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_NXTBrick_obj_t, battery),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_buttons, hubs_NXTBrick_obj_t, buttons),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_system, hubs_NXTBrick_obj_t, system),
+    PB_ATTR_DICT_SENTINEL
 };
-
-
-STATIC const mp_rom_map_elem_t hubs_NXTBrick_locals_dict_table[] = {
-    PB_ATTRIBUTE_TABLE(hubs_NXTBrick_attr_dict),
-};
-STATIC MP_DEFINE_CONST_DICT(hubs_NXTBrick_locals_dict, hubs_NXTBrick_locals_dict_table);
 
 const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = PYBRICKS_HUB_CLASS_NAME,
     .make_new = hubs_NXTBrick_make_new,
     .attr = pb_attribute_handler,
-    .locals_dict = (mp_obj_dict_t *)&hubs_NXTBrick_locals_dict,
+    .protocol = hubs_NXTBrick_attr_dict,
 };
 
 #endif // PYBRICKS_PY_HUBS && PYBRICKS_HUB_NXTBRICK

--- a/pybricks/hubs/pb_type_primehub.c
+++ b/pybricks/hubs/pb_type_primehub.c
@@ -70,19 +70,15 @@ STATIC const pb_attr_dict_entry_t hubs_PrimeHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, hubs_PrimeHub_obj_t, light),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_speaker, hubs_PrimeHub_obj_t, speaker),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_system, hubs_PrimeHub_obj_t, system),
+    PB_ATTR_DICT_SENTINEL
 };
-
-STATIC const mp_rom_map_elem_t hubs_PrimeHub_locals_dict_table[] = {
-    PB_ATTRIBUTE_TABLE(hubs_PrimeHub_attr_dict),
-};
-STATIC MP_DEFINE_CONST_DICT(hubs_PrimeHub_locals_dict, hubs_PrimeHub_locals_dict_table);
 
 const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = PYBRICKS_HUB_CLASS_NAME,
     .make_new = hubs_PrimeHub_make_new,
     .attr = pb_attribute_handler,
-    .locals_dict = (mp_obj_dict_t *)&hubs_PrimeHub_locals_dict,
+    .protocol = hubs_PrimeHub_attr_dict,
 };
 
 #endif // PYBRICKS_PY_HUBS && PYBRICKS_HUB_PRIMEHUB

--- a/pybricks/hubs/pb_type_technichub.c
+++ b/pybricks/hubs/pb_type_technichub.c
@@ -49,19 +49,15 @@ STATIC const pb_attr_dict_entry_t hubs_TechnicHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_imu, hubs_TechnicHub_obj_t, imu),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, hubs_TechnicHub_obj_t, light),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_system, hubs_TechnicHub_obj_t, system),
+    PB_ATTR_DICT_SENTINEL
 };
-
-STATIC const mp_rom_map_elem_t hubs_TechnicHub_locals_dict_table[] = {
-    PB_ATTRIBUTE_TABLE(hubs_TechnicHub_attr_dict),
-};
-STATIC MP_DEFINE_CONST_DICT(hubs_TechnicHub_locals_dict, hubs_TechnicHub_locals_dict_table);
 
 const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = PYBRICKS_HUB_CLASS_NAME,
     .make_new = hubs_TechnicHub_make_new,
     .attr = pb_attribute_handler,
-    .locals_dict = (mp_obj_dict_t *)&hubs_TechnicHub_locals_dict,
+    .protocol = hubs_TechnicHub_attr_dict,
 };
 
 #endif // PYBRICKS_PY_HUBS && PYBRICKS_HUB_TECHNICHUB

--- a/pybricks/hubs/pb_type_virtualhub.c
+++ b/pybricks/hubs/pb_type_virtualhub.c
@@ -45,19 +45,15 @@ STATIC const pb_attr_dict_entry_t hubs_VirtualHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_buttons, hubs_VirtualHub_obj_t, buttons),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, hubs_VirtualHub_obj_t, light),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_system, hubs_VirtualHub_obj_t, system),
+    PB_ATTR_DICT_SENTINEL
 };
-
-STATIC const mp_rom_map_elem_t hubs_VirtualHub_locals_dict_table[] = {
-    PB_ATTRIBUTE_TABLE(hubs_VirtualHub_attr_dict),
-};
-STATIC MP_DEFINE_CONST_DICT(hubs_VirtualHub_locals_dict, hubs_VirtualHub_locals_dict_table);
 
 const mp_obj_type_t pb_type_ThisHub = {
     { &mp_type_type },
     .name = PYBRICKS_HUB_CLASS_NAME,
     .make_new = hubs_VirtualHub_make_new,
     .attr = pb_attribute_handler,
-    .locals_dict = (mp_obj_dict_t *)&hubs_VirtualHub_locals_dict,
+    .protocol = hubs_VirtualHub_attr_dict,
 };
 
 #endif // PYBRICKS_PY_HUBS && PYBRICKS_HUB_VIRTUALHUB

--- a/pybricks/iodevices/pb_type_iodevices_ev3devsensor.c
+++ b/pybricks/iodevices/pb_type_iodevices_ev3devsensor.c
@@ -76,12 +76,12 @@ MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_Ev3devSensor_read_obj, 1, iodevices_Ev3devS
 STATIC const pb_attr_dict_entry_t iodevices_Ev3devSensor_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_sensor_index, iodevices_Ev3devSensor_obj_t, sensor_index),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_port_index, iodevices_Ev3devSensor_obj_t, port_index),
+    PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.iodevices.Ev3devSensor)
 STATIC const mp_rom_map_elem_t iodevices_Ev3devSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_read),         MP_ROM_PTR(&iodevices_Ev3devSensor_read_obj)                        },
-    PB_ATTRIBUTE_TABLE(iodevices_Ev3devSensor_attr_dict),
 };
 STATIC MP_DEFINE_CONST_DICT(iodevices_Ev3devSensor_locals_dict, iodevices_Ev3devSensor_locals_dict_table);
 
@@ -90,6 +90,7 @@ const mp_obj_type_t pb_type_iodevices_Ev3devSensor = {
     { &mp_type_type },
     .make_new = iodevices_Ev3devSensor_make_new,
     .attr = pb_attribute_handler,
+    .protocol = iodevices_Ev3devSensor_attr_dict,
     .locals_dict = (mp_obj_dict_t *)&iodevices_Ev3devSensor_locals_dict,
 };
 

--- a/pybricks/iodevices/pb_type_iodevices_lumpdevice.c
+++ b/pybricks/iodevices/pb_type_iodevices_lumpdevice.c
@@ -95,13 +95,13 @@ MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_LUMPDevice_write_obj, 1, iodevices_LUMPDevi
 
 STATIC const pb_attr_dict_entry_t iodevices_LUMPDevice_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_ID, iodevices_LUMPDevice_obj_t, id),
+    PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.iodevices.LUMPDevice)
 STATIC const mp_rom_map_elem_t iodevices_LUMPDevice_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_read),       MP_ROM_PTR(&iodevices_LUMPDevice_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_write),      MP_ROM_PTR(&iodevices_LUMPDevice_write_obj)},
-    PB_ATTRIBUTE_TABLE(iodevices_LUMPDevice_attr_dict),
 };
 STATIC MP_DEFINE_CONST_DICT(iodevices_LUMPDevice_locals_dict, iodevices_LUMPDevice_locals_dict_table);
 
@@ -110,6 +110,7 @@ const mp_obj_type_t pb_type_iodevices_LUMPDevice = {
     { &mp_type_type },
     .make_new = iodevices_LUMPDevice_make_new,
     .attr = pb_attribute_handler,
+    .protocol = iodevices_LUMPDevice_attr_dict,
     .locals_dict = (mp_obj_dict_t *)&iodevices_LUMPDevice_locals_dict,
 };
 

--- a/pybricks/nxtdevices/pb_type_nxtdevices_colorsensor.c
+++ b/pybricks/nxtdevices/pb_type_nxtdevices_colorsensor.c
@@ -143,6 +143,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_ColorSensor_color_obj, nxtdevices_Co
 
 STATIC const pb_attr_dict_entry_t nxtdevices_ColorSensor_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, nxtdevices_ColorSensor_obj_t, light),
+    PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.nxtdevices.ColorSensor)
@@ -153,7 +154,6 @@ STATIC const mp_rom_map_elem_t nxtdevices_ColorSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_reflection), MP_ROM_PTR(&nxtdevices_ColorSensor_reflection_obj)           },
     { MP_ROM_QSTR(MP_QSTR_color),      MP_ROM_PTR(&nxtdevices_ColorSensor_color_obj)                },
     { MP_ROM_QSTR(MP_QSTR_detectable_colors),  MP_ROM_PTR(&pb_ColorSensor_detectable_colors_obj)                    },
-    PB_ATTRIBUTE_TABLE(nxtdevices_ColorSensor_attr_dict),
 };
 STATIC MP_DEFINE_CONST_DICT(nxtdevices_ColorSensor_locals_dict, nxtdevices_ColorSensor_locals_dict_table);
 
@@ -163,6 +163,7 @@ const mp_obj_type_t pb_type_nxtdevices_ColorSensor = {
     .name = MP_QSTR_ColorSensor,
     .make_new = nxtdevices_ColorSensor_make_new,
     .attr = pb_attribute_handler,
+    .protocol = nxtdevices_ColorSensor_attr_dict,
     .locals_dict = (mp_obj_dict_t *)&nxtdevices_ColorSensor_locals_dict,
 };
 

--- a/pybricks/pupdevices/pb_type_pupdevices_colordistancesensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_colordistancesensor.c
@@ -151,6 +151,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(pupdevices_ColorDistanceSensor_hsv_obj, pupdevices_Col
 
 STATIC const pb_attr_dict_entry_t pupdevices_ColorDistanceSensor_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, pupdevices_ColorDistanceSensor_obj_t, light),
+    PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.pupdevices.ColorDistanceSensor)
@@ -161,7 +162,6 @@ STATIC const mp_rom_map_elem_t pupdevices_ColorDistanceSensor_locals_dict_table[
     { MP_ROM_QSTR(MP_QSTR_distance),    MP_ROM_PTR(&pupdevices_ColorDistanceSensor_distance_obj)             },
     { MP_ROM_QSTR(MP_QSTR_hsv),         MP_ROM_PTR(&pupdevices_ColorDistanceSensor_hsv_obj)                  },
     { MP_ROM_QSTR(MP_QSTR_detectable_colors),   MP_ROM_PTR(&pb_ColorSensor_detectable_colors_obj)                            },
-    PB_ATTRIBUTE_TABLE(pupdevices_ColorDistanceSensor_attr_dict),
 };
 STATIC MP_DEFINE_CONST_DICT(pupdevices_ColorDistanceSensor_locals_dict, pupdevices_ColorDistanceSensor_locals_dict_table);
 
@@ -171,6 +171,7 @@ const mp_obj_type_t pb_type_pupdevices_ColorDistanceSensor = {
     .name = MP_QSTR_ColorDistanceSensor,
     .make_new = pupdevices_ColorDistanceSensor_make_new,
     .attr = pb_attribute_handler,
+    .protocol = pupdevices_ColorDistanceSensor_attr_dict,
     .locals_dict = (mp_obj_dict_t *)&pupdevices_ColorDistanceSensor_locals_dict,
 };
 

--- a/pybricks/pupdevices/pb_type_pupdevices_colorsensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_colorsensor.c
@@ -154,6 +154,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(pupdevices_ColorSensor_ambient_obj, pupdevices_ColorSe
 
 STATIC const pb_attr_dict_entry_t pupdevices_ColorSensor_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_lights, pupdevices_ColorSensor_obj_t, lights),
+    PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.pupdevices.ColorSensor)
@@ -163,7 +164,6 @@ STATIC const mp_rom_map_elem_t pupdevices_ColorSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_reflection),  MP_ROM_PTR(&pupdevices_ColorSensor_reflection_obj)           },
     { MP_ROM_QSTR(MP_QSTR_ambient),     MP_ROM_PTR(&pupdevices_ColorSensor_ambient_obj)              },
     { MP_ROM_QSTR(MP_QSTR_detectable_colors),   MP_ROM_PTR(&pb_ColorSensor_detectable_colors_obj)                    },
-    PB_ATTRIBUTE_TABLE(pupdevices_ColorSensor_attr_dict),
 };
 STATIC MP_DEFINE_CONST_DICT(pupdevices_ColorSensor_locals_dict, pupdevices_ColorSensor_locals_dict_table);
 
@@ -173,6 +173,7 @@ const mp_obj_type_t pb_type_pupdevices_ColorSensor = {
     .name = MP_QSTR_ColorSensor,
     .make_new = pupdevices_ColorSensor_make_new,
     .attr = pb_attribute_handler,
+    .protocol = pupdevices_ColorSensor_attr_dict,
     .locals_dict = (mp_obj_dict_t *)&pupdevices_ColorSensor_locals_dict,
 };
 

--- a/pybricks/pupdevices/pb_type_pupdevices_remote.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_remote.c
@@ -317,11 +317,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(remote_name_obj, 1, 2, remote_name);
 STATIC const pb_attr_dict_entry_t pb_type_pupdevices_Remote_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_buttons, pb_type_pupdevices_Remote_obj_t, buttons),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, pb_type_pupdevices_Remote_obj_t, light),
+    PB_ATTR_DICT_SENTINEL
 };
 
 STATIC const mp_rom_map_elem_t pb_type_pupdevices_Remote_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_name), MP_ROM_PTR(&remote_name_obj) },
-    PB_ATTRIBUTE_TABLE(pb_type_pupdevices_Remote_attr_dict),
 };
 STATIC MP_DEFINE_CONST_DICT(pb_type_pupdevices_Remote_locals_dict, pb_type_pupdevices_Remote_locals_dict_table);
 
@@ -330,6 +330,7 @@ const mp_obj_type_t pb_type_pupdevices_Remote = {
     .name = MP_QSTR_Remote,
     .make_new = pb_type_pupdevices_Remote_make_new,
     .attr = pb_attribute_handler,
+    .protocol = pb_type_pupdevices_Remote_attr_dict,
     .locals_dict = (mp_obj_dict_t *)&pb_type_pupdevices_Remote_locals_dict,
 };
 

--- a/pybricks/pupdevices/pb_type_pupdevices_ultrasonicsensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_ultrasonicsensor.c
@@ -59,13 +59,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(pupdevices_UltrasonicSensor_presence_obj, pupde
 
 STATIC const pb_attr_dict_entry_t pupdevices_UltrasonicSensor_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_lights, pupdevices_UltrasonicSensor_obj_t, lights),
+    PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.pupdevices.UltrasonicSensor)
 STATIC const mp_rom_map_elem_t pupdevices_UltrasonicSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_distance),     MP_ROM_PTR(&pupdevices_UltrasonicSensor_distance_obj)              },
     { MP_ROM_QSTR(MP_QSTR_presence),     MP_ROM_PTR(&pupdevices_UltrasonicSensor_presence_obj)              },
-    PB_ATTRIBUTE_TABLE(pupdevices_UltrasonicSensor_attr_dict),
 };
 STATIC MP_DEFINE_CONST_DICT(pupdevices_UltrasonicSensor_locals_dict, pupdevices_UltrasonicSensor_locals_dict_table);
 
@@ -75,6 +75,7 @@ const mp_obj_type_t pb_type_pupdevices_UltrasonicSensor = {
     .name = MP_QSTR_UltrasonicSensor,
     .make_new = pupdevices_UltrasonicSensor_make_new,
     .attr = pb_attribute_handler,
+    .protocol = pupdevices_UltrasonicSensor_attr_dict,
     .locals_dict = (mp_obj_dict_t *)&pupdevices_UltrasonicSensor_locals_dict,
 };
 

--- a/pybricks/robotics/pb_type_drivebase.c
+++ b/pybricks/robotics/pb_type_drivebase.c
@@ -290,6 +290,7 @@ STATIC const pb_attr_dict_entry_t robotics_DriveBase_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_heading_control, robotics_DriveBase_obj_t, heading_control),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_distance_control, robotics_DriveBase_obj_t, distance_control),
     #endif
+    PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.robotics.DriveBase)
@@ -306,7 +307,6 @@ STATIC const mp_rom_map_elem_t robotics_DriveBase_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_reset),            MP_ROM_PTR(&robotics_DriveBase_reset_obj)    },
     { MP_ROM_QSTR(MP_QSTR_settings),         MP_ROM_PTR(&robotics_DriveBase_settings_obj) },
     { MP_ROM_QSTR(MP_QSTR_stalled),          MP_ROM_PTR(&robotics_DriveBase_stalled_obj)  },
-    PB_ATTRIBUTE_TABLE(robotics_DriveBase_attr_dict),
 };
 STATIC MP_DEFINE_CONST_DICT(robotics_DriveBase_locals_dict, robotics_DriveBase_locals_dict_table);
 
@@ -316,6 +316,7 @@ const mp_obj_type_t pb_type_drivebase = {
     .name = MP_QSTR_DriveBase,
     .make_new = robotics_DriveBase_make_new,
     .attr = pb_attribute_handler,
+    .protocol = robotics_DriveBase_attr_dict,
     .locals_dict = (mp_obj_dict_t *)&robotics_DriveBase_locals_dict,
 };
 

--- a/pybricks/robotics/pb_type_spikebase.c
+++ b/pybricks/robotics/pb_type_spikebase.c
@@ -228,6 +228,7 @@ STATIC const pb_attr_dict_entry_t robotics_SpikeBase_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_heading_control, robotics_SpikeBase_obj_t, heading_control),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_distance_control, robotics_SpikeBase_obj_t, distance_control),
     #endif
+    PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.robotics.SpikeBase)
@@ -239,7 +240,6 @@ STATIC const mp_rom_map_elem_t robotics_SpikeBase_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_steering_move_for_time),    MP_ROM_PTR(&robotics_SpikeBase_steering_move_for_time_obj)    },
     { MP_ROM_QSTR(MP_QSTR_steering_move_forever),     MP_ROM_PTR(&robotics_SpikeBase_steering_move_forever_obj)     },
     { MP_ROM_QSTR(MP_QSTR_stop),                      MP_ROM_PTR(&robotics_SpikeBase_stop_obj)                      },
-    PB_ATTRIBUTE_TABLE(robotics_SpikeBase_attr_dict),
 };
 STATIC MP_DEFINE_CONST_DICT(robotics_SpikeBase_locals_dict, robotics_SpikeBase_locals_dict_table);
 
@@ -249,6 +249,7 @@ const mp_obj_type_t pb_type_spikebase = {
     .name = MP_QSTR_SpikeBase,
     .make_new = robotics_SpikeBase_make_new,
     .attr = pb_attribute_handler,
+    .protocol = robotics_SpikeBase_attr_dict,
     .locals_dict = (mp_obj_dict_t *)&robotics_SpikeBase_locals_dict,
 };
 

--- a/pybricks/util_mp/pb_obj_helper.c
+++ b/pybricks/util_mp/pb_obj_helper.c
@@ -146,18 +146,12 @@ void pb_attribute_handler(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
         }
     }
 
-    // Get locals map and the last row containing the attr table.
-    const mp_map_t *map = &((mp_obj_base_t *)MP_OBJ_TO_PTR(self_in))->type->locals_dict->map;
-    const mp_map_elem_t *row = &(map->table[map->alloc - 1]);
-
     // Get number of attributes and reference to attributes array.
-    assert(MP_OBJ_QSTR_VALUE(row->key) > MP_QSTRnumber_of);
-    uint8_t attr_dict_size = MP_OBJ_QSTR_VALUE(row->key) - MP_QSTRnumber_of;
-    pb_attr_dict_entry_t *attr_dict = row->value;
+    const pb_attr_dict_entry_t *attr_dict = type->protocol;
     const pb_attr_dict_entry_t *entry = NULL;
 
-    // Look up the attribute offset.
-    for (int i = 0; i < attr_dict_size; i++) {
+    // Look up the attribute offset. attr_dict is zero-terminated.
+    for (int i = 0; attr_dict[i].name; i++) {
         if (attr_dict[i].name == attr) {
             entry = &attr_dict[i];
             break;

--- a/pybricks/util_mp/pb_obj_helper.h
+++ b/pybricks/util_mp/pb_obj_helper.h
@@ -46,16 +46,17 @@ typedef struct {
     uint8_t offset;
 } pb_attr_dict_entry_t;
 
+// pb_attr_dict_entry_t arrays must be zero-terminated
+#define PB_ATTR_DICT_SENTINEL {}
+
 // Generic entry of the attributes dictionary.
 #define PB_DEFINE_CONST_ATTR_RO(name_, type, field) {           \
         .name = (name_),                                        \
         .offset = offsetof(type, field),                        \
 }
 
-// Points to attributes dictionary. Must be the last entry of locals_dict.
-#define PB_ATTRIBUTE_TABLE(table) { MP_ROM_QSTR(MP_QSTRnumber_of + MP_ARRAY_SIZE(table)), MP_ROM_PTR(table) }
-
-// Attribute handler for any object that has an attribute dictionary.
+// Attribute handler for any object that has an attribute dictionary assigned
+// to the mp_obj_type_t protocol slot.
 void pb_attribute_handler(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
 
 #endif // PYBRICKS_INCLUDED_PBOBJ_H


### PR DESCRIPTION
Using the key of the locals dict to store non-qstr info causes the builtin help() method to crash. Instead we can use the protocol slot to avoid the crash. The attr entry arrays are now zero terminated instead of storing the size (since the entries are < 32-bits we are not using any more space than we would if we stored the size somewhere else where it had to be 32-bit aligned).

Fixes: https://github.com/pybricks/support/issues/909