### PR TITLE
pybricks.tools: Add read_one() function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 - Added `'modes'` entry to the dictionary returned by `PUPDevice.info()`. It
   is a tuple of `(name, num_values, data_type)` tuples for each available mode.
+- Added `pybricks.tools.read_input_byte()` function ([support#1102]).
 
 ### Changed
 - Changed internal drivers for LEGO devices (motors and sensors) on all platforms.
@@ -17,6 +18,7 @@
 
 [support#1095]: https://github.com/pybricks/support/issues/1095
 [support#1098]: https://github.com/pybricks/support/issues/1098
+[support#1102]: https://github.com/pybricks/support/issues/1102
 
 ## [3.3.0b6] - 2023-06-02
 

--- a/bricks/ev3dev/Makefile
+++ b/bricks/ev3dev/Makefile
@@ -311,6 +311,9 @@ test: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py $(GRX_TEST_PLUGIN_LIB)
 		GRX_PLUGIN_PATH=$(realpath $(BUILD)) GRX_DRIVER=test \
 		./run-tests.py
 
+repl: $(BUILD)/$(PROG) $(GRX_TEST_PLUGIN_LIB) modules/core.py
+	GRX_PLUGIN_PATH=$(realpath $(BUILD)) GRX_DRIVER=test $< -i modules/core.py
+
 # Value of configure's --host= option (required for cross-compilation).
 # Deduce it from CROSS_COMPILE by default, but can be overridden.
 ifneq ($(CROSS_COMPILE),)

--- a/bricks/ev3dev/modules/core.py
+++ b/bricks/ev3dev/modules/core.py
@@ -9,7 +9,7 @@ from pybricks.ev3devices import (
     GyroSensor,
 )
 from pybricks.parameters import Port, Stop, Direction, Button, Color
-from pybricks.tools import wait, StopWatch, DataLog
+from pybricks.tools import read_input_byte, wait, StopWatch, DataLog
 from pybricks.robotics import DriveBase
 from pybricks.media.ev3dev import ImageFile, SoundFile
 

--- a/bricks/virtualhub/mpvarianthal.h
+++ b/bricks/virtualhub/mpvarianthal.h
@@ -32,7 +32,7 @@
 
 void mp_hal_set_interrupt_char(char c);
 
-#define mp_hal_stdio_poll unused // this is not implemented, nor needed
+uintptr_t mp_hal_stdio_poll(uintptr_t);
 void mp_hal_stdio_mode_raw(void);
 void mp_hal_stdio_mode_orig(void);
 


### PR DESCRIPTION
This adds a new non-blocking function to read one byte from stdin. This is needed since there is no other way to read from stdin on the Move hub. It is also useful on other hubs as it eliminates the need to use poll() to avoid blocking reads.

Fixes: https://github.com/pybricks/support/issues/1102