### PR TITLE
BLE Broadcast v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - Enabled the `gc` module (except on BOOST Move hub).
+- Added `hub.ble` attribute for accessing Bluetooth capabilities.
 
 ### Changed
 - Updated MicroPython to v1.20.0.

--- a/bricks/_common/sources.mk
+++ b/bricks/_common/sources.mk
@@ -22,6 +22,7 @@ CONTIKI_SRC_C = $(addprefix lib/contiki-core/,\
 # Pybricks modules
 
 PYBRICKS_PYBRICKS_SRC_C = $(addprefix pybricks/,\
+	common/pb_type_ble.c \
 	common/pb_type_battery.c \
 	common/pb_type_charger.c \
 	common/pb_type_colorlight_external.c \

--- a/bricks/cityhub/mpconfigport.h
+++ b/bricks/cityhub/mpconfigport.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2021 The Pybricks Authors
+// Copyright (c) 2018-2023 The Pybricks Authors
 
 #include "stm32f030xc.h"
 
@@ -12,6 +12,7 @@
 
 // Pybricks modules
 #define PYBRICKS_PY_COMMON                      (1)
+#define PYBRICKS_PY_COMMON_BLE                  (1)
 #define PYBRICKS_PY_COMMON_CHARGER              (0)
 #define PYBRICKS_PY_COMMON_CONTROL              (1)
 #define PYBRICKS_PY_COMMON_IMU                  (0)

--- a/bricks/debug/mpconfigport.h
+++ b/bricks/debug/mpconfigport.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2019-2021 The Pybricks Authors
+// Copyright (c) 2019-2023 The Pybricks Authors
 
 #include "stm32f446xx.h"
 
@@ -11,6 +11,7 @@
 
 // Pybricks modules
 #define PYBRICKS_PY_COMMON                      (1)
+#define PYBRICKS_PY_COMMON_BLE                  (0)
 #define PYBRICKS_PY_COMMON_CHARGER              (0)
 #define PYBRICKS_PY_COMMON_CONTROL              (0)
 #define PYBRICKS_PY_COMMON_IMU                  (0)

--- a/bricks/essentialhub/mpconfigport.h
+++ b/bricks/essentialhub/mpconfigport.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2019-2021 The Pybricks Authors
+// Copyright (c) 2019-2023 The Pybricks Authors
 
 #include "stm32f413xx.h"
 
@@ -13,6 +13,7 @@
 
 // Pybricks modules
 #define PYBRICKS_PY_COMMON                      (1)
+#define PYBRICKS_PY_COMMON_BLE                  (1)
 #define PYBRICKS_PY_COMMON_CHARGER              (1)
 #define PYBRICKS_PY_COMMON_CONTROL              (1)
 #define PYBRICKS_PY_COMMON_IMU                  (1)

--- a/bricks/ev3dev/brickconfig.h
+++ b/bricks/ev3dev/brickconfig.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2021 The Pybricks Authors
+// Copyright (c) 2018-2023 The Pybricks Authors
 
 #include <pbdrv/config.h>
 #include "pbinit.h"
@@ -16,6 +16,7 @@
 
 // Pybricks modules
 #define PYBRICKS_PY_COMMON              (1)
+#define PYBRICKS_PY_COMMON_BLE          (0)
 #define PYBRICKS_PY_COMMON_CHARGER      (0)
 #define PYBRICKS_PY_COMMON_CONTROL      (1)
 #define PYBRICKS_PY_COMMON_IMU          (0)

--- a/bricks/ev3rt/mpconfigport.h
+++ b/bricks/ev3rt/mpconfigport.h
@@ -16,6 +16,7 @@
 
 // Pybricks modules
 #define PYBRICKS_PY_COMMON              (1)
+#define PYBRICKS_PY_COMMON_BLE          (0)
 #define PYBRICKS_PY_COMMON_CHARGER      (0)
 #define PYBRICKS_PY_COMMON_CONTROL      (0)
 #define PYBRICKS_PY_COMMON_IMU          (0)

--- a/bricks/movehub/mpconfigport.h
+++ b/bricks/movehub/mpconfigport.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2021 The Pybricks Authors
+// Copyright (c) 2018-2023 The Pybricks Authors
 
 #include "stm32f070xb.h"
 
@@ -12,6 +12,7 @@
 
 // Pybricks modules
 #define PYBRICKS_PY_COMMON                      (1)
+#define PYBRICKS_PY_COMMON_BLE                  (1)
 #define PYBRICKS_PY_COMMON_CHARGER              (0)
 #define PYBRICKS_PY_COMMON_CONTROL              (0)
 #define PYBRICKS_PY_COMMON_IMU                  (0)

--- a/bricks/nxt/mpconfigport.h
+++ b/bricks/nxt/mpconfigport.h
@@ -14,6 +14,7 @@
 
 // Pybricks modules
 #define PYBRICKS_PY_COMMON                      (1)
+#define PYBRICKS_PY_COMMON_BLE                  (0)
 #define PYBRICKS_PY_COMMON_CHARGER              (0)
 #define PYBRICKS_PY_COMMON_CONTROL              (1)
 #define PYBRICKS_PY_COMMON_IMU                  (0)

--- a/bricks/primehub/mpconfigport.h
+++ b/bricks/primehub/mpconfigport.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2019-2021 The Pybricks Authors
+// Copyright (c) 2019-2023 The Pybricks Authors
 
 #include "stm32f413xx.h"
 
@@ -14,6 +14,7 @@
 
 // Pybricks modules
 #define PYBRICKS_PY_COMMON                      (1)
+#define PYBRICKS_PY_COMMON_BLE                  (1)
 #define PYBRICKS_PY_COMMON_CHARGER              (1)
 #define PYBRICKS_PY_COMMON_CONTROL              (1)
 #define PYBRICKS_PY_COMMON_IMU                  (1)

--- a/bricks/technichub/mpconfigport.h
+++ b/bricks/technichub/mpconfigport.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2021 The Pybricks Authors
+// Copyright (c) 2018-2023 The Pybricks Authors
 
 #include "stm32l431xx.h"
 
@@ -12,6 +12,7 @@
 
 // Pybricks modules
 #define PYBRICKS_PY_COMMON                      (1)
+#define PYBRICKS_PY_COMMON_BLE                  (1)
 #define PYBRICKS_PY_COMMON_CHARGER              (0)
 #define PYBRICKS_PY_COMMON_CONTROL              (1)
 #define PYBRICKS_PY_COMMON_IMU                  (1)

--- a/bricks/virtualhub/mpconfigvariant.h
+++ b/bricks/virtualhub/mpconfigvariant.h
@@ -8,6 +8,7 @@
 
 // Pybricks modules
 #define PYBRICKS_PY_COMMON              (1)
+#define PYBRICKS_PY_COMMON_BLE          (0)
 #define PYBRICKS_PY_COMMON_CHARGER      (1)
 #define PYBRICKS_PY_COMMON_CONTROL      (1)
 #define PYBRICKS_PY_COMMON_IMU          (0)

--- a/lib/BlueNRG-MS/hci/hci_le.c
+++ b/lib/BlueNRG-MS/hci/hci_le.c
@@ -75,27 +75,27 @@ int hci_disconnect(uint16_t handle, uint8_t reason)
   return status;
 }
 
-int hci_le_read_local_version(uint8_t *hci_version, uint16_t *hci_revision, uint8_t *lmp_pal_version,
-                              uint16_t *manufacturer_name, uint16_t *lmp_pal_subversion)
+void hci_le_read_local_version_begin(void)
 {
-  struct hci_request_and_response rq;
-  read_local_version_rp resp;
+  struct hci_request rq;
 
-  memset(&resp, 0, sizeof(resp));
-
-  memset(&rq, 0, sizeof(rq));
   rq.opcode = cmd_opcode_pack(OGF_INFO_PARAM, OCF_READ_LOCAL_VERSION);
   rq.cparam = NULL;
   rq.clen = 0;
+
+  hci_send_req(&rq);
+}
+
+int hci_le_read_local_version_end(uint8_t *hci_version, uint16_t *hci_revision, uint8_t *lmp_pal_version,
+                              uint16_t *manufacturer_name, uint16_t *lmp_pal_subversion)
+{
+  struct hci_response rq;
+  read_local_version_rp resp;
+
   rq.rparam = &resp;
   rq.rlen = READ_LOCAL_VERSION_RP_SIZE;
 
-  hci_send_req_recv_rsp(&rq);
-
-  if (resp.status) {
-    return resp.status;
-  }
-
+  hci_recv_resp(&rq);
 
   *hci_version = resp.hci_version;
   *hci_revision =  btohs(resp.hci_revision);
@@ -103,7 +103,7 @@ int hci_le_read_local_version(uint8_t *hci_version, uint16_t *hci_revision, uint
   *manufacturer_name = btohs(resp.manufacturer_name);
   *lmp_pal_subversion = btohs(resp.lmp_pal_subversion);
 
-  return 0;
+  return resp.status;
 }
 
 int hci_le_read_buffer_size(uint16_t *pkt_len, uint8_t *max_pkt)

--- a/lib/BlueNRG-MS/includes/hci_le.h
+++ b/lib/BlueNRG-MS/includes/hci_le.h
@@ -184,7 +184,8 @@ int hci_le_transmitter_test(uint8_t frequency, uint8_t length, uint8_t payload);
 
 int hci_le_test_end(uint16_t *num_pkts);
 
-int hci_le_read_local_version(uint8_t *hci_version, uint16_t *hci_revision, uint8_t *lmp_pal_version,
+void hci_le_read_local_version_begin(void);
+int hci_le_read_local_version_end(uint8_t *hci_version, uint16_t *hci_revision, uint8_t *lmp_pal_version,
 			      uint16_t *manufacturer_name, uint16_t *lmp_pal_subversion);
 
 /**

--- a/lib/pbio/drv/bluetooth/bluetooth_btstack.c
+++ b/lib/pbio/drv/bluetooth/bluetooth_btstack.c
@@ -514,6 +514,12 @@ const char *pbdrv_bluetooth_get_hub_name(void) {
     return pbdrv_bluetooth_hub_name;
 }
 
+const char *pbdrv_bluetooth_get_fw_version(void) {
+    // REVISIT: this should be linked to the init script as it can be updated in software
+    // init script version
+    return "v1.4";
+}
+
 static void init_advertising_data(void) {
     bd_addr_t null_addr = { };
     gap_advertisements_set_params(0x0030, 0x0030, 0x00, 0x00, null_addr, 0x07, 0x00);

--- a/lib/pbio/drv/bluetooth/bluetooth_stm32_bluenrg.c
+++ b/lib/pbio/drv/bluetooth/bluetooth_stm32_bluenrg.c
@@ -416,6 +416,12 @@ static PT_THREAD(scan_and_connect_task(struct pt *pt, pbio_task_t *task)) {
 
     PT_BEGIN(pt);
 
+    // observing while connected to another device is not going to work
+    if (is_observing) {
+        task->status = PBIO_ERROR_INVALID_OP;
+        PT_EXIT(pt);
+    }
+
     // start scanning
     PT_WAIT_WHILE(pt, write_xfer_size);
     aci_gap_start_general_conn_establish_proc_begin(ACTIVE_SCAN, 0x0030, 0x0030, STATIC_RANDOM_ADDR, 0);

--- a/lib/pbio/include/pbdrv/bluetooth.h
+++ b/lib/pbio/include/pbdrv/bluetooth.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2021 The Pybricks Authors
+// Copyright (c) 2018-2023 The Pybricks Authors
 
 /**
  * @addtogroup BluetoothDriver Driver: Bluetooth
@@ -119,6 +119,16 @@ bool pbdrv_bluetooth_is_ready(void);
 const char *pbdrv_bluetooth_get_hub_name(void);
 
 /**
+ * Gets the Bluetooth chip firmware version.
+ *
+ * This should not be called until after the Bluetooth chip is powered on and
+ * initalized.
+ *
+ * @returns A string describing the version or an empty string if not supported.
+ */
+const char *pbdrv_bluetooth_get_fw_version(void);
+
+/**
  * Starts the advertising process, including configuring advertisements and
  * telling the Bluetooth chip to start advertising. Advertising should
  * automatically stop when a connection is made.
@@ -201,6 +211,10 @@ static inline bool pbdrv_bluetooth_is_ready(void) {
 
 static inline const char *pbdrv_bluetooth_get_hub_name(void) {
     return "Pybricks Hub";
+}
+
+static inline const char *pbdrv_bluetooth_get_fw_version(void) {
+    return "";
 }
 
 static inline void pbdrv_bluetooth_start_advertising(void) {

--- a/pybricks/common.h
+++ b/pybricks/common.h
@@ -25,7 +25,8 @@ void pb_package_pybricks_init(bool import_all);
 void pb_package_pybricks_deinit(void);
 
 #if PYBRICKS_PY_COMMON_BLE
-extern const mp_obj_module_t pb_module_ble;
+mp_obj_t pb_type_BLE_new(mp_obj_t broadcast_channel_in, mp_obj_t observe_channels_in);
+void pb_type_BLE_cleanup(void);
 #endif
 
 #if PYBRICKS_PY_COMMON_CHARGER

--- a/pybricks/common.h
+++ b/pybricks/common.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2021 The Pybricks Authors
+// Copyright (c) 2018-2023 The Pybricks Authors
 
 #ifndef PYBRICKS_INCLUDED_PYBRICKS_COMMON_H
 #define PYBRICKS_INCLUDED_PYBRICKS_COMMON_H
@@ -23,6 +23,10 @@
 
 void pb_package_pybricks_init(bool import_all);
 void pb_package_pybricks_deinit(void);
+
+#if PYBRICKS_PY_COMMON_BLE
+extern const mp_obj_module_t pb_module_ble;
+#endif
 
 #if PYBRICKS_PY_COMMON_CHARGER
 

--- a/pybricks/common/pb_type_ble.c
+++ b/pybricks/common/pb_type_ble.c
@@ -1,0 +1,33 @@
+
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2023 The Pybricks Authors
+
+#include "py/mpconfig.h"
+
+#if PYBRICKS_PY_COMMON_BLE
+
+#include <string.h>
+
+#include <pbdrv/bluetooth.h>
+
+#include "py/obj.h"
+#include "py/misc.h"
+#include "py/runtime.h"
+
+STATIC mp_obj_t pb_module_ble_version(void) {
+    const char *version = pbdrv_bluetooth_get_fw_version();
+    return mp_obj_new_str(version, strlen(version));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(pb_module_ble_version_obj, pb_module_ble_version);
+
+STATIC const mp_rom_map_elem_t common_Ble_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_version), MP_ROM_PTR(&pb_module_ble_version_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(common_Ble_locals_dict, common_Ble_locals_dict_table);
+
+const mp_obj_module_t pb_module_ble = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&common_Ble_locals_dict,
+};
+
+#endif // PYBRICKS_PY_COMMON_BLE

--- a/pybricks/common/pb_type_ble.c
+++ b/pybricks/common/pb_type_ble.c
@@ -389,13 +389,20 @@ STATIC observed_data_t *pb_module_ble_get_channel_data(mp_obj_t channel_in) {
  *
  * @param [in]  self_in     The BLE object.
  * @param [in]  channel_in  Python object containing the channel number.
- * @returns                 Python object containing a tuple of decoded data.
+ * @returns                 Python object containing a tuple of decoded data or
+ *                          None if no data has been received within
+ *                          ::OBSERVED_DATA_TIMEOUT_MS.
  * @throws ValueError       If the channel is out of range.
  * @throws RuntimeError     If the last received data was invalid.
  */
 STATIC mp_obj_t pb_module_ble_observe(mp_obj_t self_in, mp_obj_t channel_in) {
 
     observed_data_t *ch_data = pb_module_ble_get_channel_data(channel_in);
+
+    // Have not received data yet or timed out.
+    if (ch_data->rssi == INT8_MIN) {
+        return mp_const_none;
+    }
 
     // Objects can be encoded in as little as one byte so we could have up to
     // this many objects received.

--- a/pybricks/common/pb_type_ble.c
+++ b/pybricks/common/pb_type_ble.c
@@ -6,6 +6,7 @@
 
 #if PYBRICKS_PY_COMMON_BLE
 
+#include <assert.h>
 #include <string.h>
 
 #include <pbdrv/bluetooth.h>
@@ -14,20 +15,457 @@
 #include "py/misc.h"
 #include "py/runtime.h"
 
-STATIC mp_obj_t pb_module_ble_version(void) {
+#include <pybricks/common.h>
+#include <pybricks/util_pb/pb_error.h>
+#include <pybricks/util_pb/pb_task.h>
+
+// The code currently passes integers and floats directly as bytes so requires
+// little-endian to get the correct ordering over the air.
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+#error "this module requires little endian processor"
+#endif
+
+#define OBSERVED_DATA_MAX_SIZE (31 /* max adv data size */ - 5 /* overhead */)
+
+typedef struct {
+    uint8_t channel;
+    int8_t rssi;
+    uint8_t size;
+    uint8_t data[OBSERVED_DATA_MAX_SIZE];
+} observed_data_t;
+
+// pointer to dynamically allocated memory - needed for driver callback
+static observed_data_t *observed_data;
+static uint8_t num_observed_data;
+
+typedef struct {
+    mp_obj_base_t base;
+    uint8_t broadcast_channel;
+    observed_data_t observed_data[];
+} pb_obj_BLE_t;
+
+/**
+ * Type codes used for encoding/decoding data.
+ */
+typedef enum {
+    // NB: These values are sent over the air so the numeric values must not be changed.
+    // There can be at most 8 types since the values have to fit in 3 bits.
+
+    /** The Python @c None value. */
+    PB_BLE_BROADCAST_DATA_TYPE_NONE = 0,
+    /** The Python @c True value. */
+    PB_BLE_BROADCAST_DATA_TYPE_TRUE = 1,
+    /** The Python @c False value. */
+    PB_BLE_BROADCAST_DATA_TYPE_FALSE = 2,
+    /** The Python @c int type. */
+    PB_BLE_BROADCAST_DATA_TYPE_INT = 3,
+    /** The Python @c float type. */
+    PB_BLE_BROADCAST_DATA_TYPE_FLOAT = 4,
+    /** The Python @c str type. */
+    PB_BLE_BROADCAST_DATA_TYPE_STR = 5,
+    /** The Python @c bytes type. */
+    PB_BLE_BROADCAST_DATA_TYPE_BYTES = 6,
+} pb_ble_broadcast_data_type_t;
+
+#define MFG_SPECIFIC 0xFF
+#define LEGO_CID 0x0397
+
+/**
+ * Looks up a channel in the observed data table.
+ *
+ * @param [in]  channel     The channel number (1 to 255).
+ * @returns                 A pointer to the channel or @c NULL if the channel
+ *                          is not allocated in the table.
+ */
+STATIC observed_data_t *lookup_observed_data(uint8_t channel) {
+    for (size_t i = 0; i < num_observed_data; i++) {
+        observed_data_t *data = &observed_data[i];
+
+        if (data->channel == channel) {
+            return data;
+        }
+    }
+
+    return NULL;
+}
+
+/**
+ * Handles observe event from the bluetooth driver.
+ *
+ * The advertising data is parsed and if it matches the required format, it is
+ * saved in the observed_data table for later use.
+ *
+ * @param [in]  event_type      The BLE advertisement event type.
+ * @param [in]  data            The raw advertising data.
+ * @param [in]  length          The length of @p data in bytes.
+ * @param [in]  rssi            The RSSI of the event in dBm.
+ */
+STATIC void handle_observe_event(pbdrv_bluetooth_ad_type_t event_type, const uint8_t *data, uint8_t length, int8_t rssi) {
+    if (event_type == PBDRV_BLUETOOTH_AD_TYPE_ADV_NONCONN_IND && length >= 5 && data[1] == MFG_SPECIFIC && pbio_get_uint16_le(&data[2]) == LEGO_CID) {
+        uint8_t channel = data[4];
+
+        observed_data_t *ch_data = lookup_observed_data(channel);
+
+        // ignore not allocated channels
+        if (!ch_data) {
+            return;
+        }
+
+        ch_data->rssi = rssi;
+        ch_data->size = data[0] - 4;
+        memcpy(ch_data->data, &data[5], OBSERVED_DATA_MAX_SIZE);
+    }
+}
+
+/**
+ * Appends the value of a Python object to the advertising data.
+ *
+ * @param [in]  dst     Pointer to the start of the manufacturer-specific advertising data.
+ * @param [in]  index   The index in @p dst where the value should be written.
+ * @param [in]  src     The value to write.
+ * @param [in]  size    The size of @p src in bytes.
+ * @param [in]  type    The data type of @p src.
+ * @returns             The next free index in @p dst after adding the new data.
+ * @throws ValueError   If data exceeds available space remaining in @p dst.
+ */
+STATIC size_t pb_module_ble_append(uint8_t *dst, size_t index, const void *src, size_t size, pb_ble_broadcast_data_type_t type) {
+    size_t next_index = index + size + 1;
+
+    if (next_index > OBSERVED_DATA_MAX_SIZE) {
+        mp_raise_ValueError(MP_ERROR_TEXT("payload limited to 26 bytes"));
+    }
+
+    dst[index] = type << 5 | size;
+    memcpy(&dst[index + 1], src, size);
+
+    return next_index;
+}
+
+/**
+ * Encodes a Python object using the Pybricks Broadcast encoding scheme and
+ * appends it to the advertising data.
+ *
+ * @p arg must be @c None, @c True, @c False, an @c int, a @c float, a @c str
+ * or bytes-like (supports buffer protocol).
+ *
+ * @param [in]  dst     Pointer to the start of the manufacturer-specific advertising data.
+ * @param [in]  index   The index in @p dst where the value should be written.
+ * @param [in]  arg     The Python object to be encoded.
+ * @returns             The next free index in @p dst after adding the new data.
+ * @throws ValueError   If data exceeds available space remaining in @p dst.
+ * @throws TypeError    If @p arg is not one of the supported types.
+ */
+STATIC size_t pb_module_ble_encode(void *dst, size_t index, mp_obj_t arg) {
+    if (arg == mp_const_none) {
+        return pb_module_ble_append(dst, index, NULL, 0, PB_BLE_BROADCAST_DATA_TYPE_NONE);
+    }
+
+    if (arg == mp_const_true) {
+        return pb_module_ble_append(dst, index, NULL, 0, PB_BLE_BROADCAST_DATA_TYPE_TRUE);
+    }
+
+    if (arg == mp_const_false) {
+        return pb_module_ble_append(dst, index, NULL, 0, PB_BLE_BROADCAST_DATA_TYPE_FALSE);
+    }
+
+    mp_int_t int_value;
+    if (mp_obj_get_int_maybe(arg, &int_value)) {
+        if (int_value >= INT8_MIN && int_value <= INT8_MAX) {
+            int8_t int8_value = int_value;
+            return pb_module_ble_append(dst, index, &int8_value, sizeof(int8_value), PB_BLE_BROADCAST_DATA_TYPE_INT);
+        }
+
+        if (int_value >= INT16_MIN && int_value <= INT16_MAX) {
+            int16_t int16_value = int_value;
+            return pb_module_ble_append(dst, index, &int16_value, sizeof(int16_value), PB_BLE_BROADCAST_DATA_TYPE_INT);
+        }
+
+        #if __SIZEOF_POINTER__ == 4
+        return pb_module_ble_append(dst, index, &int_value, sizeof(int_value), PB_BLE_BROADCAST_DATA_TYPE_INT);
+        #else
+        if (int_value >= INT32_MIN && int_value <= INT32_MAX) {
+            int32_t int32_value = int_value;
+            return pb_module_ble_append(dst, index, &int32_value, sizeof(int32_value), PB_BLE_BROADCAST_DATA_TYPE_INT);
+        }
+
+        mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("integers are limited to 32 bits"));
+        #endif
+    }
+
+    #if MICROPY_FLOAT_IMPL != MICROPY_FLOAT_IMPL_NONE
+    mp_float_t float_value;
+    if (mp_obj_get_float_maybe(arg, &float_value)) {
+        #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
+        float single_value = float_value;
+        return pb_module_ble_append(dst, index, &single_value, sizeof(single_value), PB_BLE_BROADCAST_DATA_TYPE_FLOAT);
+        #elif MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
+        return pb_module_ble_append(dst, index, &float_value, sizeof(float_value), PB_BLE_BROADCAST_DATA_TYPE_FLOAT);
+        #else
+        #error "unsupported MICROPY_FLOAT_IMPL"
+        #endif
+    }
+    #endif
+
+    mp_buffer_info_t info;
+    if (mp_get_buffer(arg, &info, MP_BUFFER_READ)) {
+        // REVISIT: possible upstream contribution - add str type to info.typecode
+        bool is_str = mp_obj_is_str(arg);
+        return pb_module_ble_append(dst, index, info.buf, info.len, is_str ? PB_BLE_BROADCAST_DATA_TYPE_STR : PB_BLE_BROADCAST_DATA_TYPE_BYTES);
+    }
+
+    mp_raise_TypeError(MP_ERROR_TEXT("must be None, True, False, int, float, str or bytes"));
+
+    MP_UNREACHABLE
+}
+
+/**
+ * Sets the broadcast advertising data and enables broadcasting on the Bluetooth
+ * radio if it is not already enabled.
+ *
+ * The first argument is the "channel" and the remaining arguments are encoded
+ * in the advertising data.
+ *
+ * @param [in]  n_args  The number of args.
+ * @param [in]  args    The args passed in Python code.
+ * @throws ValueError   If the channel is out of range or the encoded arguments
+ *                      exceeded the available space.
+ * @throws TypeError    If any of the arguments are of a type that can't be encoded.
+ */
+STATIC mp_obj_t pb_module_ble_broadcast(size_t n_args, const mp_obj_t *args) {
+    // REVISIT: disable this method on move hub and city hub?
+    // This method will raise an OSError on move hub if it is called while the
+    // move hub is connected to Pybricks Code. Also, broadcasting interferes
+    // with observing even when not connected to Pybricks Code. On the city
+    // hub, this method succeeds, but nothing is actually sent over the air.
+
+    pb_obj_BLE_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    struct {
+        pbdrv_bluetooth_value_t v;
+        uint8_t d[5 + OBSERVED_DATA_MAX_SIZE];
+    } value;
+
+    size_t index = 0;
+    for (size_t i = 1; i < n_args; i++) {
+        index = pb_module_ble_encode(&value.v.data[5], index, args[i]);
+    }
+
+    value.v.size = index + 5;
+    value.v.data[0] = index + 4; // length
+    value.v.data[1] = MFG_SPECIFIC;
+    pbio_set_uint16_le(&value.v.data[2], LEGO_CID);
+    value.v.data[4] = self->broadcast_channel;
+
+    pbio_task_t task;
+    pbdrv_bluetooth_start_broadcasting(&task, &value.v);
+
+    pb_wait_task(&task, -1);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(pb_module_ble_broadcast_obj, 1, pb_module_ble_broadcast);
+
+/**
+ * Decodes data that was received by the Bluetooth radio.
+ *
+ * @param [in]      data    Pointer to the start of the advertising data.
+ * @param [in,out]  index   When calling, set to the index in @p data to read.
+ *                          On return, the value is updated to the next index.
+ * @returns                 The decoded value as a Python object.
+ * @throws RuntimeError     If the data was invalid and could not be decoded.
+ */
+STATIC mp_obj_t pb_module_ble_decode(observed_data_t *data, size_t *index) {
+    uint8_t size = data->data[*index] & 0x1F;
+    pb_ble_broadcast_data_type_t data_type = data->data[*index] >> 5;
+
+    (*index)++;
+
+    switch (data_type) {
+        case PB_BLE_BROADCAST_DATA_TYPE_NONE:
+            assert(size == 0);
+            return mp_const_none;
+        case PB_BLE_BROADCAST_DATA_TYPE_TRUE:
+            assert(size == 0);
+            return mp_const_true;
+        case PB_BLE_BROADCAST_DATA_TYPE_FALSE:
+            assert(size == 0);
+            return mp_const_false;
+        case PB_BLE_BROADCAST_DATA_TYPE_INT:
+            if (size == sizeof(int8_t)) {
+                int8_t int8_value = data->data[*index];
+                (*index) += sizeof(int8_value);
+                return MP_OBJ_NEW_SMALL_INT(int8_value);
+            }
+
+            if (size == sizeof(int16_t)) {
+                int16_t int16_value = pbio_get_uint16_le(&data->data[*index]);
+                (*index) += sizeof(int16_value);
+                return MP_OBJ_NEW_SMALL_INT(int16_value);
+            }
+
+            if (size == sizeof(int32_t)) {
+                int32_t int32_value = pbio_get_uint32_le(&data->data[*index]);
+                (*index) += sizeof(int32_value);
+                return mp_obj_new_int(int32_value);
+            }
+
+            break;
+
+        case PB_BLE_BROADCAST_DATA_TYPE_FLOAT:
+            #if MICROPY_FLOAT_IMPL != MICROPY_FLOAT_IMPL_NONE
+        {
+            union {
+                float f;
+                uint32_t u;
+            } float_value;
+            float_value.u = pbio_get_uint32_le(&data->data[*index]);
+            (*index) += sizeof(float_value);
+            return mp_obj_new_float_from_f(float_value.f);
+        }
+            #else
+            break;
+            #endif
+
+        case PB_BLE_BROADCAST_DATA_TYPE_STR: {
+            const char *str_data = (void *)&data->data[*index];
+            (*index) += size;
+            return mp_obj_new_str(str_data, size);
+        }
+
+        case PB_BLE_BROADCAST_DATA_TYPE_BYTES: {
+            const byte *bytes_data = (void *)&data->data[*index];
+            (*index) += size;
+            return mp_obj_new_bytes(bytes_data, size);
+        }
+    }
+
+    mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("received bad data"));
+}
+
+/**
+ * Retrieves the last received advertising data and enables observing in the
+ * Bluetooth radio if it is not already enabled.
+ *
+ * @param [in]  self_in     The BLE object.
+ * @param [in]  channel_in  Python object containing the channel number.
+ * @returns                 Python object containing a tuple of the RSSI and
+ *                          the decoded data.
+ * @throws ValueError       If the channel is out of range.
+ * @throws RuntimeError     If the last received data was invalid.
+ */
+STATIC mp_obj_t pb_module_ble_observe(mp_obj_t self_in, mp_obj_t channel_in) {
+    mp_int_t channel = mp_obj_get_int(channel_in);
+
+    observed_data_t *ch_data = lookup_observed_data(channel);
+
+    if (!ch_data) {
+        mp_raise_ValueError(MP_ERROR_TEXT("channel not allocated"));
+    }
+
+    pbio_task_t task;
+    pbdrv_bluetooth_start_observing(&task, handle_observe_event);
+    pb_wait_task(&task, -1);
+
+    // Objects can be encoded in as little as one byte so we could have up to
+    // this many objects received.
+    mp_obj_t items[OBSERVED_DATA_MAX_SIZE];
+
+    size_t index = 0;
+    size_t i;
+    for (i = 0; i < OBSERVED_DATA_MAX_SIZE; i++) {
+        if (index >= ch_data->size) {
+            break;
+        }
+
+        items[i] = pb_module_ble_decode(ch_data, &index);
+    }
+
+    mp_obj_t result[2];
+    result[0] = MP_OBJ_NEW_SMALL_INT(ch_data->rssi); // RSSI
+    result[1] = mp_obj_new_tuple(i, items); // data
+
+    return mp_obj_new_tuple(MP_ARRAY_SIZE(result), result);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(pb_module_ble_observe_obj, pb_module_ble_observe);
+
+/**
+ * Gets the Bluetooth chip frimware version.
+ * @param [in]  self_in     The BLE MicroPython object instance.
+ * @returns                 MicroPython object containing the firmware version
+ *                          as a str.
+ */
+STATIC mp_obj_t pb_module_ble_version(mp_obj_t self_in) {
     const char *version = pbdrv_bluetooth_get_fw_version();
     return mp_obj_new_str(version, strlen(version));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(pb_module_ble_version_obj, pb_module_ble_version);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_module_ble_version_obj, pb_module_ble_version);
 
-STATIC const mp_rom_map_elem_t common_Ble_locals_dict_table[] = {
+STATIC const mp_rom_map_elem_t common_BLE_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_broadcast), MP_ROM_PTR(&pb_module_ble_broadcast_obj) },
+    { MP_ROM_QSTR(MP_QSTR_observe), MP_ROM_PTR(&pb_module_ble_observe_obj) },
     { MP_ROM_QSTR(MP_QSTR_version), MP_ROM_PTR(&pb_module_ble_version_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(common_Ble_locals_dict, common_Ble_locals_dict_table);
+STATIC MP_DEFINE_CONST_DICT(common_BLE_locals_dict, common_BLE_locals_dict_table);
 
-const mp_obj_module_t pb_module_ble = {
-    .base = { &mp_type_module },
-    .globals = (mp_obj_dict_t *)&common_Ble_locals_dict,
-};
+STATIC MP_DEFINE_CONST_OBJ_TYPE(pb_type_BLE,
+    MP_QSTR_BLE,
+    MP_TYPE_FLAG_NONE,
+    locals_dict, &common_BLE_locals_dict);
+
+/**
+ * Creates a new instance of the BLE class.
+ *
+ * Do not call this function more than once unless pb_type_BLE_cleanup() is called first.
+ *
+ * @param [in]  broadcast_channel_in    (int) The channel number to use for broadcasting.
+ * @param [in]  observe_channels_in     (list[int]) A list of channels numbers to observe.
+ * @returns                             A newly allocated object.
+ * @throws ValueError                   If either parameter contains an out of range channel number.
+ */
+mp_obj_t pb_type_BLE_new(mp_obj_t broadcast_channel_in, mp_obj_t observe_channels_in) {
+    // making the assumption that this is only called once before each pb_type_BLE_cleanup()
+    assert(observed_data == NULL);
+
+    mp_int_t broadcast_channel = mp_obj_get_int(broadcast_channel_in);
+
+    if (broadcast_channel < 0 || broadcast_channel > UINT8_MAX) {
+        mp_raise_ValueError(MP_ERROR_TEXT("broadcast channel must be 0 to 255"));
+    }
+
+    mp_int_t num_channels = mp_obj_get_int(mp_obj_len(observe_channels_in));
+
+    if (num_channels < 0 || num_channels > UINT8_MAX) {
+        mp_raise_ValueError(MP_ERROR_TEXT("len observe channels must be 0 to 255"));
+    }
+
+    pb_obj_BLE_t *self = mp_obj_malloc_var(pb_obj_BLE_t, observed_data_t, num_channels, &pb_type_BLE);
+    self->broadcast_channel = broadcast_channel;
+
+    for (mp_int_t i = 0; i < num_channels; i++) {
+        mp_int_t channel = mp_obj_get_int(mp_obj_subscr(
+            observe_channels_in, MP_OBJ_NEW_SMALL_INT(i), MP_OBJ_SENTINEL));
+
+        if (channel < 0 || channel > UINT8_MAX) {
+            mp_raise_ValueError(MP_ERROR_TEXT("observe channel must be 0 to 255"));
+        }
+
+        self->observed_data[i].channel = channel;
+        self->observed_data[i].rssi = INT8_MIN;
+    }
+
+    // globals for driver callback
+    observed_data = self->observed_data;
+    num_observed_data = num_channels;
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+void pb_type_BLE_cleanup(void) {
+    pbdrv_bluetooth_stop_broadcasting();
+    pbdrv_bluetooth_stop_observing();
+    observed_data = NULL;
+    num_observed_data = 0;
+    // TODO: wait for stop?
+}
 
 #endif // PYBRICKS_PY_COMMON_BLE

--- a/pybricks/hubs/pb_type_cityhub.c
+++ b/pybricks/hubs/pb_type_cityhub.c
@@ -11,6 +11,7 @@
 #include <pybricks/common.h>
 #include <pybricks/hubs.h>
 
+#include <pybricks/util_mp/pb_kwarg_helper.h>
 #include <pybricks/util_mp/pb_obj_helper.h>
 
 typedef struct _hubs_CityHub_obj_t {
@@ -29,10 +30,16 @@ static const pb_obj_enum_member_t *cityhub_buttons[] = {
 };
 
 STATIC mp_obj_t hubs_CityHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    #if PYBRICKS_PY_COMMON_BLE
+    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
+        PB_ARG_DEFAULT_INT(broadcast_channel, 0),
+        PB_ARG_DEFAULT_OBJ(observe_channels, mp_const_empty_tuple_obj));
+    #endif
+
     hubs_CityHub_obj_t *self = mp_obj_malloc(hubs_CityHub_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
     #if PYBRICKS_PY_COMMON_BLE
-    self->ble = MP_OBJ_FROM_PTR(&pb_module_ble);
+    self->ble = pb_type_BLE_new(broadcast_channel_in, observe_channels_in);
     #endif
     self->button = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(cityhub_buttons), cityhub_buttons, pbio_button_is_pressed);
     self->light = common_ColorLight_internal_obj_new(pbsys_status_light);

--- a/pybricks/hubs/pb_type_cityhub.c
+++ b/pybricks/hubs/pb_type_cityhub.c
@@ -16,6 +16,9 @@
 typedef struct _hubs_CityHub_obj_t {
     mp_obj_base_t base;
     mp_obj_t battery;
+    #if PYBRICKS_PY_COMMON_BLE
+    mp_obj_t ble;
+    #endif
     mp_obj_t button;
     mp_obj_t light;
     mp_obj_t system;
@@ -28,6 +31,9 @@ static const pb_obj_enum_member_t *cityhub_buttons[] = {
 STATIC mp_obj_t hubs_CityHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     hubs_CityHub_obj_t *self = mp_obj_malloc(hubs_CityHub_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
+    #if PYBRICKS_PY_COMMON_BLE
+    self->ble = MP_OBJ_FROM_PTR(&pb_module_ble);
+    #endif
     self->button = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(cityhub_buttons), cityhub_buttons, pbio_button_is_pressed);
     self->light = common_ColorLight_internal_obj_new(pbsys_status_light);
     self->system = MP_OBJ_FROM_PTR(&pb_type_System);
@@ -36,6 +42,9 @@ STATIC mp_obj_t hubs_CityHub_make_new(const mp_obj_type_t *type, size_t n_args, 
 
 STATIC const pb_attr_dict_entry_t hubs_CityHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_CityHub_obj_t, battery),
+    #if PYBRICKS_PY_COMMON_BLE
+    PB_DEFINE_CONST_ATTR_RO(MP_QSTR_ble, hubs_CityHub_obj_t, ble),
+    #endif
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_button, hubs_CityHub_obj_t, button),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, hubs_CityHub_obj_t, light),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_system, hubs_CityHub_obj_t, system),

--- a/pybricks/hubs/pb_type_essentialhub.c
+++ b/pybricks/hubs/pb_type_essentialhub.c
@@ -44,12 +44,17 @@ static const pb_obj_enum_member_t *essentialhub_buttons[] = {
 STATIC mp_obj_t hubs_EssentialHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_DEFAULT_OBJ(top_side, pb_type_Axis_Z_obj),
-        PB_ARG_DEFAULT_OBJ(front_side, pb_type_Axis_X_obj));
+        PB_ARG_DEFAULT_OBJ(front_side, pb_type_Axis_X_obj)
+        #if PYBRICKS_PY_COMMON_BLE
+        , PB_ARG_DEFAULT_INT(broadcast_channel, 0)
+        , PB_ARG_DEFAULT_OBJ(observe_channels, mp_const_empty_tuple_obj)
+        #endif
+        );
 
     hubs_EssentialHub_obj_t *self = mp_obj_malloc(hubs_EssentialHub_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
     #if PYBRICKS_PY_COMMON_BLE
-    self->ble = MP_OBJ_FROM_PTR(&pb_module_ble);
+    self->ble = pb_type_BLE_new(broadcast_channel_in, observe_channels_in);
     #endif
     self->buttons = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(essentialhub_buttons), essentialhub_buttons, pbio_button_is_pressed);
     self->charger = pb_type_Charger_obj_new();

--- a/pybricks/hubs/pb_type_essentialhub.c
+++ b/pybricks/hubs/pb_type_essentialhub.c
@@ -27,6 +27,9 @@
 typedef struct _hubs_EssentialHub_obj_t {
     mp_obj_base_t base;
     mp_obj_t battery;
+    #if PYBRICKS_PY_COMMON_BLE
+    mp_obj_t ble;
+    #endif
     mp_obj_t buttons;
     mp_obj_t charger;
     mp_obj_t imu;
@@ -45,6 +48,9 @@ STATIC mp_obj_t hubs_EssentialHub_make_new(const mp_obj_type_t *type, size_t n_a
 
     hubs_EssentialHub_obj_t *self = mp_obj_malloc(hubs_EssentialHub_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
+    #if PYBRICKS_PY_COMMON_BLE
+    self->ble = MP_OBJ_FROM_PTR(&pb_module_ble);
+    #endif
     self->buttons = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(essentialhub_buttons), essentialhub_buttons, pbio_button_is_pressed);
     self->charger = pb_type_Charger_obj_new();
     self->imu = pb_type_IMU_obj_new(top_side_in, front_side_in);
@@ -55,6 +61,9 @@ STATIC mp_obj_t hubs_EssentialHub_make_new(const mp_obj_type_t *type, size_t n_a
 
 STATIC const pb_attr_dict_entry_t hubs_EssentialHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_EssentialHub_obj_t, battery),
+    #if PYBRICKS_PY_COMMON_BLE
+    PB_DEFINE_CONST_ATTR_RO(MP_QSTR_ble, hubs_EssentialHub_obj_t, ble),
+    #endif
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_button, hubs_EssentialHub_obj_t, buttons),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_charger, hubs_EssentialHub_obj_t, charger),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_imu, hubs_EssentialHub_obj_t, imu),

--- a/pybricks/hubs/pb_type_movehub.c
+++ b/pybricks/hubs/pb_type_movehub.c
@@ -14,6 +14,7 @@
 #include <pybricks/common.h>
 #include <pybricks/hubs.h>
 
+#include <pybricks/util_mp/pb_kwarg_helper.h>
 #include <pybricks/util_mp/pb_obj_helper.h>
 
 // LIS3DH motion sensor
@@ -257,10 +258,16 @@ static const pb_obj_enum_member_t *movehub_buttons[] = {
 };
 
 STATIC mp_obj_t hubs_MoveHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    #if PYBRICKS_PY_COMMON_BLE
+    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
+        PB_ARG_DEFAULT_INT(broadcast_channel, 0),
+        PB_ARG_DEFAULT_OBJ(observe_channels, mp_const_empty_tuple_obj));
+    #endif
+
     hubs_MoveHub_obj_t *self = mp_obj_malloc(hubs_MoveHub_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
     #if PYBRICKS_PY_COMMON_BLE
-    self->ble = MP_OBJ_FROM_PTR(&pb_module_ble);
+    self->ble = pb_type_BLE_new(broadcast_channel_in, observe_channels_in);
     #endif
     self->button = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(movehub_buttons), movehub_buttons, pbio_button_is_pressed);
     self->imu = hubs_MoveHub_IMU_make_new();

--- a/pybricks/hubs/pb_type_movehub.c
+++ b/pybricks/hubs/pb_type_movehub.c
@@ -243,6 +243,9 @@ STATIC mp_obj_t hubs_MoveHub_IMU_make_new(void) {
 typedef struct _hubs_MoveHub_obj_t {
     mp_obj_base_t base;
     mp_obj_t battery;
+    #if PYBRICKS_PY_COMMON_BLE
+    mp_obj_t ble;
+    #endif
     mp_obj_t button;
     mp_obj_t imu;
     mp_obj_t light;
@@ -256,6 +259,9 @@ static const pb_obj_enum_member_t *movehub_buttons[] = {
 STATIC mp_obj_t hubs_MoveHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     hubs_MoveHub_obj_t *self = mp_obj_malloc(hubs_MoveHub_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
+    #if PYBRICKS_PY_COMMON_BLE
+    self->ble = MP_OBJ_FROM_PTR(&pb_module_ble);
+    #endif
     self->button = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(movehub_buttons), movehub_buttons, pbio_button_is_pressed);
     self->imu = hubs_MoveHub_IMU_make_new();
     self->light = common_ColorLight_internal_obj_new(pbsys_status_light);
@@ -265,6 +271,9 @@ STATIC mp_obj_t hubs_MoveHub_make_new(const mp_obj_type_t *type, size_t n_args, 
 
 STATIC const pb_attr_dict_entry_t hubs_MoveHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_MoveHub_obj_t, battery),
+    #if PYBRICKS_PY_COMMON_BLE
+    PB_DEFINE_CONST_ATTR_RO(MP_QSTR_ble, hubs_MoveHub_obj_t, ble),
+    #endif
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_button, hubs_MoveHub_obj_t, button),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_imu, hubs_MoveHub_obj_t, imu),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, hubs_MoveHub_obj_t, light),

--- a/pybricks/hubs/pb_type_primehub.c
+++ b/pybricks/hubs/pb_type_primehub.c
@@ -27,6 +27,9 @@
 typedef struct _hubs_PrimeHub_obj_t {
     mp_obj_base_t base;
     mp_obj_t battery;
+    #if PYBRICKS_PY_COMMON_BLE
+    mp_obj_t ble;
+    #endif
     mp_obj_t buttons;
     mp_obj_t charger;
     mp_obj_t display;
@@ -50,6 +53,9 @@ STATIC mp_obj_t hubs_PrimeHub_make_new(const mp_obj_type_t *type, size_t n_args,
 
     hubs_PrimeHub_obj_t *self = mp_obj_malloc(hubs_PrimeHub_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
+    #if PYBRICKS_PY_COMMON_BLE
+    self->ble = MP_OBJ_FROM_PTR(&pb_module_ble);
+    #endif
     self->buttons = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(primehub_buttons), primehub_buttons, pbio_button_is_pressed);
     self->charger = pb_type_Charger_obj_new();
     self->display = pb_type_LightMatrix_obj_new(pbsys_hub_light_matrix);
@@ -62,6 +68,9 @@ STATIC mp_obj_t hubs_PrimeHub_make_new(const mp_obj_type_t *type, size_t n_args,
 
 STATIC const pb_attr_dict_entry_t hubs_PrimeHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_PrimeHub_obj_t, battery),
+    #if PYBRICKS_PY_COMMON_BLE
+    PB_DEFINE_CONST_ATTR_RO(MP_QSTR_ble, hubs_PrimeHub_obj_t, ble),
+    #endif
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_buttons, hubs_PrimeHub_obj_t, buttons),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_charger, hubs_PrimeHub_obj_t, charger),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_display, hubs_PrimeHub_obj_t, display),

--- a/pybricks/hubs/pb_type_primehub.c
+++ b/pybricks/hubs/pb_type_primehub.c
@@ -49,12 +49,17 @@ static const pb_obj_enum_member_t *primehub_buttons[] = {
 STATIC mp_obj_t hubs_PrimeHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_DEFAULT_OBJ(top_side, pb_type_Axis_Z_obj),
-        PB_ARG_DEFAULT_OBJ(front_side, pb_type_Axis_X_obj));
+        PB_ARG_DEFAULT_OBJ(front_side, pb_type_Axis_X_obj)
+        #if PYBRICKS_PY_COMMON_BLE
+        , PB_ARG_DEFAULT_INT(broadcast_channel, 0)
+        , PB_ARG_DEFAULT_OBJ(observe_channels, mp_const_empty_tuple_obj)
+        #endif
+        );
 
     hubs_PrimeHub_obj_t *self = mp_obj_malloc(hubs_PrimeHub_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
     #if PYBRICKS_PY_COMMON_BLE
-    self->ble = MP_OBJ_FROM_PTR(&pb_module_ble);
+    self->ble = pb_type_BLE_new(broadcast_channel_in, observe_channels_in);
     #endif
     self->buttons = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(primehub_buttons), primehub_buttons, pbio_button_is_pressed);
     self->charger = pb_type_Charger_obj_new();

--- a/pybricks/hubs/pb_type_technichub.c
+++ b/pybricks/hubs/pb_type_technichub.c
@@ -34,12 +34,17 @@ static const pb_obj_enum_member_t *technichub_buttons[] = {
 STATIC mp_obj_t hubs_TechnicHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_DEFAULT_OBJ(top_side, pb_type_Axis_Z_obj),
-        PB_ARG_DEFAULT_OBJ(front_side, pb_type_Axis_X_obj));
+        PB_ARG_DEFAULT_OBJ(front_side, pb_type_Axis_X_obj)
+        #if PYBRICKS_PY_COMMON_BLE
+        , PB_ARG_DEFAULT_INT(broadcast_channel, 0)
+        , PB_ARG_DEFAULT_OBJ(observe_channels, mp_const_empty_tuple_obj)
+        #endif
+        );
 
     hubs_TechnicHub_obj_t *self = mp_obj_malloc(hubs_TechnicHub_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
     #if PYBRICKS_PY_COMMON_BLE
-    self->ble = MP_OBJ_FROM_PTR(&pb_module_ble);
+    self->ble = pb_type_BLE_new(broadcast_channel_in, observe_channels_in);
     #endif
     self->button = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(technichub_buttons), technichub_buttons, pbio_button_is_pressed);
     self->imu = pb_type_IMU_obj_new(top_side_in, front_side_in);

