### PR TITLE
bricks/virtualhub: Build without CPython.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -105,23 +105,11 @@
             "request": "launch",
             "program": "${workspaceFolder}/bricks/virtualhub/build-debug/virtualhub-micropython",
             "args": [
-                "./tests/motors/single_motor.py"
+                "./tests/motors/open_loop.py"
             ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [
-                {
-                    "name": "PYTHONPATH",
-                    "value": "lib/pbio/cpython"
-                },
-                {
-                    "name": "PBIO_VIRTUAL_PLATFORM_MODULE",
-                    "value": "pbio_virtual.platform.robot"
-                },
-                {
-                    "name": "PATH",
-                    "value": "${workspaceFolder}/.venv/bin:${env:PATH}",
-                }
             ],
             "externalConsole": false,
             "MIMode": "gdb",

--- a/bricks/virtualhub/mpconfigvariant.h
+++ b/bricks/virtualhub/mpconfigvariant.h
@@ -35,6 +35,13 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE (0)
 #define PYBRICKS_PY_TOOLS               (1)
 
+// Pybricks options
+#define PYBRICKS_OPT_COMPILER                   (1)
+#define PYBRICKS_OPT_FLOAT                      (1)
+#define PYBRICKS_OPT_TERSE_ERR                  (0)
+#define PYBRICKS_OPT_EXTRA_MOD                  (1)
+#define PYBRICKS_OPT_CUSTOM_IMPORT              (1)
+
 // Upstream MicroPython options
 #define MICROPY_MODULE_ATTR_DELEGATION          (1)
 #define MICROPY_MODULE_BUILTIN_INIT             (1)

--- a/bricks/virtualhub/mpvarianthal.h
+++ b/bricks/virtualhub/mpvarianthal.h
@@ -65,16 +65,12 @@ static inline int mp_hal_readline(vstr_t *vstr, const char *p) {
 #endif
 
 // MicroPython time needs to be driven by the virtual clock driver.
-
+#include <pbdrv/clock.h>
 void pb_virtualhub_delay_us(mp_uint_t us);
-mp_uint_t pb_virtualhub_ticks_ms(void);
-mp_uint_t pb_virtualhub_ticks_us(void);
-uint64_t pb_virtualhub_time_ns(void);
 
 #define mp_hal_delay_us pb_virtualhub_delay_us
-#define mp_hal_ticks_ms pb_virtualhub_ticks_ms
-#define mp_hal_ticks_us pb_virtualhub_ticks_us
-#define mp_hal_time_ns pb_virtualhub_time_ns
+#define mp_hal_ticks_ms pbdrv_clock_get_ms
+#define mp_hal_ticks_us pbdrv_clock_get_us
 #define mp_hal_ticks_cpu() 0
 
 void mp_hal_get_random(size_t n, void *buf);

--- a/lib/pbio/platform/virtual_hub/pbdrvconfig.h
+++ b/lib/pbio/platform/virtual_hub/pbdrvconfig.h
@@ -2,32 +2,30 @@
 // Copyright (c) 2022 The Pybricks Authors
 
 #define PBDRV_CONFIG_BATTERY                                (1)
-#define PBDRV_CONFIG_BATTERY_VIRTUAL                        (1)
+#define PBDRV_CONFIG_BATTERY_TEST                           (1)
 
 #define PBDRV_CONFIG_BUTTON                                 (1)
-#define PBDRV_CONFIG_BUTTON_VIRTUAL                         (1)
+#define PBDRV_CONFIG_BUTTON_TEST                            (1)
 
 #define PBDRV_CONFIG_CLOCK                                  (1)
-#define PBDRV_CONFIG_CLOCK_VIRTUAL                          (1)
+#define PBDRV_CONFIG_CLOCK_LINUX                            (1)
+#define PBDRV_CONFIG_CLOCK_LINUX_SIGNAL                     (1)
 
 #define PBDRV_CONFIG_COUNTER                                (1)
 #define PBDRV_CONFIG_COUNTER_NUM_DEV                        (6)
-#define PBDRV_CONFIG_COUNTER_VIRTUAL_CPYTHON                (1)
-#define PBDRV_CONFIG_COUNTER_VIRTUAL_CPYTHON_NUM_DEV        (6)
+#define PBDRV_CONFIG_COUNTER_VIRTUAL_SIMULATION             (1)
+#define PBDRV_CONFIG_COUNTER_VIRTUAL_SIMULATION_NUM_DEV     (6)
 
 #define PBDRV_CONFIG_IOPORT                                 (1)
-#define PBDRV_CONFIG_IOPORT_VIRTUAL_CPYTHON                 (1)
-
-#define PBDRV_CONFIG_LED                                    (1)
-#define PBDRV_CONFIG_LED_NUM_DEV                            (1)
-#define PBDRV_CONFIG_LED_VIRTUAL                            (1)
-#define PBDRV_CONFIG_LED_VIRTUAL_NUM_DEV                    (1)
+#define PBDRV_CONFIG_IOPORT_TEST                            (1)
+#define PBDRV_CONFIG_IOPORT_TEST_NUM_PORTS                  (6)
+#define PBDRV_CONFIG_IOPORT_TEST_FIRST_PORT                 PBIO_PORT_ID_A
+#define PBDRV_CONFIG_IOPORT_TEST_LAST_PORT                  PBIO_PORT_ID_F
 
 #define PBDRV_CONFIG_MOTOR_DRIVER                           (1)
 #define PBDRV_CONFIG_MOTOR_DRIVER_NUM_DEV                   (6)
-#define PBDRV_CONFIG_MOTOR_DRIVER_VIRTUAL_CPYTHON           (1)
-
-#define PBDRV_CONFIG_VIRTUAL                                (1)
+#define PBDRV_CONFIG_MOTOR_DRIVER_VIRTUAL_SIMULATION        (1)
+#define PBDRV_CONFIG_MOTOR_DRIVER_VIRTUAL_SIMULATION_AUTO_START (1)
 
 #define PBDRV_CONFIG_HAS_PORT_A (1)
 #define PBDRV_CONFIG_HAS_PORT_B (1)

--- a/lib/pbio/platform/virtual_hub/pbioconfig.h
+++ b/lib/pbio/platform/virtual_hub/pbioconfig.h
@@ -5,7 +5,7 @@
 #define PBIO_CONFIG_DCMOTOR                 (6)
 #define PBIO_CONFIG_DCMOTOR_NUM_DEV         (6)
 #define PBIO_CONFIG_DRIVEBASE_SPIKE         (1)
-#define PBIO_CONFIG_LIGHT                   (1)
+#define PBIO_CONFIG_LIGHT                   (0)
 #define PBIO_CONFIG_LOGGER                  (1)
 #define PBIO_CONFIG_LIGHT_MATRIX            (0)
 #define PBIO_CONFIG_MOTOR_PROCESS           (1)

--- a/lib/pbio/platform/virtual_hub/pbsysconfig.h
+++ b/lib/pbio/platform/virtual_hub/pbsysconfig.h
@@ -6,6 +6,6 @@
 #define PBSYS_CONFIG_HUB_LIGHT_MATRIX               (0)
 #define PBSYS_CONFIG_MAIN                           (0)
 #define PBSYS_CONFIG_PROGRAM_LOAD                   (0)
-#define PBSYS_CONFIG_STATUS_LIGHT                   (1)
+#define PBSYS_CONFIG_STATUS_LIGHT                   (0)
 #define PBSYS_CONFIG_STATUS_LIGHT_BATTERY           (0)
 #define PBSYS_CONFIG_PROGRAM_STOP                   (0)

--- a/lib/pbio/platform/virtual_hub/platform.c
+++ b/lib/pbio/platform/virtual_hub/platform.c
@@ -1,4 +1,132 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2022 The Pybricks Authors
+// Copyright (c) 2023 The Pybricks Authors
 
-// This file is unused, but required for the common make file.
+#include "../../drv/ioport/ioport_test.h"
+#include "../../drv/motor_driver/motor_driver_virtual_simulation.h"
+
+const pbio_iodev_capability_flags_t smart_motor = PBIO_IODEV_CAPABILITY_FLAG_IS_DC_OUTPUT | PBIO_IODEV_CAPABILITY_FLAG_HAS_MOTOR_REL_POS | PBIO_IODEV_CAPABILITY_FLAG_HAS_MOTOR_ABS_POS;
+
+const pbio_iodev_info_t iodev_info[PBDRV_CONFIG_IOPORT_TEST_NUM_PORTS] = {
+    // Port A
+    {
+        .type_id = PBIO_IODEV_TYPE_ID_SPIKE_M_MOTOR,
+        .capability_flags = smart_motor,
+    },
+    // Port B
+    {
+        .type_id = PBIO_IODEV_TYPE_ID_SPIKE_M_MOTOR,
+        .capability_flags = smart_motor,
+    },
+    // Port C
+    {
+        .type_id = PBIO_IODEV_TYPE_ID_SPIKE_L_MOTOR,
+        .capability_flags = smart_motor,
+    },
+    // Port D
+    {
+        .type_id = PBIO_IODEV_TYPE_ID_NONE,
+    },
+    // Port E
+    {
+        .type_id = PBIO_IODEV_TYPE_ID_SPIKE_S_MOTOR,
+        .capability_flags = smart_motor,
+    },
+    // Port F
+    {
+        .type_id = PBIO_IODEV_TYPE_ID_SPIKE_L_MOTOR,
+        .capability_flags = smart_motor,
+    },
+};
+
+const pbdrv_ioport_test_platform_data_t
+    pbdrv_ioport_test_platform_data[PBDRV_CONFIG_IOPORT_TEST_NUM_PORTS] = {
+    // Port A
+    {
+        .iodev = {
+            .info = &iodev_info[0],
+            .mode = PBIO_IODEV_MODE_PUP_ABS_MOTOR__CALIB,
+        },
+    },
+    // Port B
+    {
+        .iodev = {
+            .info = &iodev_info[1],
+            .mode = PBIO_IODEV_MODE_PUP_ABS_MOTOR__CALIB,
+        },
+    },
+    // Port C
+    {
+        .iodev = {
+            .info = &iodev_info[2],
+            .mode = PBIO_IODEV_MODE_PUP_ABS_MOTOR__CALIB,
+        },
+    },
+    // Port D
+    {
+        .iodev = {
+            .info = &iodev_info[3],
+        },
+    },
+    // Port E
+    {
+        .iodev = {
+            .info = &iodev_info[4],
+            .mode = PBIO_IODEV_MODE_PUP_ABS_MOTOR__CALIB,
+        },
+    },
+    // Port F
+    {
+        .iodev = {
+            .info = &iodev_info[5],
+            .mode = PBIO_IODEV_MODE_PUP_ABS_MOTOR__CALIB,
+        },
+    },
+};
+
+#define INFINITY (1e100)
+
+const pbdrv_motor_driver_virtual_simulation_platform_data_t
+    pbdrv_motor_driver_virtual_simulation_platform_data[PBDRV_CONFIG_MOTOR_DRIVER_NUM_DEV] = {
+    {
+        .port_id = PBIO_PORT_ID_A,
+        .initial_angle = 123456,
+        .initial_speed = 0,
+        .endstop_angle_negative = -INFINITY,
+        .endstop_angle_positive = INFINITY,
+    },
+    {
+        .port_id = PBIO_PORT_ID_B,
+        .initial_angle = 0,
+        .initial_speed = 0,
+        .endstop_angle_negative = -INFINITY,
+        .endstop_angle_positive = INFINITY,
+    },
+    {
+        .port_id = PBIO_PORT_ID_C,
+        .initial_angle = 0,
+        .initial_speed = 0,
+        .endstop_angle_negative = -142000,
+        .endstop_angle_positive = 142000,
+    },
+    {
+        .port_id = PBIO_PORT_ID_D,
+        .initial_angle = 0,
+        .initial_speed = 0,
+        .endstop_angle_negative = -INFINITY,
+        .endstop_angle_positive = INFINITY,
+    },
+    {
+        .port_id = PBIO_PORT_ID_E,
+        .initial_angle = 0,
+        .initial_speed = 0,
+        .endstop_angle_negative = -INFINITY,
+        .endstop_angle_positive = INFINITY,
+    },
+    {
+        .port_id = PBIO_PORT_ID_F,
+        .initial_angle = 45000,
+        .initial_speed = 0,
+        .endstop_angle_negative = -INFINITY,
+        .endstop_angle_positive = INFINITY,
+    },
+};

--- a/pybricks/hubs/pb_type_virtualhub.c
+++ b/pybricks/hubs/pb_type_virtualhub.c
@@ -35,7 +35,8 @@ STATIC mp_obj_t hubs_VirtualHub_make_new(const mp_obj_type_t *type, size_t n_arg
     self->base.type = (mp_obj_type_t *)type;
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
     self->buttons = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(virtualhub_buttons), virtualhub_buttons, pbio_button_is_pressed);
-    self->light = common_ColorLight_internal_obj_new(pbsys_status_light);
+    // FIXME: Implement lights.
+    // self->light = common_ColorLight_internal_obj_new(pbsys_status_light);
     self->system = MP_OBJ_FROM_PTR(&pb_type_System);
     return MP_OBJ_FROM_PTR(self);
 }
@@ -43,7 +44,7 @@ STATIC mp_obj_t hubs_VirtualHub_make_new(const mp_obj_type_t *type, size_t n_arg
 STATIC const pb_attr_dict_entry_t hubs_VirtualHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_VirtualHub_obj_t, battery),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_buttons, hubs_VirtualHub_obj_t, buttons),
