### PR TITLE
bricks: Checkout micropython-lib.

### DIFF
--- a/bricks/_common/arm_none_eabi.mk
+++ b/bricks/_common/arm_none_eabi.mk
@@ -36,6 +36,13 @@ ifeq ("$(wildcard $(PBTOP)/micropython/README.md)","")
 $(error failed)
 endif
 endif
+ifeq ("$(wildcard $(PBTOP)/micropython/lib/micropython-lib/README.md)","")
+$(info GIT cloning micropython-lib submodule)
+$(info $(shell cd $(PBTOP)/micropython && git submodule update --init lib/micropython-lib))
+ifeq ("$(wildcard $(PBTOP)/micropython/lib/micropython-lib/README.md)","")
+$(error failed)
+endif
+endif
 ifeq ($(PB_LIB_STM32_HAL),1)
 ifeq ("$(wildcard $(PBTOP)/micropython/lib/stm32lib/README.md)","")
 $(info GIT cloning stm32lib submodule)

--- a/bricks/virtualhub/Makefile
+++ b/bricks/virtualhub/Makefile
@@ -18,6 +18,16 @@ BUILD_DIR = build
 endif
 endif
 
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+PBTOP := $(patsubst %/bricks/virtualhub/Makefile,%,$(mkfile_path))
+ifeq ("$(wildcard $(PBTOP)/micropython/lib/micropython-lib/README.md)","")
+$(info GIT cloning micropython-lib submodule)
+$(info $(shell cd $(PBTOP)/micropython && git submodule update --init lib/micropython-lib))
+ifeq ("$(wildcard $(PBTOP)/micropython/lib/micropython-lib/README.md)","")
+$(error failed)
+endif
+endif
+
 # Include frozen manifest only if there is anything to freeze.
 ifneq ("$(wildcard ../../bricks/_common/modules/*.py)","")
 FROZEN_MANIFEST ?= ../../../bricks/_common/manifest.py


### PR DESCRIPTION
This appears to be necessary to build frozen modules now.

Is this the right way to do it?

Fixes:
```
CC ../../micropython/py/showbc.c
CC ../../micropython/py/repl.c
CC ../../micropython/py/smallint.c
CC ../../micropython/py/frozenmod.c
-e Error: micropython-lib submodule is not initialized. Run 'make submodules'  <-------
CC ../../micropython/extmod/machine_bitstream.c
CC ../../micropython/extmod/machine_i2c.c
```