### PR TITLE
pbio/drv/legodev: Replace unplug reset by watchdog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 ## [Unreleased]
 
+### Fixed
 - Fixed Technic (Extra) Large motors not working ([support#1131]) on all hubs.
 - Fixed Powered Up Light not working ([support#1131]) on all hubs.
+- Fixed UART sensors not working on Technic Hub ([support#1137]).
 
-[support#1064]: https://github.com/pybricks/support/issues/1131
+[support#1131]: https://github.com/pybricks/support/issues/1131
+[support#1137]: https://github.com/pybricks/support/issues/1137
 
 ## [3.3.0b7] - 2023-06-30
 

--- a/lib/pbio/drv/legodev/legodev_pup.h
+++ b/lib/pbio/drv/legodev/legodev_pup.h
@@ -33,11 +33,11 @@ extern const pbdrv_legodev_pup_int_platform_data_t
 extern const pbdrv_legodev_pup_ext_platform_data_t
     pbdrv_legodev_pup_ext_platform_data[PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV];
 
-void pbdrv_legodev_pup_reset_device_detection(pbdrv_legodev_pup_uart_dev_t *dev);
+void pbdrv_legodev_pup_reset_watchdog(pbdrv_legodev_pup_uart_dev_t *uartdev);
 
 #else
 
-static inline void pbdrv_legodev_pup_reset_device_detection(pbdrv_legodev_pup_uart_dev_t *dev) {
+static inline void pbdrv_legodev_pup_reset_watchdog(pbdrv_legodev_pup_uart_dev_t *uartdev) {
 }
 
 #endif // PBDRV_CONFIG_LEGODEV_PUP

--- a/lib/pbio/test/src/test_uartdev.c
+++ b/lib/pbio/test/src/test_uartdev.c
@@ -19,7 +19,6 @@
 #include <pbio/util.h>
 #include <test-pbio.h>
 
-#include "../drv/legodev/legodev_pup.h"
 #include "../drv/legodev/legodev_pup_uart.h"
 
 #include "../src/processes.h"


### PR DESCRIPTION
This keeps the device connection manager in control even if the UART device and PT threads get in a confused state.

Fixes https://github.com/pybricks/support/issues/1137