### PR TITLE
pbio/motor_process: catch up timer if behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 
 ### Fixed
 - Fixed stdin containing `0x06` command byte ([support#1052]).
+- Fixed motor process causing delays on ev3dev ([support#1035]).
 
+[support#1035]: https://github.com/pybricks/support/issues/1035
 [support#1052]: https://github.com/pybricks/support/issues/1052
 
 ## [3.3.0b4] - 2023-04-21

--- a/lib/pbio/src/motor_process.c
+++ b/lib/pbio/src/motor_process.c
@@ -37,8 +37,17 @@ PROCESS_THREAD(pbio_motor_process, ev, data) {
         // Update servos
         pbio_servo_update_all();
 
-        // Reset timer to wait for next update
+        // Reset timer to wait for next update. Using etimer_reset() instead
+        // of etimer_restart() makes average update period closer to the expected
+        // PBIO_CONFIG_CONTROL_LOOP_TIME_MS when occasional delays occur.
         etimer_reset(&timer);
+
+        // If we have fallen too far behind though, jump ahead to catch up.
+        // Otherwise, this process will run in a tight loop and not yield
+        // until the timer catches up.
+        if (timer_expired(&timer.timer)) {
+            etimer_restart(&timer);
+        }
     }
 
     PROCESS_END();


### PR DESCRIPTION
This adds an extra check to make sure the motor poll timer hasn't fallen too far behind.

Before this change, if calling the motor process was blocked for too long, it would cause the motor contiki process to never yield until the wall clock caught up. This would also cause motor updates to be called with a time delta of 0 which probably caused unexpected conditions in some of the calculations.

We can avoid this by checking to see if we have a condition that would trigger the unwanted behavior and reset the timer to a larger interval. This could cause a hiccup in the observer calculations but is a significant improvement over the alternative.

Fixes: https://github.com/pybricks/support/issues/1035