### PR TITLE
drv/ioport_lpf2: add boot power quirk

### DIFF
--- a/lib/pbio/drv/ioport/ioport_pup.c
+++ b/lib/pbio/drv/ioport/ioport_pup.c
@@ -30,7 +30,10 @@ void pbdrv_ioport_init(void) {
     for (uint8_t i = 0; i < PBDRV_CONFIG_IOPORT_NUM_DEV; i++) {
         init_one_port(&pbdrv_ioport_pup_platform_data.ports[i].pins);
     }
-    pbdrv_ioport_enable_vcc(true);
+
+    // Begin with vcc disabled. The relevant ioport mode will turn this on
+    // when needed.
+    pbdrv_ioport_enable_vcc(false);
 }
 
 void pbdrv_ioport_deinit(void) {

--- a/lib/pbio/drv/legodev/legodev_pup.c
+++ b/lib/pbio/drv/legodev/legodev_pup.c
@@ -25,6 +25,7 @@
 
 #include <pbdrv/counter.h>
 #include <pbdrv/legodev.h>
+#include <pbdrv/ioport.h>
 #include "../ioport/ioport_pup.h"
 
 #include "legodev_pup.h"
@@ -319,6 +320,14 @@ PROCESS_THREAD(pbio_legodev_pup_process, ev, data) {
     static ext_dev_t *dev;
 
     PROCESS_BEGIN();
+
+    // Some hubs turn on power to the I/O ports in the bootloader. This causes
+    // UART sync delays after boot. It is faster to power cycle the I/O devices
+    // than it is to wait for long sync in most cases.
+    pbdrv_ioport_enable_vcc(false);
+    etimer_set(&timer, 500);
+    PROCESS_WAIT_EVENT_UNTIL(ev == PROCESS_EVENT_TIMER && etimer_expired(&timer));
+    pbdrv_ioport_enable_vcc(true);
 
     etimer_set(&timer, 2);
 


### PR DESCRIPTION
The city hub powers on the I/O ports (pin 4) during boot, so by the time the device connection manager detected a UART device, in many cases, it was too late to catch the device on the first sync. In the case of the BOOST color distance sensor, this meant waiting 10 seconds instead of 5 for the sensor to be ready.

This adds an option to enable a workaround for the quirk that cycles power to the I/O ports immediately after boot. This is faster than waiting for the next sync cycle.

Issue: https://github.com/pybricks/support/issues/747