-    PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, hubs_VirtualHub_obj_t, light),
+    // PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, hubs_VirtualHub_obj_t, light),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_system, hubs_VirtualHub_obj_t, system),
     PB_ATTR_DICT_SENTINEL
 };

--- a/test-virtualhub.sh
+++ b/test-virtualhub.sh
@@ -25,7 +25,7 @@ export PYTHONPATH="$PBIO_DIR/cpython"
 export PBIO_VIRTUAL_PLATFORM_MODULE=pbio_virtual.platform.robot
 
 cd "$MP_TEST_DIR"
-./run-tests.py --test-dirs $(find "$PB_TEST_DIR/virtualhub" -type d) "$@" || \
+./run-tests.py --test-dirs $(find "$PB_TEST_DIR/virtualhub" -type d -and ! -wholename "*/build/*"  -and ! -wholename "*/run_test.py") "$@" || \
     (code=$?; ./run-tests.py --print-failures; exit $code)
 
 if [[ $COVERAGE ]]; then

--- a/tests/virtualhub/motor/drivebase.py
+++ b/tests/virtualhub/motor/drivebase.py
@@ -1,0 +1,16 @@
+from pybricks.pupdevices import Motor
+from pybricks.tools import wait
+from pybricks.parameters import Port, Direction
+from pybricks.robotics import DriveBase
+
+# Initialize default "Driving Base" with medium motors and wheels.
+left_motor = Motor(Port.A, Direction.COUNTERCLOCKWISE)
+right_motor = Motor(Port.B)
+drive_base = DriveBase(left_motor, right_motor, wheel_diameter=56, axle_track=112)
+
+# Drive straight forward and back again.
+drive_base.straight(500)
+drive_base.straight(-500)
+
+wait(100)
+drive_base.stop()


