### PR TITLE
Improve EV3 loop time and motor performance

### DIFF
--- a/bricks/ev3dev/pbinit.c
+++ b/bricks/ev3dev/pbinit.c
@@ -39,7 +39,7 @@ static pthread_t task_caller_thread;
 static void *task_caller(void *arg) {
     struct timespec ts;
     ts.tv_sec = 0;
-    ts.tv_nsec = PBIO_CONFIG_CONTROL_LOOP_TIME_MS * 1000000;
+    ts.tv_nsec = 2000000;
 
     while (!stopping_thread) {
         MP_THREAD_GIL_ENTER();


### PR DESCRIPTION
Before the change, it looked like this. Speed estimates are way off:

![image](https://user-images.githubusercontent.com/12326241/219868624-11dfde51-d126-4768-8be0-7647fae0fbee.png)

After this change, it looks like this. The motor makes a perfect speed trapazoid:

![image](https://user-images.githubusercontent.com/12326241/219868583-096a30e5-e908-4560-9b1e-54a84ac0baf7.png)
