### PR TITLE
pbio/drv/imu_lsm6ds3tr_c_stm32: Read gyro and acceleration in one pass.

### DIFF
--- a/lib/pbio/drv/imu/imu_lsm6ds3tr_c_stm32.c
+++ b/lib/pbio/drv/imu/imu_lsm6ds3tr_c_stm32.c
@@ -208,10 +208,13 @@ static PT_THREAD(pbdrv_imu_lsm6ds3tr_c_stm32_init(struct pt *pt)) {
     /* Gyroscope - filtering chain */
     // PT_SPAWN(pt, &child, lsm6ds3tr_c_gy_band_pass_set(&child, ctx, LSM6DS3TR_C_HP_16mHz_LP1_LIGHT));
 
-    // configure interrupts
+    // Configure INT1 to trigger when new gyro data is ready.
     PT_SPAWN(pt, &child, lsm6ds3tr_c_pin_int1_route_set(&child, ctx, (lsm6ds3tr_c_int1_route_t) {
         .int1_drdy_g = 1,
     }));
+
+    // If we leave the default latched mode, sometimes we don't get the INT1 interrupt.
+    PT_SPAWN(pt, &child, lsm6ds3tr_c_data_ready_mode_set(&child, ctx, LSM6DS3TR_C_DRDY_PULSED));
 
     // Enable rounding mode so we can get gyro + accel in one read.
     PT_SPAWN(pt, &child, lsm6ds3tr_c_rounding_mode_set(&child, ctx, LSM6DS3TR_C_ROUND_GY_XL));

--- a/lib/pbio/drv/imu/imu_lsm6ds3tr_c_stm32.c
+++ b/lib/pbio/drv/imu/imu_lsm6ds3tr_c_stm32.c
@@ -170,11 +170,6 @@ static PT_THREAD(pbdrv_imu_lsm6ds3tr_c_stm32_init(struct pt *pt)) {
     } while (rst);
 
     /*
-     *  Enable Block Data Update
-     */
-    PT_SPAWN(pt, &child, lsm6ds3tr_c_block_data_update_set(&child, ctx, PROPERTY_ENABLE));
-
-    /*
      * Set Output Data Rate
      */
     PT_SPAWN(pt, &child, lsm6ds3tr_c_xl_data_rate_set(&child, ctx, LSM6DS3TR_C_XL_ODR_833Hz));
@@ -188,25 +183,6 @@ static PT_THREAD(pbdrv_imu_lsm6ds3tr_c_stm32_init(struct pt *pt)) {
 
     PT_SPAWN(pt, &child, lsm6ds3tr_c_gy_full_scale_set(&child, ctx, LSM6DS3TR_C_1000dps));
     imu_dev->gyro_scale = lsm6ds3tr_c_from_fs1000dps_to_mdps(1) / 1000.0f;
-
-    /*
-     * Configure filtering chain(No aux interface)
-     */
-    /* Accelerometer - analog filter */
-    // PT_SPAWN(pt, &child, lsm6ds3tr_c_xl_filter_analog_set(&child, ctx, LSM6DS3TR_C_XL_ANA_BW_400Hz));
-
-    /* Accelerometer - LPF1 path ( LPF2 not used )*/
-    // PT_SPAWN(pt, &child, lsm6ds3tr_c_xl_lp1_bandwidth_set(&child, ctx, LSM6DS3TR_C_XL_LP1_ODR_DIV_4));
-
-    /* Accelerometer - LPF1 + LPF2 path */
-    // PT_SPAWN(pt, &child, lsm6ds3tr_c_xl_lp2_bandwidth_set(&child, ctx, LSM6DS3TR_C_XL_LOW_NOISE_LP_ODR_DIV_100));
-
-    /* Accelerometer - High Pass / Slope path */
-    // PT_SPAWN(pt, &child, lsm6ds3tr_c_xl_reference_mode_set(&child, ctx, PROPERTY_DISABLE));
-    // PT_SPAWN(pt, &child, lsm6ds3tr_c_xl_hp_bandwidth_set(&child, ctx, LSM6DS3TR_C_XL_HP_ODR_DIV_100));
-
-    /* Gyroscope - filtering chain */
-    // PT_SPAWN(pt, &child, lsm6ds3tr_c_gy_band_pass_set(&child, ctx, LSM6DS3TR_C_HP_16mHz_LP1_LIGHT));
 
     // Configure INT1 to trigger when new gyro data is ready.
     PT_SPAWN(pt, &child, lsm6ds3tr_c_pin_int1_route_set(&child, ctx, (lsm6ds3tr_c_int1_route_t) {


### PR DESCRIPTION
This should further reduce overhead.