### PR TITLE
DRAFT: Add docker-make to run 'make' via Docker

### DIFF
--- a/docker-make
+++ b/docker-make
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v docker >/dev/null; then
+	echo "Docker not found" >&2
+	exit 1
+fi
+
+
+image_name="pybricks-build"
+image_version="$(cat -- $0 tools/docker/make.Dockerfile | openssl sha256)"
+
+#echo docker image ls $image_name:$image_version
+#docker image ls -q $image_name:$image_version
+
+if [[ -z "$(docker image ls -q $image_name:$image_version)" ]]; then
+	echo "Building image..."
+	( cd tools/docker ; docker build -t $image_name:$image_version -f make.Dockerfile . )
+fi
+
+# docker ps --format '{{json .}}' --filter Name=repo -a
+
+#exec docker run -it -d --user $(id -u):$(id -g) --mount type=bind,dst=/src,src="$(pwd)" $image_name:$image_version -- "$@"
+# echo docker run -it --rm --user $(id -u):$(id -g) $image_name:$image_version  "$@"
+echo docker run -it --rm --mount "type=bind,dst=/src,src=$(pwd)" $image_name:$image_version "$@"
+exec docker run -it --rm --mount "type=bind,dst=/src,src=$(pwd)" $image_name:$image_version "$@"
+

--- a/tools/docker/make.Dockerfile
+++ b/tools/docker/make.Dockerfile
@@ -1,0 +1,42 @@
+#
+
+# syntax=docker/dockerfile:1
+
+FROM ubuntu:22.04
+
+ENV LANG C.UTF-8
+
+# software-properties-common provides apt-add-repository
+
+RUN export DEBIAN_FRONTEND=noninteractive ; mkdir -m 777 /src && \
+    apt-get update && \
+    apt-get install -y curl git python3 python3-pip build-essential qemu-user-static pipx ruby u-boot-tools && \
+    apt-get install -y software-properties-common && \
+    apt-add-repository ppa:pybricks/ppa && \
+    apt-get install -y uncrustify && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Poetry
+RUN pipx install poetry
+
+# For ev3rt
+RUN gem install shell
+
+# TODO
+# https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads
+# https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi.tar.xz?rev=7bd049b7a3034e64885fa1a71c12f91d&hash=732D909FA8F68C0E1D0D17D08E057619
+
+RUN arm_toolchain_version=$(curl https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads | sed -n 's!^.*<h4>Version \(.*\)</h4>.*$!\1!p') ; \
+    curl -Lo gcc-arm-none-eabi.tar.xz https://developer.arm.com/-/media/Files/downloads/gnu/${arm_toolchain_version}/binrel/arm-gnu-toolchain-${arm_toolchain_version}-x86_64-arm-none-eabi.tar.xz && \
+    mkdir -p /opt/gcc-arm-none-eabi && \
+    tar xf gcc-arm-none-eabi.tar.xz --strip-components=1 -C /opt/gcc-arm-none-eabi && \
+    echo 'export PATH=$PATH:/opt/gcc-arm-none-eabi/bin' | tee -a /etc/profile.d/gcc-arm-none-eabi.sh
+
+
+ENV PATH=/opt/gcc-arm-none-eabi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# RUN make $MAKEOPTS -C micropython/mpy-cross
+
+WORKDIR /src 
+
+ENTRYPOINT [ "/usr/bin/make" ]


### PR DESCRIPTION
Add `docker-make`, a wrapper around `make` using Docker to run `make` in a well-defined Linux-based environment.

Usage: `docker-make [make-args...]` 

Note: This is an early experiment and `docker-make ev3rt` (the only make target I tried so far) doesn't succeeds at compiling yet. I'm still investigating the issue, but I'm posting this early draft to get feedback if there is interest in this contribution.