### PR TITLE
.github/workflows/build: Install poetry before using it.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,13 +194,11 @@ jobs:
         path: micropython/mpy-cross/build
     - name: Fix file permission
       run: chmod +x micropython/mpy-cross/build/mpy-cross
+    - run: pipx install poetry
+    - run: poetry install --only=stats
     - name: Build firmware (pull request)
       if: ${{ github.base_ref != null }}
       run: poetry run .github/build-each-commit.py ${{ matrix.hub }} ${{ github.sha }}
-    - run: pipx install poetry
-      if: ${{ github.base_ref == null && github.ref != 'refs/heads/master' }}
-    - run: poetry install --only=stats
-      if: ${{ github.base_ref == null && github.ref != 'refs/heads/master' }}
     - name: Build firmware (non-master branch)
       if: ${{ github.base_ref == null && github.ref != 'refs/heads/master' }}
       env:


### PR DESCRIPTION
Fixes `poetry: command not found` on pull requests.