### PR DESCRIPTION
This uses the test drivers instead of the CPython implementation. This is easier to debug and maintain, and it runs a lot faster.

No specialized configuration is needed to run it anymore. You can just run the virtualhub-micropython executable as if it is normal MicroPython. It just so happens to have a working `pybricks` package.

The robot setup is defined in `platform.c`. It currently uses 5 motors, but this can be changed later to simulate a few sensors. Lights and buttons are not done yet, which is a regression for now.

The goal is to get to a virtualhub that we'll use more often (as opposed to using DFU on a real Prime Hub all the time). The existing implementation is very extensible and potentially very powerful, but sometimes a bit cumbersome to work with (which could be me).

This is what the updated implementation can currently do (although I haven't pushed the *optional* React app that makes this visualization yet):

https://user-images.githubusercontent.com/12326241/221375380-f7f759c5-763b-45b2-a3ea-6d09629c1556.mp4

---------

Some next steps (not in this PR):
- Remove the CPython drivers from `lib/pbio`
- Clean up and publish the React app used in the video. Since this is aimed at just developers for now, I suppose we could include it here instead of making yet another repo (thoughts?).
- Implement lights, light matrix, buttons.
- Implement sensors and incorporate them into the 2D visualization, e.g. a motor that presses the force sensor, and a motor that spins colored bricks in front of the color sensor.
- Revise how the data piping works so we can include lights and handle on-click button events.