--- a/pybricks/hubs/pb_type_technichub.c
+++ b/pybricks/hubs/pb_type_technichub.c
@@ -18,6 +18,9 @@
 typedef struct _hubs_TechnicHub_obj_t {
     mp_obj_base_t base;
     mp_obj_t battery;
+    #if PYBRICKS_PY_COMMON_BLE
+    mp_obj_t ble;
+    #endif
     mp_obj_t button;
     mp_obj_t imu;
     mp_obj_t light;
@@ -35,6 +38,9 @@ STATIC mp_obj_t hubs_TechnicHub_make_new(const mp_obj_type_t *type, size_t n_arg
 
     hubs_TechnicHub_obj_t *self = mp_obj_malloc(hubs_TechnicHub_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
+    #if PYBRICKS_PY_COMMON_BLE
+    self->ble = MP_OBJ_FROM_PTR(&pb_module_ble);
+    #endif
     self->button = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(technichub_buttons), technichub_buttons, pbio_button_is_pressed);
     self->imu = pb_type_IMU_obj_new(top_side_in, front_side_in);
     self->light = common_ColorLight_internal_obj_new(pbsys_status_light);
@@ -44,6 +50,9 @@ STATIC mp_obj_t hubs_TechnicHub_make_new(const mp_obj_type_t *type, size_t n_arg
 
 STATIC const pb_attr_dict_entry_t hubs_TechnicHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_TechnicHub_obj_t, battery),
+    #if PYBRICKS_PY_COMMON_BLE
+    PB_DEFINE_CONST_ATTR_RO(MP_QSTR_ble, hubs_TechnicHub_obj_t, ble),
+    #endif
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_button, hubs_TechnicHub_obj_t, button),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_imu, hubs_TechnicHub_obj_t, imu),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, hubs_TechnicHub_obj_t, light),

--- a/pybricks/pybricks.c
+++ b/pybricks/pybricks.c
@@ -122,7 +122,11 @@ void pb_package_pybricks_init(bool import_all) {
 }
 #endif // PYBRICKS_OPT_COMPILER
 
+// REVISIT: move these to object finalizers if we enable finalizers in the GC
 void pb_package_pybricks_deinit(void) {
+    #if PYBRICKS_PY_COMMON_BLE
+    pb_type_BLE_cleanup();
+    #endif
     // Disconnect from remote.
     #if PYBRICKS_PY_PUPDEVICES
     pb_type_Remote_cleanup();


### PR DESCRIPTION
This is an alternate attempt at hub to hub communication using BLE advertising data similar #80. (Thanks again @NStrijbosch and @laurensvalk  for all of the work done there.)

### Differences from #80

- Advertising and scanning and being connected to Pybricks Code and being connected to a remote on the Technic hub all at the same time seems to be working, so there is no background process to switch between advertising and scanning. The previous observed problems could have been caused by bugs in the existing Bluetooth driver code that have (hopefully) been fixed since then.
- Support for Move hub is added.
- Since LEGO has announced the discontinuation of MINDSTORMS, compatibility with the official firmware seems less important, so this has a different data encoding scheme and uses non-connectable advertisements.
  - The new encoding scheme allows us to squeeze in more data.
  - Using non-connectable advertisements is the "right" way to do this according to BLE author recommendations and prevents other devices from connecting while broadcasting. It also sends data less frequently (every 100ms) which should reduce radio interference.
- Different Python API that better fits new encoding scheme.

### Limitations

- Broadcast (sending non-connectable advertisements in any form) does not work on City hub. This appears to be a firmware bug (it has the same chip as Technic hub but different firmware version).
- Broadcast on Move hub only works when not connected to Pybricks Code, otherwise it raises `OSError` with `EPERM`.
- Using broadcast and observe on the Move hub at the same time has very inconsistent (and usually very high) latency.
- Using observe while connected to Pybricks Code results in inconsistent latency on smaller hubs. SPIKE hubs seem to work well even when connected to Pybricks Code and city/technic hubs work better when not connected to Pybricks Code.

### Python API

This adds a new `ble` attribute to the `Hub` object with the following methods and extends the `Hub` constructor with additional arguments.

```python
class BLE:
    def broadcast(*args: None | bool | int | float | str | bytes) -> None:
        """
        Starts broadcasting advertising data containing *args*.

        Params:
            *args: Zero or more values to be broadcast.

        .. note:: Advertising data size is quite limited. For example, you
            can send one string or byte array that is 25 bytes or 12
            ``True``/``False`` values or 5 floating point values or any
            combination of values as long as the total packed size doesn't
            exceed the available space. The exact technical specification
            can be found at ...

        Example::

            # Broadcast 3 values.
            hub.ble.broadcast(100, "hi", False)

            # Broadcast no values. Useful if you only care about RSSI.
            hub.ble.broadcast()

        Bad example::

            # Dont' do this! The first value will never be broadcast.
            hub.ble.broadcast("first")
            hub.ble.broadcast("second")
        """

    def observe(channel: int) ->  tuple[None | bool | int | float | str | bytes, ...] | None:
        """
        Retrieves the last observed data for a given channel.

        Args:
            channel: The channel to observe (0 to 255).

        Returns:
            A tuple of the most recent RSSI and the advertising data or ``None`` if no data
            has been received yet or it has been more than one second since the last data
            was received.

        Example::

            data = hub.ble.observe(channel=0)

            if data is not None:
                a, b, c = data
                # if the other hub called hub.ble.broadcast(100, "hi", False)
                # then a == 100 and b == "hi" and c is False
                ...

        Bad example::

            # Don't do this! This will fail the first time it is called because no
            # data has been received yet causing unpacking to fail.
            a, b, c = hub.ble.observe(channel=0)
        """

    def signal_strength(channel: int) -> int:
    """
    Gets the average signal strength in dBm for the given channel.

    This is useful for detecting how near the broadcasting device is. A close
    device may have a signal strength around -40 dBm while a far away device
    might have a signal strength around -70 dBm.

    Args:
        channel: The channel number (0 to 255).

    Returns:
        The signal strength or ``-128`` if nothing has been received yet or the
        broadcasts are no longer being received.
    """

    def version() -> str:
        """
        Gets the firmware version from the Bluetooth chip.

        Example::

            print(hub.ble.version())
        """


class Hub(..., broadcast_channel=1, observe_channels=[]):
    """
    Params:
        broadcast_channel:
            A value from 0 to 255 indicating which channel ``hub.ble.broadcast()``
            will use. Default is channel 0.
        observe_channels:
            A list of channels channel to listen to when
            ``hub.ble.observe()`` is called. Listening to more channels
            requires more memory. Default is an empty list (no channels).

    Example::

        # Broadcast on channel 1. Observe channels 2 and 3.
        hub = PrimeHub(broadcast_channel=1, observe_channel=[2, 3])
    """
    ...
    ble: BLE
```

### Ideas for changes to current implementation

- (fixed) ~~Known issue: RSSI is initially 0 instead of -127.~~
- (done) ~~RSSI should change to -127 after some timeout of not receiving new advertisement data. How long should this be? 1 second, 10 seconds?~~
- (done) ~~`last_observe_channel` should be changed `observe_channels` and take an iterable of channels. The range of allowable channel values for both broadcast and observe can then be expanded to 0 to 255 instead of 0 to 15. This would be nice to make it easier to avoid using the same channels as your neighbor.~~
- (done) ~~Furthermore, BLE scanning could be enabled at construction time rather than the first time `hub.ble.observer()` is called.~~
- State in documentation that broadcasting is not supported on Move hub and City hub and recommend using nRF UART instead if needed on those hubs. Broadcast would be modified to to simply always raise an error on those hubs (would probably save quite a bit of firmware size on Move hub which is always a good thing).
