### PR TITLE
UART sensors cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,13 @@
 - Fixed Powered Up Light not working ([support#1131]) on all hubs.
 - Fixed UART sensors not working on Technic Hub ([support#1137]).
 - Fixed incorrect number of ports on City Hub ([support#1131]).
+- Improved external device detection speed ([support#1140]).
 
 [support#1054]: https://github.com/pybricks/support/issues/1054
 [support#1105]: https://github.com/pybricks/support/issues/1105
 [support#1131]: https://github.com/pybricks/support/issues/1131
 [support#1137]: https://github.com/pybricks/support/issues/1137
+[support#1140]: https://github.com/pybricks/support/issues/1140
 
 ## [3.3.0b7] - 2023-06-30
 

--- a/lib/pbio/drv/core.c
+++ b/lib/pbio/drv/core.c
@@ -37,6 +37,7 @@
 #include "random/random.h"
 #include "reset/reset.h"
 #include "sound/sound.h"
+#include "uart/uart.h"
 #include "usb/usb.h"
 #include "watchdog/watchdog.h"
 
@@ -87,6 +88,7 @@ void pbdrv_init(void) {
     pbdrv_random_init();
     pbdrv_reset_init();
     pbdrv_sound_init();
+    pbdrv_uart_init();
     pbdrv_usb_init();
     pbdrv_watchdog_init();
 

--- a/lib/pbio/drv/ioport/ioport_pup.c
+++ b/lib/pbio/drv/ioport/ioport_pup.c
@@ -30,10 +30,7 @@ void pbdrv_ioport_init(void) {
     for (uint8_t i = 0; i < PBDRV_CONFIG_IOPORT_NUM_DEV; i++) {
         init_one_port(&pbdrv_ioport_pup_platform_data.ports[i].pins);
     }
-
-    // Begin with vcc disabled. The relevant ioport mode will turn this on
-    // when needed.
-    pbdrv_ioport_enable_vcc(false);
+    pbdrv_ioport_enable_vcc(true);
 }
 
 void pbdrv_ioport_deinit(void) {

--- a/lib/pbio/drv/legodev/legodev_pup.c
+++ b/lib/pbio/drv/legodev/legodev_pup.c
@@ -377,11 +377,15 @@ struct _pbdrv_legodev_dev_t {
 static pbdrv_legodev_dev_t devs[PBDRV_CONFIG_LEGODEV_PUP_NUM_INT_DEV + PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV];
 
 PROCESS_THREAD(pbio_legodev_pup_process, ev, data) {
+    #if PBDRV_CONFIG_LEGODEV_PUP_POWER_CYCLE_PORTS
     static struct etimer timer;
+    #endif
+
     static int i;
 
     PROCESS_BEGIN();
 
+    #if PBDRV_CONFIG_LEGODEV_PUP_POWER_CYCLE_PORTS
     // Some hubs turn on power to the I/O ports in the bootloader. This causes
     // UART sync delays after boot. It is faster to power cycle the I/O devices
     // than it is to wait for long sync in most cases.
@@ -389,6 +393,7 @@ PROCESS_THREAD(pbio_legodev_pup_process, ev, data) {
     etimer_set(&timer, 500);
     PROCESS_WAIT_EVENT_UNTIL(ev == PROCESS_EVENT_TIMER && etimer_expired(&timer));
     pbdrv_ioport_enable_vcc(true);
+    #endif // PBDRV_CONFIG_LEGODEV_PUP_POWER_CYCLE_PORTS
 
     while (!pbsys_status_test(PBIO_PYBRICKS_STATUS_SHUTDOWN)) {
         for (i = 0; i < PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV; i++) {

--- a/lib/pbio/drv/legodev/legodev_pup.h
+++ b/lib/pbio/drv/legodev/legodev_pup.h
@@ -33,13 +33,6 @@ extern const pbdrv_legodev_pup_int_platform_data_t
 extern const pbdrv_legodev_pup_ext_platform_data_t
     pbdrv_legodev_pup_ext_platform_data[PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV];
 
-void pbdrv_legodev_pup_reset_watchdog(pbdrv_legodev_pup_uart_dev_t *uartdev);
-
-#else
-
-static inline void pbdrv_legodev_pup_reset_watchdog(pbdrv_legodev_pup_uart_dev_t *uartdev) {
-}
-
 #endif // PBDRV_CONFIG_LEGODEV_PUP
 
 #endif // _INTERNAL_PBDRV_LEGODEV_PUP_H_

--- a/lib/pbio/drv/legodev/legodev_pup_uart.c
+++ b/lib/pbio/drv/legodev/legodev_pup_uart.c
@@ -197,13 +197,13 @@ struct _pbdrv_legodev_pup_uart_dev_t {
     uint8_t rx_msg_size;
     /**< Total number of errors that have occurred. */
     uint32_t err_count;
-    /**< Number of bad reads when receiving DATA data->msgs. */
+    /**< Number of bad reads when receiving DATA ludev->msgs. */
     uint32_t num_data_err;
     /**< Time of most recently started transmission. */
     uint32_t tx_start_time;
-    /**< Flag that indicates that good DATA data->msg has been received since last watchdog timeout. */
+    /**< Flag that indicates that good DATA ludev->msg has been received since last watchdog timeout. */
     bool data_rec;
-    /**< data->msg to be printed in case of an error. */
+    /**< ludev->msg to be printed in case of an error. */
     DBG_ERR(const char *last_err);
     #if PBDRV_CONFIG_LEGODEV_MODE_INFO
     /**< Mode value used to keep track of mode in INFO messages while syncing. */
@@ -221,42 +221,42 @@ enum {
 
 static uint8_t bufs[PBDRV_CONFIG_LEGODEV_PUP_UART_NUM_DEV][NUM_BUF][EV3_UART_MAX_MESSAGE_SIZE];
 
-static pbdrv_legodev_pup_uart_dev_t dev_data[PBDRV_CONFIG_LEGODEV_PUP_UART_NUM_DEV];
+static pbdrv_legodev_pup_uart_dev_t ludevs[PBDRV_CONFIG_LEGODEV_PUP_UART_NUM_DEV];
 
-// The following data is really just part of dev_data, but separate allocation reduces overal code size
+// The following data is really just part of ludevs, but separate allocation reduces overal code size
 static uint8_t data_read_bufs[PBDRV_CONFIG_LEGODEV_PUP_UART_NUM_DEV][PBDRV_LEGODEV_MAX_DATA_SIZE] __attribute__((aligned(4)));
 static pbdrv_legodev_pup_uart_data_set_t data_set_bufs[PBDRV_CONFIG_LEGODEV_PUP_UART_NUM_DEV];
 
 #define PBIO_PT_WAIT_READY(pt, expr) PT_WAIT_UNTIL((pt), (expr) != PBIO_ERROR_AGAIN)
 
 pbdrv_legodev_pup_uart_dev_t *pbdrv_legodev_pup_uart_configure(uint8_t device_index, uint8_t uart_driver_index, pbio_dcmotor_t *dcmotor) {
-    pbdrv_legodev_pup_uart_dev_t *port_data = &dev_data[device_index];
-    port_data->dcmotor = dcmotor;
-    port_data->tx_msg = &bufs[device_index][BUF_TX_MSG][0];
-    port_data->rx_msg = &bufs[device_index][BUF_RX_MSG][0];
-    port_data->status = PBDRV_LEGODEV_PUP_UART_STATUS_ERR;
-    port_data->err_count = 0;
-    port_data->data_set = &data_set_bufs[device_index];
-    port_data->bin_data = data_read_bufs[device_index];
+    pbdrv_legodev_pup_uart_dev_t *ludev = &ludevs[device_index];
+    ludev->dcmotor = dcmotor;
+    ludev->tx_msg = &bufs[device_index][BUF_TX_MSG][0];
+    ludev->rx_msg = &bufs[device_index][BUF_RX_MSG][0];
+    ludev->status = PBDRV_LEGODEV_PUP_UART_STATUS_ERR;
+    ludev->err_count = 0;
+    ludev->data_set = &data_set_bufs[device_index];
+    ludev->bin_data = data_read_bufs[device_index];
 
     // legodev driver is started after all other drivers, so we
     // assume that we do not need to wait for this to be ready.
-    pbdrv_uart_get(uart_driver_index, &port_data->uart);
-    return port_data;
+    pbdrv_uart_get(uart_driver_index, &ludev->uart);
+    return ludev;
 }
 
-static void pbdrv_legodev_request_mode(pbdrv_legodev_pup_uart_dev_t *port_data, uint8_t mode) {
-    port_data->mode_switch.desired_mode = mode;
-    port_data->mode_switch.time = pbdrv_clock_get_ms();
-    port_data->mode_switch.requested = true;
+static void pbdrv_legodev_request_mode(pbdrv_legodev_pup_uart_dev_t *ludev, uint8_t mode) {
+    ludev->mode_switch.desired_mode = mode;
+    ludev->mode_switch.time = pbdrv_clock_get_ms();
+    ludev->mode_switch.requested = true;
     pbdrv_legodev_pup_uart_process_poll();
 }
 
-static void pbdrv_legodev_request_data_set(pbdrv_legodev_pup_uart_dev_t *port_data, uint8_t mode, const uint8_t *data, uint8_t size) {
-    port_data->data_set->size = size;
-    port_data->data_set->desired_mode = mode;
-    port_data->data_set->time = pbdrv_clock_get_ms();
-    memcpy(port_data->data_set->bin_data, data, size);
+static void pbdrv_legodev_request_data_set(pbdrv_legodev_pup_uart_dev_t *ludev, uint8_t mode, const uint8_t *data, uint8_t size) {
+    ludev->data_set->size = size;
+    ludev->data_set->desired_mode = mode;
+    ludev->data_set->time = pbdrv_clock_get_ms();
+    memcpy(ludev->data_set->bin_data, data, size);
     pbdrv_legodev_pup_uart_process_poll();
 }
 
@@ -283,15 +283,15 @@ static uint8_t ev3_uart_get_msg_size(uint8_t header) {
 }
 
 
-static void pbdrv_legodev_pup_uart_parse_msg(pbdrv_legodev_pup_uart_dev_t *data) {
+static void pbdrv_legodev_pup_uart_parse_msg(pbdrv_legodev_pup_uart_dev_t *ludev) {
     uint32_t speed;
     uint8_t msg_type, cmd, msg_size, mode, cmd2;
 
-    msg_type = data->rx_msg[0] & LUMP_MSG_TYPE_MASK;
-    cmd = data->rx_msg[0] & LUMP_MSG_CMD_MASK;
-    msg_size = ev3_uart_get_msg_size(data->rx_msg[0]);
+    msg_type = ludev->rx_msg[0] & LUMP_MSG_TYPE_MASK;
+    cmd = ludev->rx_msg[0] & LUMP_MSG_CMD_MASK;
+    msg_size = ev3_uart_get_msg_size(ludev->rx_msg[0]);
     mode = cmd;
-    cmd2 = data->rx_msg[1];
+    cmd2 = ludev->rx_msg[1];
 
     // The original EV3 spec only allowed for up to 8 modes (3-bit number).
     // The Powered UP spec extents this by adding an extra flag to INFO commands.
@@ -301,25 +301,25 @@ static void pbdrv_legodev_pup_uart_parse_msg(pbdrv_legodev_pup_uart_dev_t *data)
         mode += 8;
         cmd2 &= ~LUMP_INFO_MODE_PLUS_8;
     } else {
-        mode += data->ext_mode;
+        mode += ludev->ext_mode;
     }
 
     if (msg_size > 1) {
         uint8_t checksum = 0xFF;
         for (int i = 0; i < msg_size - 1; i++) {
-            checksum ^= data->rx_msg[i];
+            checksum ^= ludev->rx_msg[i];
         }
-        if (checksum != data->rx_msg[msg_size - 1]) {
-            DBG_ERR(data->last_err = "Bad checksum");
+        if (checksum != ludev->rx_msg[msg_size - 1]) {
+            DBG_ERR(ludev->last_err = "Bad checksum");
             // if INFO messages are done and we are now receiving data, it is
             // OK to occasionally have a bad checksum
-            if (data->status == PBDRV_LEGODEV_PUP_UART_STATUS_DATA) {
+            if (ludev->status == PBDRV_LEGODEV_PUP_UART_STATUS_DATA) {
 
                 // The LEGO EV3 color sensor sends bad checksums
                 // for RGB-RAW data (mode 4). The check here could be
                 // improved if someone can find a pattern.
-                if (data->device_info.type_id != PBDRV_LEGODEV_TYPE_ID_EV3_COLOR_SENSOR
-                    || data->rx_msg[0] != (LUMP_MSG_TYPE_DATA | LUMP_MSG_SIZE_8 | 4)) {
+                if (ludev->device_info.type_id != PBDRV_LEGODEV_TYPE_ID_EV3_COLOR_SENSOR
+                    || ludev->rx_msg[0] != (LUMP_MSG_TYPE_DATA | LUMP_MSG_SIZE_8 | 4)) {
                     return;
                 }
             } else {
@@ -339,18 +339,18 @@ static void pbdrv_legodev_pup_uart_parse_msg(pbdrv_legodev_pup_uart_dev_t *data)
                     break;
                 case LUMP_SYS_ACK:
                     #if PBDRV_CONFIG_LEGODEV_MODE_INFO
-                    if (!data->device_info.num_modes) {
-                        DBG_ERR(data->last_err = "Received ACK before all mode INFO");
+                    if (!ludev->device_info.num_modes) {
+                        DBG_ERR(ludev->last_err = "Received ACK before all mode INFO");
                         goto err;
                     }
-                    if ((data->info_flags & EV3_UART_INFO_FLAG_REQUIRED) != EV3_UART_INFO_FLAG_REQUIRED) {
-                        DBG_ERR(data->last_err = "Did not receive all required INFO");
+                    if ((ludev->info_flags & EV3_UART_INFO_FLAG_REQUIRED) != EV3_UART_INFO_FLAG_REQUIRED) {
+                        DBG_ERR(ludev->last_err = "Did not receive all required INFO");
                         goto err;
                     }
-                    data->device_info.mode = data->new_mode;
+                    ludev->device_info.mode = ludev->new_mode;
                     #endif
 
-                    data->status = PBDRV_LEGODEV_PUP_UART_STATUS_ACK;
+                    ludev->status = PBDRV_LEGODEV_PUP_UART_STATUS_ACK;
 
                     return;
             }
@@ -359,37 +359,37 @@ static void pbdrv_legodev_pup_uart_parse_msg(pbdrv_legodev_pup_uart_dev_t *data)
             switch (cmd) {
                 case LUMP_CMD_MODES:
                     #if PBDRV_CONFIG_LEGODEV_MODE_INFO
-                    if (test_and_set_bit(EV3_UART_INFO_BIT_CMD_MODES, &data->info_flags)) {
-                        DBG_ERR(data->last_err = "Received duplicate modes INFO");
+                    if (test_and_set_bit(EV3_UART_INFO_BIT_CMD_MODES, &ludev->info_flags)) {
+                        DBG_ERR(ludev->last_err = "Received duplicate modes INFO");
                         goto err;
                     }
                     if (cmd2 > LUMP_MAX_MODE) {
-                        DBG_ERR(data->last_err = "Number of modes is out of range");
+                        DBG_ERR(ludev->last_err = "Number of modes is out of range");
                         goto err;
                     }
-                    data->device_info.num_modes = cmd2 + 1;
+                    ludev->device_info.num_modes = cmd2 + 1;
                     if (msg_size > 5) {
                         // Powered Up devices can have an extended mode message that
                         // includes modes > LUMP_MAX_MODE
-                        data->device_info.num_modes = data->rx_msg[3] + 1;
+                        ludev->device_info.num_modes = ludev->rx_msg[3] + 1;
                     }
 
-                    debug_pr("num_modes: %d\n", data->device_info.num_modes);
+                    debug_pr("num_modes: %d\n", ludev->device_info.num_modes);
                     #endif
                     break;
                 case LUMP_CMD_SPEED:
                     #if PBDRV_CONFIG_LEGODEV_MODE_INFO
-                    if (test_and_set_bit(EV3_UART_INFO_BIT_CMD_SPEED, &data->info_flags)) {
-                        DBG_ERR(data->last_err = "Received duplicate speed INFO");
+                    if (test_and_set_bit(EV3_UART_INFO_BIT_CMD_SPEED, &ludev->info_flags)) {
+                        DBG_ERR(ludev->last_err = "Received duplicate speed INFO");
                         goto err;
                     }
                     #endif
-                    speed = pbio_get_uint32_le(data->rx_msg + 1);
+                    speed = pbio_get_uint32_le(ludev->rx_msg + 1);
                     if (speed < EV3_UART_SPEED_MIN || speed > EV3_UART_SPEED_MAX) {
-                        DBG_ERR(data->last_err = "Speed is out of range");
+                        DBG_ERR(ludev->last_err = "Speed is out of range");
                         goto err;
                     }
-                    data->new_baud_rate = speed;
+                    ludev->new_baud_rate = speed;
 
                     debug_pr("speed: %" PRIu32 "\n", speed);
 
@@ -398,7 +398,7 @@ static void pbdrv_legodev_pup_uart_parse_msg(pbdrv_legodev_pup_uart_dev_t *data)
                     #if PBDRV_CONFIG_LEGODEV_MODE_INFO
                     if (cmd2 & 0x20) {
                         // TODO: write_cmd_size = cmd2 & 0x3;
-                        if (data->info_flags & PBDRV_LEGODEV_CAPABILITY_FLAG_HAS_MOTOR_REL_POS) {
+                        if (ludev->info_flags & PBDRV_LEGODEV_CAPABILITY_FLAG_HAS_MOTOR_REL_POS) {
                             // TODO: msg[3] and msg[4] probably give us useful information
                         } else {
                             // TODO: handle other write commands
@@ -409,21 +409,21 @@ static void pbdrv_legodev_pup_uart_parse_msg(pbdrv_legodev_pup_uart_dev_t *data)
                 case LUMP_CMD_EXT_MODE:
                     // Powered up devices can have modes > LUMP_MAX_MODE. This
                     // command precedes other commands to add the extra 8 to the mode
-                    data->ext_mode = data->rx_msg[1];
+                    ludev->ext_mode = ludev->rx_msg[1];
                     break;
                 case LUMP_CMD_VERSION:
                     #if PBDRV_CONFIG_LEGODEV_MODE_INFO
-                    if (test_and_set_bit(EV3_UART_INFO_BIT_CMD_VERSION, &data->info_flags)) {
-                        DBG_ERR(data->last_err = "Received duplicate version INFO");
+                    if (test_and_set_bit(EV3_UART_INFO_BIT_CMD_VERSION, &ludev->info_flags)) {
+                        DBG_ERR(ludev->last_err = "Received duplicate version INFO");
                         goto err;
                     }
                     // TODO: this might be useful someday
-                    debug_pr("fw version: %08" PRIx32 "\n", pbio_get_uint32_le(data->rx_msg + 1));
-                    debug_pr("hw version: %08" PRIx32 "\n", pbio_get_uint32_le(data->rx_msg + 5));
+                    debug_pr("fw version: %08" PRIx32 "\n", pbio_get_uint32_le(ludev->rx_msg + 1));
+                    debug_pr("hw version: %08" PRIx32 "\n", pbio_get_uint32_le(ludev->rx_msg + 5));
                     #endif // LUMP_CMD_VERSION
                     break;
                 default:
-                    DBG_ERR(data->last_err = "Unknown command");
+                    DBG_ERR(ludev->last_err = "Unknown command");
                     goto err;
             }
             break;
@@ -431,9 +431,9 @@ static void pbdrv_legodev_pup_uart_parse_msg(pbdrv_legodev_pup_uart_dev_t *data)
         case LUMP_MSG_TYPE_INFO:
             switch (cmd2) {
                 case LUMP_INFO_NAME: {
-                    data->info_flags &= ~EV3_UART_INFO_FLAG_ALL_INFO;
-                    if (data->rx_msg[2] < 'A' || data->rx_msg[2] > 'z') {
-                        DBG_ERR(data->last_err = "Invalid name INFO");
+                    ludev->info_flags &= ~EV3_UART_INFO_FLAG_ALL_INFO;
+                    if (ludev->rx_msg[2] < 'A' || ludev->rx_msg[2] > 'z') {
+                        DBG_ERR(ludev->last_err = "Invalid name INFO");
                         goto err;
                     }
                     /*
@@ -443,54 +443,54 @@ static void pbdrv_legodev_pup_uart_parse_msg(pbdrv_legodev_pup_uart_dev_t *data)
                     * ensure a null terminator for the string
                     * functions.
                     */
-                    data->rx_msg[msg_size - 1] = 0;
-                    const char *name = (char *)(data->rx_msg + 2);
+                    ludev->rx_msg[msg_size - 1] = 0;
+                    const char *name = (char *)(ludev->rx_msg + 2);
                     size_t name_len = strlen(name);
                     if (name_len > LUMP_MAX_NAME_SIZE) {
-                        DBG_ERR(data->last_err = "Name is too long");
+                        DBG_ERR(ludev->last_err = "Name is too long");
                         goto err;
                     }
-                    data->new_mode = mode;
-                    data->info_flags |= EV3_UART_INFO_FLAG_INFO_NAME;
-                    strncpy(data->device_info.mode_info[mode].name, name, name_len);
+                    ludev->new_mode = mode;
+                    ludev->info_flags |= EV3_UART_INFO_FLAG_INFO_NAME;
+                    strncpy(ludev->device_info.mode_info[mode].name, name, name_len);
 
                     // newer LEGO UART devices send additional 6 mode capability flags
                     uint8_t flags = 0;
                     if (name_len <= LUMP_MAX_SHORT_NAME_SIZE && msg_size > LUMP_MAX_NAME_SIZE) {
                         // Only the first is used in practice.
-                        flags = data->rx_msg[8];
+                        flags = ludev->rx_msg[8];
                     } else {
                         // for newer devices that don't send it, set flags by device ID
                         // TODO: Look up from static info like we do for basic devices
-                        if (data->device_info.type_id == PBDRV_LEGODEV_TYPE_ID_INTERACTIVE_MOTOR) {
+                        if (ludev->device_info.type_id == PBDRV_LEGODEV_TYPE_ID_INTERACTIVE_MOTOR) {
                             flags = LUMP_MODE_FLAGS0_MOTOR | LUMP_MODE_FLAGS0_MOTOR_POWER | LUMP_MODE_FLAGS0_MOTOR_SPEED | LUMP_MODE_FLAGS0_MOTOR_REL_POS;
                         }
                     }
 
                     // Although capabilities are sent per mode, we apply them to the whole device
                     if (flags & LUMP_MODE_FLAGS0_MOTOR_POWER) {
-                        data->device_info.flags |= PBDRV_LEGODEV_CAPABILITY_FLAG_IS_DC_OUTPUT;
+                        ludev->device_info.flags |= PBDRV_LEGODEV_CAPABILITY_FLAG_IS_DC_OUTPUT;
                     }
                     if (flags & LUMP_MODE_FLAGS0_MOTOR_SPEED) {
-                        data->device_info.flags |= PBDRV_LEGODEV_CAPABILITY_FLAG_HAS_MOTOR_SPEED;
+                        ludev->device_info.flags |= PBDRV_LEGODEV_CAPABILITY_FLAG_HAS_MOTOR_SPEED;
                     }
                     if (flags & LUMP_MODE_FLAGS0_MOTOR_REL_POS) {
-                        data->device_info.flags |= PBDRV_LEGODEV_CAPABILITY_FLAG_HAS_MOTOR_REL_POS;
+                        ludev->device_info.flags |= PBDRV_LEGODEV_CAPABILITY_FLAG_HAS_MOTOR_REL_POS;
                     }
                     if (flags & LUMP_MODE_FLAGS0_MOTOR_ABS_POS) {
-                        data->device_info.flags |= PBDRV_LEGODEV_CAPABILITY_FLAG_HAS_MOTOR_ABS_POS;
+                        ludev->device_info.flags |= PBDRV_LEGODEV_CAPABILITY_FLAG_HAS_MOTOR_ABS_POS;
                     }
                     if (flags & LUMP_MODE_FLAGS0_NEEDS_SUPPLY_PIN1) {
-                        data->device_info.flags |= PBDRV_LEGODEV_CAPABILITY_FLAG_NEEDS_SUPPLY_PIN1;
+                        ludev->device_info.flags |= PBDRV_LEGODEV_CAPABILITY_FLAG_NEEDS_SUPPLY_PIN1;
                     }
                     if (flags & LUMP_MODE_FLAGS0_NEEDS_SUPPLY_PIN2) {
-                        data->device_info.flags |= PBDRV_LEGODEV_CAPABILITY_FLAG_NEEDS_SUPPLY_PIN2;
+                        ludev->device_info.flags |= PBDRV_LEGODEV_CAPABILITY_FLAG_NEEDS_SUPPLY_PIN2;
                     }
 
-                    debug_pr("new_mode: %d\n", data->new_mode);
+                    debug_pr("new_mode: %d\n", ludev->new_mode);
                     debug_pr("flags: %02X %02X %02X %02X %02X %02X\n",
-                        data->rx_msg[8 + 0], data->rx_msg[8 + 1], data->rx_msg[8 + 2],
-                        data->rx_msg[8 + 3], data->rx_msg[8 + 4], data->rx_msg[8 + 5]);
+                        ludev->rx_msg[8 + 0], ludev->rx_msg[8 + 1], ludev->rx_msg[8 + 2],
+                        ludev->rx_msg[8 + 3], ludev->rx_msg[8 + 4], ludev->rx_msg[8 + 5]);
                 }
                 break;
                 case LUMP_INFO_RAW:
@@ -499,124 +499,124 @@ static void pbdrv_legodev_pup_uart_parse_msg(pbdrv_legodev_pup_uart_dev_t *data)
                 case LUMP_INFO_UNITS:
                     break;
                 case LUMP_INFO_MAPPING:
-                    if (data->new_mode != mode) {
-                        DBG_ERR(data->last_err = "Received INFO for incorrect mode");
+                    if (ludev->new_mode != mode) {
+                        DBG_ERR(ludev->last_err = "Received INFO for incorrect mode");
                         goto err;
                     }
-                    if (test_and_set_bit(EV3_UART_INFO_BIT_INFO_MAPPING, &data->info_flags)) {
-                        DBG_ERR(data->last_err = "Received duplicate mapping INFO");
+                    if (test_and_set_bit(EV3_UART_INFO_BIT_INFO_MAPPING, &ludev->info_flags)) {
+                        DBG_ERR(ludev->last_err = "Received duplicate mapping INFO");
                         goto err;
                     }
 
                     // Mode supports writing if rx_msg[3] is nonzero.
-                    data->device_info.mode_info[mode].writable = data->rx_msg[3] != 0;
+                    ludev->device_info.mode_info[mode].writable = ludev->rx_msg[3] != 0;
 
-                    debug_pr("mapping: in %02x out %02x\n", data->rx_msg[2], data->rx_msg[3]);
-                    debug_pr("mapping: in %02x out %02x\n", data->rx_msg[2], data->rx_msg[3]);
-                    debug_pr("Writable: %d\n", data->device_info.mode_info[mode].writable);
+                    debug_pr("mapping: in %02x out %02x\n", ludev->rx_msg[2], ludev->rx_msg[3]);
+                    debug_pr("mapping: in %02x out %02x\n", ludev->rx_msg[2], ludev->rx_msg[3]);
+                    debug_pr("Writable: %d\n", ludev->device_info.mode_info[mode].writable);
 
                     break;
                 case LUMP_INFO_MODE_COMBOS:
-                    if (data->new_mode != mode) {
-                        DBG_ERR(data->last_err = "Received INFO for incorrect mode");
+                    if (ludev->new_mode != mode) {
+                        DBG_ERR(ludev->last_err = "Received INFO for incorrect mode");
                         goto err;
                     }
-                    if (test_and_set_bit(EV3_UART_INFO_BIT_INFO_MODE_COMBOS, &data->info_flags)) {
-                        DBG_ERR(data->last_err = "Received duplicate mode combos INFO");
+                    if (test_and_set_bit(EV3_UART_INFO_BIT_INFO_MODE_COMBOS, &ludev->info_flags)) {
+                        DBG_ERR(ludev->last_err = "Received duplicate mode combos INFO");
                         goto err;
                     }
 
                     // REVISIT: this is potentially an array of combos
-                    debug_pr("mode combos: %04x\n", data->rx_msg[3] << 8 | data->rx_msg[2]);
+                    debug_pr("mode combos: %04x\n", ludev->rx_msg[3] << 8 | ludev->rx_msg[2]);
 
                     break;
                 case LUMP_INFO_UNK9:
-                    if (data->new_mode != mode) {
-                        DBG_ERR(data->last_err = "Received INFO for incorrect mode");
+                    if (ludev->new_mode != mode) {
+                        DBG_ERR(ludev->last_err = "Received INFO for incorrect mode");
                         goto err;
                     }
-                    if (test_and_set_bit(EV3_UART_INFO_BIT_INFO_UNK9, &data->info_flags)) {
-                        DBG_ERR(data->last_err = "Received duplicate UNK9 INFO");
+                    if (test_and_set_bit(EV3_UART_INFO_BIT_INFO_UNK9, &ludev->info_flags)) {
+                        DBG_ERR(ludev->last_err = "Received duplicate UNK9 INFO");
                         goto err;
                     }
 
                     // first 3 parameters look like PID constants, 4th is max tacho_rate
                     debug_pr("motor parameters: %" PRIu32 " %" PRIu32 " %" PRIu32 " %" PRIu32 "\n",
-                        pbio_get_uint32_le(data->rx_msg + 2), pbio_get_uint32_le(data->rx_msg + 6),
-                        pbio_get_uint32_le(data->rx_msg + 10), pbio_get_uint32_le(data->rx_msg + 14));
+                        pbio_get_uint32_le(ludev->rx_msg + 2), pbio_get_uint32_le(ludev->rx_msg + 6),
+                        pbio_get_uint32_le(ludev->rx_msg + 10), pbio_get_uint32_le(ludev->rx_msg + 14));
 
                     break;
                 case LUMP_INFO_UNK11:
-                    if (data->new_mode != mode) {
-                        DBG_ERR(data->last_err = "Received INFO for incorrect mode");
+                    if (ludev->new_mode != mode) {
+                        DBG_ERR(ludev->last_err = "Received INFO for incorrect mode");
                         goto err;
                     }
-                    if (test_and_set_bit(EV3_UART_INFO_BIT_INFO_UNK11, &data->info_flags)) {
-                        DBG_ERR(data->last_err = "Received duplicate UNK11 INFO");
+                    if (test_and_set_bit(EV3_UART_INFO_BIT_INFO_UNK11, &ludev->info_flags)) {
+                        DBG_ERR(ludev->last_err = "Received duplicate UNK11 INFO");
                         goto err;
                     }
                     break;
                 case LUMP_INFO_FORMAT:
-                    if (data->new_mode != mode) {
-                        DBG_ERR(data->last_err = "Received INFO for incorrect mode");
+                    if (ludev->new_mode != mode) {
+                        DBG_ERR(ludev->last_err = "Received INFO for incorrect mode");
                         goto err;
                     }
-                    if (test_and_set_bit(EV3_UART_INFO_BIT_INFO_FORMAT, &data->info_flags)) {
-                        DBG_ERR(data->last_err = "Received duplicate format INFO");
+                    if (test_and_set_bit(EV3_UART_INFO_BIT_INFO_FORMAT, &ludev->info_flags)) {
+                        DBG_ERR(ludev->last_err = "Received duplicate format INFO");
                         goto err;
                     }
-                    data->device_info.mode_info[mode].num_values = data->rx_msg[2];
-                    if (!data->device_info.mode_info[mode].num_values) {
-                        DBG_ERR(data->last_err = "Invalid number of data sets");
+                    ludev->device_info.mode_info[mode].num_values = ludev->rx_msg[2];
+                    if (!ludev->device_info.mode_info[mode].num_values) {
+                        DBG_ERR(ludev->last_err = "Invalid number of data sets");
                         goto err;
                     }
                     if (msg_size < 7) {
-                        DBG_ERR(data->last_err = "Invalid format data->msg size");
+                        DBG_ERR(ludev->last_err = "Invalid format ludev->msg size");
                         goto err;
                     }
-                    if ((data->info_flags & EV3_UART_INFO_FLAG_REQUIRED) != EV3_UART_INFO_FLAG_REQUIRED) {
-                        DBG_ERR(data->last_err = "Did not receive all required INFO");
+                    if ((ludev->info_flags & EV3_UART_INFO_FLAG_REQUIRED) != EV3_UART_INFO_FLAG_REQUIRED) {
+                        DBG_ERR(ludev->last_err = "Did not receive all required INFO");
                         goto err;
                     }
-                    data->device_info.mode_info[mode].data_type = data->rx_msg[3];
-                    if (data->new_mode) {
-                        data->new_mode--;
+                    ludev->device_info.mode_info[mode].data_type = ludev->rx_msg[3];
+                    if (ludev->new_mode) {
+                        ludev->new_mode--;
                     }
 
-                    debug_pr("num_values: %d\n", data->device_info.mode_info[mode].num_values);
-                    debug_pr("data_type: %d\n", data->device_info.mode_info[mode].data_type);
+                    debug_pr("num_values: %d\n", ludev->device_info.mode_info[mode].num_values);
+                    debug_pr("data_type: %d\n", ludev->device_info.mode_info[mode].data_type);
 
                     break;
             }
             break;
         #endif
         case LUMP_MSG_TYPE_DATA:
-            if (data->status != PBDRV_LEGODEV_PUP_UART_STATUS_DATA) {
-                DBG_ERR(data->last_err = "Received DATA before INFO was complete");
+            if (ludev->status != PBDRV_LEGODEV_PUP_UART_STATUS_DATA) {
+                DBG_ERR(ludev->last_err = "Received DATA before INFO was complete");
                 goto err;
             }
 
             #if PBDRV_CONFIG_LEGODEV_MODE_INFO
-            if (mode >= data->device_info.num_modes) {
-                DBG_ERR(data->last_err = "Invalid mode received");
+            if (mode >= ludev->device_info.num_modes) {
+                DBG_ERR(ludev->last_err = "Invalid mode received");
                 goto err;
             }
             #endif
 
             // Data is for requested mode.
-            if (mode == data->mode_switch.desired_mode) {
-                memcpy(data->bin_data, data->rx_msg + 1, msg_size - 2);
+            if (mode == ludev->mode_switch.desired_mode) {
+                memcpy(ludev->bin_data, ludev->rx_msg + 1, msg_size - 2);
 
-                if (data->device_info.mode != mode) {
+                if (ludev->device_info.mode != mode) {
                     // First time getting data in this mode, so register time.
-                    data->mode_switch.time = pbdrv_clock_get_ms();
+                    ludev->mode_switch.time = pbdrv_clock_get_ms();
                 }
             }
-            data->device_info.mode = mode;
+            ludev->device_info.mode = mode;
 
-            data->data_rec = true;
-            if (data->num_data_err) {
-                data->num_data_err--;
+            ludev->data_rec = true;
+            if (ludev->num_data_err) {
+                ludev->num_data_err--;
             }
             break;
     }
@@ -624,15 +624,15 @@ static void pbdrv_legodev_pup_uart_parse_msg(pbdrv_legodev_pup_uart_dev_t *data)
     return;
 
 err:
-    data->status = PBDRV_LEGODEV_PUP_UART_STATUS_ERR;
-    debug_pr("Data error: %s\n", data->last_err);
+    ludev->status = PBDRV_LEGODEV_PUP_UART_STATUS_ERR;
+    debug_pr("Data error: %s\n", ludev->last_err);
 }
 
 static uint8_t ev3_uart_set_msg_hdr(lump_msg_type_t type, lump_msg_size_t size, lump_cmd_t cmd) {
     return (type & LUMP_MSG_TYPE_MASK) | (size & LUMP_MSG_SIZE_MASK) | (cmd & LUMP_MSG_CMD_MASK);
 }
 
-static void ev3_uart_prepare_tx_msg(pbdrv_legodev_pup_uart_dev_t *port_data, lump_msg_type_t msg_type,
+static void ev3_uart_prepare_tx_msg(pbdrv_legodev_pup_uart_dev_t *ludev, lump_msg_type_t msg_type,
     lump_cmd_t cmd, const uint8_t *data, uint8_t len) {
     uint8_t header, checksum, i;
     uint8_t offset = 0;
@@ -641,15 +641,15 @@ static void ev3_uart_prepare_tx_msg(pbdrv_legodev_pup_uart_dev_t *port_data, lum
     if (msg_type == LUMP_MSG_TYPE_DATA) {
         // Only Powered Up devices support setting data, and they expect to have an
         // extra command sent to give the part of the mode > 7
-        port_data->tx_msg[0] = ev3_uart_set_msg_hdr(LUMP_MSG_TYPE_CMD, LUMP_MSG_SIZE_1, LUMP_CMD_EXT_MODE);
-        port_data->tx_msg[1] = port_data->device_info.mode > LUMP_MAX_MODE ? 8 : 0;
-        port_data->tx_msg[2] = 0xff ^ port_data->tx_msg[0] ^ port_data->tx_msg[1];
+        ludev->tx_msg[0] = ev3_uart_set_msg_hdr(LUMP_MSG_TYPE_CMD, LUMP_MSG_SIZE_1, LUMP_CMD_EXT_MODE);
+        ludev->tx_msg[1] = ludev->device_info.mode > LUMP_MAX_MODE ? 8 : 0;
+        ludev->tx_msg[2] = 0xff ^ ludev->tx_msg[0] ^ ludev->tx_msg[1];
         offset = 3;
     }
 
     checksum = 0xff;
     for (i = 0; i < len; i++) {
-        port_data->tx_msg[offset + i + 1] = data[i];
+        ludev->tx_msg[offset + i + 1] = data[i];
         checksum ^= data[i];
     }
 
@@ -674,73 +674,72 @@ static void ev3_uart_prepare_tx_msg(pbdrv_legodev_pup_uart_dev_t *port_data, lum
 
     // pad with zeros
     for (; i < len; i++) {
-        port_data->tx_msg[offset + i + 1] = 0;
+        ludev->tx_msg[offset + i + 1] = 0;
     }
 
     header = ev3_uart_set_msg_hdr(msg_type, size, cmd);
     checksum ^= header;
 
-    port_data->tx_msg[offset] = header;
-    port_data->tx_msg[offset + i + 1] = checksum;
-    port_data->tx_msg_size = offset + i + 2;
+    ludev->tx_msg[offset] = header;
+    ludev->tx_msg[offset + i + 1] = checksum;
+    ludev->tx_msg_size = offset + i + 2;
 }
 
-static PT_THREAD(pbdrv_legodev_pup_uart_send_prepared_msg(pbdrv_legodev_pup_uart_dev_t * data, pbio_error_t * err)) {
-    PT_BEGIN(&data->write_pt);
-    data->tx_start_time = pbdrv_clock_get_ms();
-    PBIO_PT_WAIT_READY(&data->write_pt, *err = pbdrv_uart_write_begin(data->uart, data->tx_msg, data->tx_msg_size, EV3_UART_IO_TIMEOUT));
+static PT_THREAD(pbdrv_legodev_pup_uart_send_prepared_msg(pbdrv_legodev_pup_uart_dev_t * ludev, pbio_error_t * err)) {
+    PT_BEGIN(&ludev->write_pt);
+    ludev->tx_start_time = pbdrv_clock_get_ms();
+    PBIO_PT_WAIT_READY(&ludev->write_pt, *err = pbdrv_uart_write_begin(ludev->uart, ludev->tx_msg, ludev->tx_msg_size, EV3_UART_IO_TIMEOUT));
     if (*err == PBIO_SUCCESS) {
-        PBIO_PT_WAIT_READY(&data->write_pt, *err = pbdrv_uart_write_end(data->uart));
+        PBIO_PT_WAIT_READY(&ludev->write_pt, *err = pbdrv_uart_write_end(ludev->uart));
     }
-    PT_END(&data->write_pt);
+    PT_END(&ludev->write_pt);
 }
 
-static PT_THREAD(pbdrv_legodev_pup_uart_update(pbdrv_legodev_pup_uart_dev_t * data)) {
+static PT_THREAD(pbdrv_legodev_pup_uart_update(pbdrv_legodev_pup_uart_dev_t * ludev)) {
     static pbio_error_t err;
-    uint8_t checksum;
 
-    PT_BEGIN(&data->pt);
+    PT_BEGIN(&ludev->pt);
 
     // reset state for new device
-    data->device_info.type_id = PBDRV_LEGODEV_TYPE_ID_NONE;
-    data->device_info.mode = 0;
-    data->ext_mode = 0;
+    ludev->device_info.type_id = PBDRV_LEGODEV_TYPE_ID_NONE;
+    ludev->device_info.mode = 0;
+    ludev->ext_mode = 0;
     #if PBDRV_CONFIG_LEGODEV_MODE_INFO
-    data->device_info.flags = PBDRV_LEGODEV_CAPABILITY_FLAG_NONE;
+    ludev->device_info.flags = PBDRV_LEGODEV_CAPABILITY_FLAG_NONE;
     #endif
-    data->status = PBDRV_LEGODEV_PUP_UART_STATUS_SYNCING;
+    ludev->status = PBDRV_LEGODEV_PUP_UART_STATUS_SYNCING;
 
     // Send SPEED command at 115200 baud
     debug_pr("set baud: %d\n", EV3_UART_SPEED_LPF2);
-    pbdrv_uart_set_baud_rate(data->uart, EV3_UART_SPEED_LPF2);
+    pbdrv_uart_set_baud_rate(ludev->uart, EV3_UART_SPEED_LPF2);
     uint8_t speed_payload[4];
     pbio_set_uint32_le(speed_payload, EV3_UART_SPEED_LPF2);
-    ev3_uart_prepare_tx_msg(data, LUMP_MSG_TYPE_CMD, LUMP_CMD_SPEED, speed_payload, sizeof(speed_payload));
+    ev3_uart_prepare_tx_msg(ludev, LUMP_MSG_TYPE_CMD, LUMP_CMD_SPEED, speed_payload, sizeof(speed_payload));
 
-    pbdrv_uart_flush(data->uart);
+    pbdrv_uart_flush(ludev->uart);
 
-    PT_SPAWN(&data->pt, &data->write_pt, pbdrv_legodev_pup_uart_send_prepared_msg(data, &err));
+    PT_SPAWN(&ludev->pt, &ludev->write_pt, pbdrv_legodev_pup_uart_send_prepared_msg(ludev, &err));
     if (err != PBIO_SUCCESS) {
-        DBG_ERR(data->last_err = "Speed tx failed");
+        DBG_ERR(ludev->last_err = "Speed tx failed");
         goto err;
     }
 
-    pbdrv_uart_flush(data->uart);
+    pbdrv_uart_flush(ludev->uart);
 
     // read one byte to check for ACK
-    PBIO_PT_WAIT_READY(&data->pt, err = pbdrv_uart_read_begin(data->uart, data->rx_msg, 1, 10));
+    PBIO_PT_WAIT_READY(&ludev->pt, err = pbdrv_uart_read_begin(ludev->uart, ludev->rx_msg, 1, 10));
     if (err != PBIO_SUCCESS) {
-        DBG_ERR(data->last_err = "UART Rx error during baud");
+        DBG_ERR(ludev->last_err = "UART Rx error during baud");
         goto err;
     }
 
-    PBIO_PT_WAIT_READY(&data->pt, err = pbdrv_uart_read_end(data->uart));
-    if ((err == PBIO_SUCCESS && data->rx_msg[0] != LUMP_SYS_ACK) || err == PBIO_ERROR_TIMEDOUT) {
+    PBIO_PT_WAIT_READY(&ludev->pt, err = pbdrv_uart_read_end(ludev->uart));
+    if ((err == PBIO_SUCCESS && ludev->rx_msg[0] != LUMP_SYS_ACK) || err == PBIO_ERROR_TIMEDOUT) {
         // if we did not get ACK within 100ms, then switch to slow baud rate for sync
-        pbdrv_uart_set_baud_rate(data->uart, EV3_UART_SPEED_MIN);
+        pbdrv_uart_set_baud_rate(ludev->uart, EV3_UART_SPEED_MIN);
         debug_pr("set baud: %d\n", EV3_UART_SPEED_MIN);
     } else if (err != PBIO_SUCCESS) {
-        DBG_ERR(data->last_err = "UART Rx error during baud");
+        DBG_ERR(ludev->last_err = "UART Rx error during baud");
         goto err;
     }
 
@@ -749,280 +748,280 @@ sync:
     // To get in sync with the data stream from the sensor, we look for a valid TYPE command.
     for (;;) {
 
-        PBIO_PT_WAIT_READY(&data->pt, err = pbdrv_uart_read_begin(data->uart, data->rx_msg, 1, EV3_UART_IO_TIMEOUT));
+        PBIO_PT_WAIT_READY(&ludev->pt, err = pbdrv_uart_read_begin(ludev->uart, ludev->rx_msg, 1, EV3_UART_IO_TIMEOUT));
         if (err != PBIO_SUCCESS) {
-            DBG_ERR(data->last_err = "UART Rx error during sync");
+            DBG_ERR(ludev->last_err = "UART Rx error during sync");
             goto err;
         }
-        PBIO_PT_WAIT_READY(&data->pt, err = pbdrv_uart_read_end(data->uart));
+        PBIO_PT_WAIT_READY(&ludev->pt, err = pbdrv_uart_read_end(ludev->uart));
         if (err == PBIO_ERROR_TIMEDOUT) {
             continue;
         }
         if (err != PBIO_SUCCESS) {
-            DBG_ERR(data->last_err = "UART Rx error during sync");
+            DBG_ERR(ludev->last_err = "UART Rx error during sync");
             goto err;
         }
 
-        if (data->rx_msg[0] == (LUMP_MSG_TYPE_CMD | LUMP_CMD_TYPE)) {
+        if (ludev->rx_msg[0] == (LUMP_MSG_TYPE_CMD | LUMP_CMD_TYPE)) {
             break;
         }
     }
 
     // then read the rest of the message
 
-    PBIO_PT_WAIT_READY(&data->pt, err = pbdrv_uart_read_begin(data->uart, data->rx_msg + 1, 2, EV3_UART_IO_TIMEOUT));
+    PBIO_PT_WAIT_READY(&ludev->pt, err = pbdrv_uart_read_begin(ludev->uart, ludev->rx_msg + 1, 2, EV3_UART_IO_TIMEOUT));
     if (err != PBIO_SUCCESS) {
-        DBG_ERR(data->last_err = "UART Rx error while reading type");
+        DBG_ERR(ludev->last_err = "UART Rx error while reading type");
         goto err;
     }
-    PBIO_PT_WAIT_READY(&data->pt, err = pbdrv_uart_read_end(data->uart));
+    PBIO_PT_WAIT_READY(&ludev->pt, err = pbdrv_uart_read_end(ludev->uart));
     if (err != PBIO_SUCCESS) {
-        DBG_ERR(data->last_err = "UART Rx error while reading type");
+        DBG_ERR(ludev->last_err = "UART Rx error while reading type");
         goto err;
     }
 
-    bool bad_id = data->rx_msg[1] < EV3_UART_TYPE_MIN || data->rx_msg[1] > EV3_UART_TYPE_MAX;
-    checksum = 0xff ^ data->rx_msg[0] ^ data->rx_msg[1];
-    bool bad_id_checksum = data->rx_msg[2] != checksum;
+    bool bad_id = ludev->rx_msg[1] < EV3_UART_TYPE_MIN || ludev->rx_msg[1] > EV3_UART_TYPE_MAX;
+    uint8_t checksum = 0xff ^ ludev->rx_msg[0] ^ ludev->rx_msg[1];
+    bool bad_id_checksum = ludev->rx_msg[2] != checksum;
 
     if (bad_id || bad_id_checksum) {
-        DBG_ERR(data->last_err = "Bad device type id or checksum");
-        if (data->err_count > 10) {
-            data->err_count = 0;
+        DBG_ERR(ludev->last_err = "Bad device type id or checksum");
+        if (ludev->err_count > 10) {
+            ludev->err_count = 0;
             goto err;
         }
-        data->err_count++;
+        ludev->err_count++;
         goto sync;
     }
 
     // if all was good, we are ready to start receiving the mode info
-    data->device_info.type_id = data->rx_msg[1];
-    data->data_rec = false;
-    data->num_data_err = 0;
-    data->status = PBDRV_LEGODEV_PUP_UART_STATUS_INFO;
+    ludev->device_info.type_id = ludev->rx_msg[1];
+    ludev->data_rec = false;
+    ludev->num_data_err = 0;
+    ludev->status = PBDRV_LEGODEV_PUP_UART_STATUS_INFO;
     #if PBDRV_CONFIG_LEGODEV_MODE_INFO
-    data->device_info.flags = PBDRV_LEGODEV_CAPABILITY_FLAG_NONE;
-    data->info_flags = EV3_UART_INFO_FLAG_CMD_TYPE;
-    data->device_info.num_modes = 1;
+    ludev->device_info.flags = PBDRV_LEGODEV_CAPABILITY_FLAG_NONE;
+    ludev->info_flags = EV3_UART_INFO_FLAG_CMD_TYPE;
+    ludev->device_info.num_modes = 1;
     #endif
-    debug_pr("type id: %d\n", data->device_info.type_id);
+    debug_pr("type id: %d\n", ludev->device_info.type_id);
 
-    while (data->status == PBDRV_LEGODEV_PUP_UART_STATUS_INFO) {
+    while (ludev->status == PBDRV_LEGODEV_PUP_UART_STATUS_INFO) {
         // read the message header
-        PBIO_PT_WAIT_READY(&data->pt, err = pbdrv_uart_read_begin(data->uart, data->rx_msg, 1, EV3_UART_IO_TIMEOUT));
+        PBIO_PT_WAIT_READY(&ludev->pt, err = pbdrv_uart_read_begin(ludev->uart, ludev->rx_msg, 1, EV3_UART_IO_TIMEOUT));
         if (err != PBIO_SUCCESS) {
-            DBG_ERR(data->last_err = "UART Rx begin error during info header");
+            DBG_ERR(ludev->last_err = "UART Rx begin error during info header");
             goto err;
         }
-        PBIO_PT_WAIT_READY(&data->pt, err = pbdrv_uart_read_end(data->uart));
+        PBIO_PT_WAIT_READY(&ludev->pt, err = pbdrv_uart_read_end(ludev->uart));
         if (err != PBIO_SUCCESS) {
-            DBG_ERR(data->last_err = "UART Rx end error during info header");
+            DBG_ERR(ludev->last_err = "UART Rx end error during info header");
             goto err;
         }
 
-        data->rx_msg_size = ev3_uart_get_msg_size(data->rx_msg[0]);
-        if (data->rx_msg_size > EV3_UART_MAX_MESSAGE_SIZE) {
-            DBG_ERR(data->last_err = "Bad message size during info");
+        ludev->rx_msg_size = ev3_uart_get_msg_size(ludev->rx_msg[0]);
+        if (ludev->rx_msg_size > EV3_UART_MAX_MESSAGE_SIZE) {
+            DBG_ERR(ludev->last_err = "Bad message size during info");
             goto err;
         }
 
         // read the rest of the message
-        if (data->rx_msg_size > 1) {
-            PBIO_PT_WAIT_READY(&data->pt, err = pbdrv_uart_read_begin(data->uart, data->rx_msg + 1, data->rx_msg_size - 1, EV3_UART_IO_TIMEOUT));
+        if (ludev->rx_msg_size > 1) {
+            PBIO_PT_WAIT_READY(&ludev->pt, err = pbdrv_uart_read_begin(ludev->uart, ludev->rx_msg + 1, ludev->rx_msg_size - 1, EV3_UART_IO_TIMEOUT));
             if (err != PBIO_SUCCESS) {
-                DBG_ERR(data->last_err = "UART Rx begin error during info");
+                DBG_ERR(ludev->last_err = "UART Rx begin error during info");
                 goto err;
             }
-            PBIO_PT_WAIT_READY(&data->pt, err = pbdrv_uart_read_end(data->uart));
+            PBIO_PT_WAIT_READY(&ludev->pt, err = pbdrv_uart_read_end(ludev->uart));
             if (err != PBIO_SUCCESS) {
-                DBG_ERR(data->last_err = "UART Rx end error during info");
+                DBG_ERR(ludev->last_err = "UART Rx end error during info");
                 goto err;
             }
         }
 
-        // at this point, we have a full data->msg that can be parsed
-        pbdrv_legodev_pup_uart_parse_msg(data);
+        // at this point, we have a full ludev->msg that can be parsed
+        pbdrv_legodev_pup_uart_parse_msg(ludev);
     }
 
     // at this point we should have read all of the mode info
-    if (data->status != PBDRV_LEGODEV_PUP_UART_STATUS_ACK) {
-        // data->last_err should be set by pbdrv_legodev_pup_uart_parse_msg()
+    if (ludev->status != PBDRV_LEGODEV_PUP_UART_STATUS_ACK) {
+        // ludev->last_err should be set by pbdrv_legodev_pup_uart_parse_msg()
         goto err;
     }
 
     // reply with ACK
-    data->tx_msg[0] = LUMP_SYS_ACK;
-    data->tx_msg_size = 1;
-    PT_SPAWN(&data->pt, &data->write_pt, pbdrv_legodev_pup_uart_send_prepared_msg(data, &err));
+    ludev->tx_msg[0] = LUMP_SYS_ACK;
+    ludev->tx_msg_size = 1;
+    PT_SPAWN(&ludev->pt, &ludev->write_pt, pbdrv_legodev_pup_uart_send_prepared_msg(ludev, &err));
     if (err != PBIO_SUCCESS) {
-        DBG_ERR(data->last_err = "UART Tx error during ack.");
+        DBG_ERR(ludev->last_err = "UART Tx error during ack.");
         goto err;
     }
 
     // schedule baud rate change
-    etimer_set(&data->timer, 10);
-    PT_WAIT_UNTIL(&data->pt, etimer_expired(&data->timer));
+    etimer_set(&ludev->timer, 10);
+    PT_WAIT_UNTIL(&ludev->pt, etimer_expired(&ludev->timer));
 
     // change the baud rate
-    pbdrv_uart_set_baud_rate(data->uart, data->new_baud_rate);
-    debug_pr("set baud: %" PRIu32 "\n", data->new_baud_rate);
+    pbdrv_uart_set_baud_rate(ludev->uart, ludev->new_baud_rate);
+    debug_pr("set baud: %" PRIu32 "\n", ludev->new_baud_rate);
 
-    data->status = PBDRV_LEGODEV_PUP_UART_STATUS_DATA;
+    ludev->status = PBDRV_LEGODEV_PUP_UART_STATUS_DATA;
     // reset data rx thread
-    PT_INIT(&data->data_pt);
+    PT_INIT(&ludev->data_pt);
 
     // Load static flags on platforms that don't read device info
     #if !PBDRV_CONFIG_LEGODEV_MODE_INFO
-    data->device_info.flags = pbdrv_legodev_spec_basic_flags(data->device_info.type_id);
+    ludev->device_info.flags = pbdrv_legodev_spec_basic_flags(ludev->device_info.type_id);
     #endif
 
     // Turn on power for devices that need it
-    if (data->device_info.flags & PBDRV_LEGODEV_CAPABILITY_FLAG_NEEDS_SUPPLY_PIN1) {
-        pbdrv_motor_driver_set_duty_cycle(data->dcmotor->motor_driver, -PBDRV_MOTOR_DRIVER_MAX_DUTY);
-    } else if (data->device_info.flags & PBDRV_LEGODEV_CAPABILITY_FLAG_NEEDS_SUPPLY_PIN2) {
-        pbdrv_motor_driver_set_duty_cycle(data->dcmotor->motor_driver, PBDRV_MOTOR_DRIVER_MAX_DUTY);
+    if (ludev->device_info.flags & PBDRV_LEGODEV_CAPABILITY_FLAG_NEEDS_SUPPLY_PIN1) {
+        pbdrv_motor_driver_set_duty_cycle(ludev->dcmotor->motor_driver, -PBDRV_MOTOR_DRIVER_MAX_DUTY);
+    } else if (ludev->device_info.flags & PBDRV_LEGODEV_CAPABILITY_FLAG_NEEDS_SUPPLY_PIN2) {
+        pbdrv_motor_driver_set_duty_cycle(ludev->dcmotor->motor_driver, PBDRV_MOTOR_DRIVER_MAX_DUTY);
     } else {
-        pbdrv_motor_driver_coast(data->dcmotor->motor_driver);
+        pbdrv_motor_driver_coast(ludev->dcmotor->motor_driver);
     }
 
     // Request switch to default mode for this device.
-    pbdrv_legodev_request_mode(data, pbdrv_legodev_spec_default_mode(data->device_info.type_id));
+    pbdrv_legodev_request_mode(ludev, pbdrv_legodev_spec_default_mode(ludev->device_info.type_id));
 
     // Reset other timers
-    etimer_reset_with_new_interval(&data->timer, EV3_UART_DATA_KEEP_ALIVE_TIMEOUT);
-    data->data_set->time = pbdrv_clock_get_ms();
-    data->data_set->size = 0;
+    etimer_reset_with_new_interval(&ludev->timer, EV3_UART_DATA_KEEP_ALIVE_TIMEOUT);
+    ludev->data_set->time = pbdrv_clock_get_ms();
+    ludev->data_set->size = 0;
 
-    while (data->status == PBDRV_LEGODEV_PUP_UART_STATUS_DATA) {
+    while (ludev->status == PBDRV_LEGODEV_PUP_UART_STATUS_DATA) {
 
-        PT_WAIT_UNTIL(&data->pt, etimer_expired(&data->timer) || data->mode_switch.requested || data->data_set->size > 0);
+        PT_WAIT_UNTIL(&ludev->pt, etimer_expired(&ludev->timer) || ludev->mode_switch.requested || ludev->data_set->size > 0);
 
         // Handle keep alive timeout
-        if (etimer_expired(&data->timer)) {
+        if (etimer_expired(&ludev->timer)) {
             // make sure we are receiving data
-            if (!data->data_rec) {
-                data->num_data_err++;
-                DBG_ERR(data->last_err = "No data since last keepalive");
-                if (data->num_data_err > 6) {
-                    data->status = PBDRV_LEGODEV_PUP_UART_STATUS_ERR;
+            if (!ludev->data_rec) {
+                ludev->num_data_err++;
+                DBG_ERR(ludev->last_err = "No data since last keepalive");
+                if (ludev->num_data_err > 6) {
+                    ludev->status = PBDRV_LEGODEV_PUP_UART_STATUS_ERR;
                     goto err;
                 }
             }
-            data->data_rec = false;
-            data->tx_msg[0] = LUMP_SYS_NACK;
-            data->tx_msg_size = 1;
-            PT_SPAWN(&data->pt, &data->write_pt, pbdrv_legodev_pup_uart_send_prepared_msg(data, &err));
+            ludev->data_rec = false;
+            ludev->tx_msg[0] = LUMP_SYS_NACK;
+            ludev->tx_msg_size = 1;
+            PT_SPAWN(&ludev->pt, &ludev->write_pt, pbdrv_legodev_pup_uart_send_prepared_msg(ludev, &err));
             if (err != PBIO_SUCCESS) {
-                DBG_ERR(data->last_err = "Error during keepalive.");
+                DBG_ERR(ludev->last_err = "Error during keepalive.");
                 goto err;
             }
-            etimer_reset_with_new_interval(&data->timer, EV3_UART_DATA_KEEP_ALIVE_TIMEOUT);
+            etimer_reset_with_new_interval(&ludev->timer, EV3_UART_DATA_KEEP_ALIVE_TIMEOUT);
 
             // Retry mode switch if it hasn't been handled or failed.
-            if (data->device_info.mode != data->mode_switch.desired_mode && pbdrv_clock_get_ms() - data->mode_switch.time > EV3_UART_IO_TIMEOUT) {
-                data->mode_switch.requested = true;
+            if (ludev->device_info.mode != ludev->mode_switch.desired_mode && pbdrv_clock_get_ms() - ludev->mode_switch.time > EV3_UART_IO_TIMEOUT) {
+                ludev->mode_switch.requested = true;
             }
         }
 
         // Handle requested mode change
-        if (data->mode_switch.requested) {
-            data->mode_switch.requested = false;
-            ev3_uart_prepare_tx_msg(data, LUMP_MSG_TYPE_CMD, LUMP_CMD_SELECT, &data->mode_switch.desired_mode, 1);
-            PT_SPAWN(&data->pt, &data->write_pt, pbdrv_legodev_pup_uart_send_prepared_msg(data, &err));
+        if (ludev->mode_switch.requested) {
+            ludev->mode_switch.requested = false;
+            ev3_uart_prepare_tx_msg(ludev, LUMP_MSG_TYPE_CMD, LUMP_CMD_SELECT, &ludev->mode_switch.desired_mode, 1);
+            PT_SPAWN(&ludev->pt, &ludev->write_pt, pbdrv_legodev_pup_uart_send_prepared_msg(ludev, &err));
             if (err != PBIO_SUCCESS) {
-                DBG_ERR(data->last_err = "Setting requested mode failed.");
+                DBG_ERR(ludev->last_err = "Setting requested mode failed.");
                 goto err;
             }
         }
 
         // Handle requested data set
-        if (data->data_set->size > 0) {
+        if (ludev->data_set->size > 0) {
             // Only set data if we are in the correct mode already.
-            if (data->device_info.mode == data->data_set->desired_mode) {
-                ev3_uart_prepare_tx_msg(data, LUMP_MSG_TYPE_DATA, data->data_set->desired_mode, data->data_set->bin_data, data->data_set->size);
-                data->data_set->size = 0;
-                data->data_set->time = pbdrv_clock_get_ms();
-                PT_SPAWN(&data->pt, &data->write_pt, pbdrv_legodev_pup_uart_send_prepared_msg(data, &err));
+            if (ludev->device_info.mode == ludev->data_set->desired_mode) {
+                ev3_uart_prepare_tx_msg(ludev, LUMP_MSG_TYPE_DATA, ludev->data_set->desired_mode, ludev->data_set->bin_data, ludev->data_set->size);
+                ludev->data_set->size = 0;
+                ludev->data_set->time = pbdrv_clock_get_ms();
+                PT_SPAWN(&ludev->pt, &ludev->write_pt, pbdrv_legodev_pup_uart_send_prepared_msg(ludev, &err));
                 if (err != PBIO_SUCCESS) {
-                    DBG_ERR(data->last_err = "Setting requested data failed.");
+                    DBG_ERR(ludev->last_err = "Setting requested data failed.");
                     goto err;
                 }
-                data->data_set->time = pbdrv_clock_get_ms();
-            } else if (pbdrv_clock_get_ms() - data->data_set->time < 500) {
+                ludev->data_set->time = pbdrv_clock_get_ms();
+            } else if (pbdrv_clock_get_ms() - ludev->data_set->time < 500) {
                 // Not in the right mode yet, try again later for a reasonable amount of time.
                 pbdrv_legodev_pup_uart_process_poll();
-                PT_YIELD(&data->pt);
+                PT_YIELD(&ludev->pt);
             } else {
                 // Give up setting data.
-                data->data_set->size = 0;
+                ludev->data_set->size = 0;
             }
         }
     }
 
 err:
     // reset and start over
-    data->status = PBDRV_LEGODEV_PUP_UART_STATUS_ERR;
-    etimer_stop(&data->timer);
-    debug_pr("%s\n", data->last_err);
+    ludev->status = PBDRV_LEGODEV_PUP_UART_STATUS_ERR;
+    etimer_stop(&ludev->timer);
+    debug_pr("%s\n", ludev->last_err);
 
     // Turn off battery supply to this port
-    pbdrv_motor_driver_coast(data->dcmotor->motor_driver);
+    pbdrv_motor_driver_coast(ludev->dcmotor->motor_driver);
 
-    PT_END(&data->pt);
+    PT_END(&ludev->pt);
 }
 
 // REVISIT: This is not the greatest. We can easily get a buffer overrun and
 // loose data. For now, the retry after bad message size helps get back into
 // sync with the data stream.
-static PT_THREAD(pbdrv_legodev_pup_uart_receive_data(pbdrv_legodev_pup_uart_dev_t * data)) {
+static PT_THREAD(pbdrv_legodev_pup_uart_receive_data(pbdrv_legodev_pup_uart_dev_t * ludev)) {
     pbio_error_t err;
 
-    PT_BEGIN(&data->data_pt);
+    PT_BEGIN(&ludev->data_pt);
 
     while (true) {
-        PBIO_PT_WAIT_READY(&data->data_pt,
-            err = pbdrv_uart_read_begin(data->uart, data->rx_msg, 1, EV3_UART_IO_TIMEOUT));
+        PBIO_PT_WAIT_READY(&ludev->data_pt,
+            err = pbdrv_uart_read_begin(ludev->uart, ludev->rx_msg, 1, EV3_UART_IO_TIMEOUT));
         if (err != PBIO_SUCCESS) {
-            DBG_ERR(data->last_err = "UART Rx data header begin error");
+            DBG_ERR(ludev->last_err = "UART Rx data header begin error");
             break;
         }
-        PBIO_PT_WAIT_READY(&data->data_pt, err = pbdrv_uart_read_end(data->uart));
+        PBIO_PT_WAIT_READY(&ludev->data_pt, err = pbdrv_uart_read_end(ludev->uart));
         if (err != PBIO_SUCCESS) {
-            DBG_ERR(data->last_err = "UART Rx data header end error");
+            DBG_ERR(ludev->last_err = "UART Rx data header end error");
             break;
         }
 
-        data->rx_msg_size = ev3_uart_get_msg_size(data->rx_msg[0]);
-        if (data->rx_msg_size < 3 || data->rx_msg_size > EV3_UART_MAX_MESSAGE_SIZE) {
-            DBG_ERR(data->last_err = "Bad data message size");
+        ludev->rx_msg_size = ev3_uart_get_msg_size(ludev->rx_msg[0]);
+        if (ludev->rx_msg_size < 3 || ludev->rx_msg_size > EV3_UART_MAX_MESSAGE_SIZE) {
+            DBG_ERR(ludev->last_err = "Bad data message size");
             continue;
         }
 
-        uint8_t msg_type = data->rx_msg[0] & LUMP_MSG_TYPE_MASK;
-        uint8_t cmd = data->rx_msg[0] & LUMP_MSG_CMD_MASK;
+        uint8_t msg_type = ludev->rx_msg[0] & LUMP_MSG_TYPE_MASK;
+        uint8_t cmd = ludev->rx_msg[0] & LUMP_MSG_CMD_MASK;
         if (msg_type != LUMP_MSG_TYPE_DATA && (msg_type != LUMP_MSG_TYPE_CMD ||
                                                (cmd != LUMP_CMD_WRITE && cmd != LUMP_CMD_EXT_MODE))) {
-            DBG_ERR(data->last_err = "Bad msg type");
+            DBG_ERR(ludev->last_err = "Bad msg type");
             continue;
         }
 
-        PBIO_PT_WAIT_READY(&data->data_pt,
-            err = pbdrv_uart_read_begin(data->uart, data->rx_msg + 1, data->rx_msg_size - 1, EV3_UART_IO_TIMEOUT));
+        PBIO_PT_WAIT_READY(&ludev->data_pt,
+            err = pbdrv_uart_read_begin(ludev->uart, ludev->rx_msg + 1, ludev->rx_msg_size - 1, EV3_UART_IO_TIMEOUT));
         if (err != PBIO_SUCCESS) {
-            DBG_ERR(data->last_err = "UART Rx data begin error");
+            DBG_ERR(ludev->last_err = "UART Rx data begin error");
             break;
         }
-        PBIO_PT_WAIT_READY(&data->data_pt, err = pbdrv_uart_read_end(data->uart));
+        PBIO_PT_WAIT_READY(&ludev->data_pt, err = pbdrv_uart_read_end(ludev->uart));
         if (err != PBIO_SUCCESS) {
-            DBG_ERR(data->last_err = "UART Rx data end error");
+            DBG_ERR(ludev->last_err = "UART Rx data end error");
             break;
         }
 
-        // at this point, we have a full data->msg that can be parsed
-        pbdrv_legodev_pup_uart_parse_msg(data);
+        // at this point, we have a full ludev->msg that can be parsed
+        pbdrv_legodev_pup_uart_parse_msg(ludev);
     }
 
-    PT_END(&data->data_pt);
+    PT_END(&ludev->data_pt);
 }
 
 /**
@@ -1043,12 +1042,12 @@ size_t pbdrv_legodev_size_of(pbdrv_legodev_data_type_t type) {
     return 0;
 }
 
-PT_THREAD(pbdrv_legodev_pup_uart_thread(struct pt *pt, pbdrv_legodev_pup_uart_dev_t *port_data)) {
+PT_THREAD(pbdrv_legodev_pup_uart_thread(struct pt *pt, pbdrv_legodev_pup_uart_dev_t *ludev)) {
     PT_BEGIN(pt);
-    PT_INIT(&port_data->pt);
-    while (PT_SCHEDULE(pbdrv_legodev_pup_uart_update(port_data))) {
-        if (port_data->status == PBDRV_LEGODEV_PUP_UART_STATUS_DATA) {
-            pbdrv_legodev_pup_uart_receive_data(port_data);
+    PT_INIT(&ludev->pt);
+    while (PT_SCHEDULE(pbdrv_legodev_pup_uart_update(ludev))) {
+        if (ludev->status == PBDRV_LEGODEV_PUP_UART_STATUS_DATA) {
+            pbdrv_legodev_pup_uart_receive_data(ludev);
         }
         PT_YIELD(pt);
     }
@@ -1066,29 +1065,29 @@ PT_THREAD(pbdrv_legodev_pup_uart_thread(struct pt *pt, pbdrv_legodev_pup_uart_de
  */
 pbio_error_t pbdrv_legodev_is_ready(pbdrv_legodev_dev_t *legodev) {
 
-    pbdrv_legodev_pup_uart_dev_t *port_data = pbdrv_legodev_get_uart_dev(legodev);
-    if (!port_data || port_data->status == PBDRV_LEGODEV_PUP_UART_STATUS_ERR) {
+    pbdrv_legodev_pup_uart_dev_t *ludev = pbdrv_legodev_get_uart_dev(legodev);
+    if (!ludev || ludev->status == PBDRV_LEGODEV_PUP_UART_STATUS_ERR) {
         return PBIO_ERROR_NO_DEV;
     }
 
-    if (port_data->status != PBDRV_LEGODEV_PUP_UART_STATUS_DATA) {
+    if (ludev->status != PBDRV_LEGODEV_PUP_UART_STATUS_DATA) {
         return PBIO_ERROR_AGAIN;
     }
 
     uint32_t time = pbdrv_clock_get_ms();
 
     // Not ready if waiting for mode change
-    if (port_data->device_info.mode != port_data->mode_switch.desired_mode) {
+    if (ludev->device_info.mode != ludev->mode_switch.desired_mode) {
         return PBIO_ERROR_AGAIN;
     }
 
     // Not ready if waiting for stale data to be discarded.
-    if (time - port_data->mode_switch.time <= pbdrv_legodev_spec_stale_data_delay(port_data->device_info.type_id, port_data->device_info.mode)) {
+    if (time - ludev->mode_switch.time <= pbdrv_legodev_spec_stale_data_delay(ludev->device_info.type_id, ludev->device_info.mode)) {
         return PBIO_ERROR_AGAIN;
     }
 
     // Not ready if just recently set new data.
-    if (port_data->data_set->size > 0 || time - port_data->data_set->time <= pbdrv_legodev_spec_data_set_delay(port_data->device_info.type_id, port_data->device_info.mode)) {
+    if (ludev->data_set->size > 0 || time - ludev->data_set->time <= pbdrv_legodev_spec_data_set_delay(ludev->device_info.type_id, ludev->device_info.mode)) {
         return PBIO_ERROR_AGAIN;
     }
 
@@ -1108,13 +1107,13 @@ pbio_error_t pbdrv_legodev_is_ready(pbdrv_legodev_dev_t *legodev) {
  */
 pbio_error_t pbdrv_legodev_set_mode(pbdrv_legodev_dev_t *legodev, uint8_t mode) {
 
-    pbdrv_legodev_pup_uart_dev_t *port_data = pbdrv_legodev_get_uart_dev(legodev);
-    if (!port_data) {
+    pbdrv_legodev_pup_uart_dev_t *ludev = pbdrv_legodev_get_uart_dev(legodev);
+    if (!ludev) {
         return PBIO_ERROR_NO_DEV;
     }
 
     // Mode already set or being set, so return success.
-    if (port_data->mode_switch.desired_mode == mode || port_data->device_info.mode == mode) {
+    if (ludev->mode_switch.desired_mode == mode || ludev->device_info.mode == mode) {
         return PBIO_SUCCESS;
     }
 
@@ -1126,13 +1125,13 @@ pbio_error_t pbdrv_legodev_set_mode(pbdrv_legodev_dev_t *legodev, uint8_t mode) 
 
     #if PBDRV_CONFIG_LEGODEV_MODE_INFO
     // Can only set available modes.
-    if (mode >= port_data->device_info.num_modes) {
+    if (mode >= ludev->device_info.num_modes) {
         return PBIO_ERROR_INVALID_ARG;
     }
     #endif
 
     // Request mode switch.
-    pbdrv_legodev_request_mode(port_data, mode);
+    pbdrv_legodev_request_mode(ludev, mode);
 
     return PBIO_SUCCESS;
 }
@@ -1150,25 +1149,25 @@ pbio_error_t pbdrv_legodev_set_mode(pbdrv_legodev_dev_t *legodev, uint8_t mode) 
  */
 pbio_error_t pbdrv_legodev_get_data(pbdrv_legodev_dev_t *legodev, uint8_t mode, void **data) {
 
-    pbdrv_legodev_pup_uart_dev_t *port_data = pbdrv_legodev_get_uart_dev(legodev);
-    if (!port_data) {
+    pbdrv_legodev_pup_uart_dev_t *ludev = pbdrv_legodev_get_uart_dev(legodev);
+    if (!ludev) {
         return PBIO_ERROR_NO_DEV;
     }
 
     // Can only request data for mode that is set.
-    if (mode != port_data->device_info.mode) {
+    if (mode != ludev->device_info.mode) {
         return PBIO_ERROR_INVALID_OP;
     }
 
     // Can only read if ready.
-    *data = port_data->bin_data;
+    *data = ludev->bin_data;
     return pbdrv_legodev_is_ready(legodev);
 }
 
 /**
  * Set data for the current mode.
  *
-* @param [in]  legodev     The legodev instance.
+ * @param [in]  legodev     The legodev instance.
  * @param [out] data        Data to be set.
  * @param [in]  size        Size of data to be set.
  * @return                  ::PBIO_SUCCESS on success.
@@ -1176,13 +1175,13 @@ pbio_error_t pbdrv_legodev_get_data(pbdrv_legodev_dev_t *legodev, uint8_t mode, 
  */
 pbio_error_t pbdrv_legodev_set_mode_with_data(pbdrv_legodev_dev_t *legodev, uint8_t mode, const void *data, uint8_t size) {
 
-    pbdrv_legodev_pup_uart_dev_t *port_data = pbdrv_legodev_get_uart_dev(legodev);
-    if (!port_data) {
+    pbdrv_legodev_pup_uart_dev_t *ludev = pbdrv_legodev_get_uart_dev(legodev);
+    if (!ludev) {
         return PBIO_ERROR_NO_DEV;
     }
 
     #if PBDRV_CONFIG_LEGODEV_MODE_INFO
-    const pbdrv_legodev_mode_info_t *mode_info = &port_data->device_info.mode_info[mode];
+    const pbdrv_legodev_mode_info_t *mode_info = &ludev->device_info.mode_info[mode];
     // Not all modes support setting data and data must be of expected size.
     if (!mode_info->writable || size != mode_info->num_values * pbdrv_legodev_size_of(mode_info->data_type)) {
         return PBIO_ERROR_INVALID_OP;
@@ -1196,19 +1195,19 @@ pbio_error_t pbdrv_legodev_set_mode_with_data(pbdrv_legodev_dev_t *legodev, uint
     }
 
     // Request data set.
-    pbdrv_legodev_request_data_set(port_data, mode, data, size);
+    pbdrv_legodev_request_data_set(ludev, mode, data, size);
     return PBIO_SUCCESS;
 }
 
 pbio_error_t pbdrv_legodev_get_info(pbdrv_legodev_dev_t *legodev, pbdrv_legodev_info_t **info) {
 
-    pbdrv_legodev_pup_uart_dev_t *port_data = pbdrv_legodev_get_uart_dev(legodev);
-    if (!port_data) {
+    pbdrv_legodev_pup_uart_dev_t *ludev = pbdrv_legodev_get_uart_dev(legodev);
+    if (!ludev) {
         return PBIO_ERROR_NO_DEV;
     }
     // Info is set even in case of error. Caller can decide what values apply
     // based on the error code.
-    *info = &port_data->device_info;
+    *info = &ludev->device_info;
     return pbdrv_legodev_is_ready(legodev);
 }
 

--- a/lib/pbio/drv/legodev/legodev_pup_uart.c
+++ b/lib/pbio/drv/legodev/legodev_pup_uart.c
@@ -122,33 +122,33 @@ enum ev3_uart_info_flags {
 typedef enum {
     /** Something bad happened. */
     PBDRV_LEGODEV_PUP_UART_STATUS_ERR,
-    /**< Waiting for data that looks like LEGO UART protocol. */
+    /** Waiting for data that looks like LEGO UART protocol. */
     PBDRV_LEGODEV_PUP_UART_STATUS_SYNCING,
-    /**< Reading device info before changing baud rate. */
+    /** Reading device info before changing baud rate. */
     PBDRV_LEGODEV_PUP_UART_STATUS_INFO,
-    /**< ACK received, delay changing baud rate. */
+    /** ACK received, delay changing baud rate. */
     PBDRV_LEGODEV_PUP_UART_STATUS_ACK,
-    /**< Ready to send commands and receive data. */
+    /** Ready to send commands and receive data. */
     PBDRV_LEGODEV_PUP_UART_STATUS_DATA,
 } pbdrv_legodev_pup_uart_status_t;
 
 typedef struct {
-    /**< The mode to be set. */
+    /** The mode to be set. */
     uint8_t desired_mode;
-    /**< Whether a mode change was requested (set low when handled). */
+    /** Whether a mode change was requested (set low when handled). */
     bool requested;
-    /**< Time of switch completion (if info.mode == desired_mode) or time of switch request (if info.mode != desired_mode). */
+    /** Time of switch completion (if info.mode == desired_mode) or time of switch request (if info.mode != desired_mode). */
     uint32_t time;
 } pbdrv_legodev_pup_uart_mode_switch_t;
 
 typedef struct {
-    /**< The data to be set. */
+    /** The data to be set. */
     uint8_t bin_data[PBDRV_LEGODEV_MAX_DATA_SIZE]  __attribute__((aligned(4)));
-    /**< The size of the data to be set, also acts as set request flag. */
+    /** The size of the data to be set, also acts as set request flag. */
     uint8_t size;
-    /**< The mode at which to set data */
+    /** The mode at which to set data */
     uint8_t desired_mode;
-    /**< Time of the data set request (if size != 0) or time of completing transmission (if size == 0). */
+    /** Time of the data set request (if size != 0) or time of completing transmission (if size == 0). */
     uint32_t time;
 } pbdrv_legodev_pup_uart_data_set_t;
 
@@ -156,19 +156,19 @@ typedef struct {
  * struct ev3_uart_port_data - Data for EV3/LPF2 UART Sensor communication
  */
 struct _pbdrv_legodev_pup_uart_dev_t {
-    /**< Main protothread, first used for synchronization thread and then for data send thread. */
+    /** Main protothread, first used for synchronization thread and then for data send thread. */
     struct pt pt;
-    /**< Protothread for receiving sensor data, running in parallel to the data send thread. */
+    /** Protothread for receiving sensor data, running in parallel to the data send thread. */
     struct pt recv_pt;
-    /**< Child protothread of the main protothread used for writing data */
+    /** Child protothread of the main protothread used for writing data */
     struct pt write_pt;
-    /**< Timer for sending keepalive messages and other delays. */
+    /** Timer for sending keepalive messages and other delays. */
     struct etimer timer;
-    /**< Device information, including mode info */
+    /** Device information, including mode info */
     pbdrv_legodev_info_t device_info;
-    /**< Pointer to the UART device to use for communications. */
+    /** Pointer to the UART device to use for communications. */
     pbdrv_uart_dev_t *uart;
-    /**< Pointer to the DC motor device to use for powered devices. */
+    /** Pointer to the DC motor device to use for powered devices. */
     pbio_dcmotor_t *dcmotor;
     /**
      * Most recent binary data read from the device. How to interpret this data
@@ -177,40 +177,40 @@ struct _pbdrv_legodev_pup_uart_dev_t {
      * the values could be foreign-endian.
      */
     uint8_t *bin_data;
-    /**< The current device connection state. */
+    /** The current device connection state. */
     pbdrv_legodev_pup_uart_status_t status;
-    /**< Mode switch status. */
+    /** Mode switch status. */
     pbdrv_legodev_pup_uart_mode_switch_t mode_switch;
-    /**< Data set buffer and status. */
+    /** Data set buffer and status. */
     pbdrv_legodev_pup_uart_data_set_t *data_set;
-    /**< Extra mode adder for Powered Up devices (for modes > LUMP_MAX_MODE). */
+    /** Extra mode adder for Powered Up devices (for modes > LUMP_MAX_MODE). */
     uint8_t ext_mode;
-    /**< New baud rate that will be set with ev3_uart_change_bitrate. */
+    /** New baud rate that will be set with ev3_uart_change_bitrate. */
     uint32_t new_baud_rate;
-    /**< Buffer to hold messages transmitted to the device. */
+    /** Buffer to hold messages transmitted to the device. */
     uint8_t *tx_msg;
-    /**< Size of the current message being transmitted. */
+    /** Size of the current message being transmitted. */
     uint8_t tx_msg_size;
-    /**< Buffer to hold messages received from the device. */
+    /** Buffer to hold messages received from the device. */
     uint8_t *rx_msg;
-    /**< Size of the current message being received. */
+    /** Size of the current message being received. */
     uint8_t rx_msg_size;
-    /**< Total number of errors that have occurred. */
+    /** Total number of errors that have occurred. */
     uint32_t err_count;
-    /**< Number of bad reads when receiving DATA ludev->msgs. */
+    /** Number of bad reads when receiving DATA ludev->msgs. */
     uint32_t num_data_err;
-    /**< Time of most recently started transmission. */
+    /** Time of most recently started transmission. */
     uint32_t tx_start_time;
-    /**< Flag that indicates that good DATA ludev->msg has been received since last watchdog timeout. */
+    /** Flag that indicates that good DATA ludev->msg has been received since last watchdog timeout. */
     bool data_rec;
-    /**< Return value for synchronization thread. */
+    /** Return value for synchronization thread. */
     pbio_error_t err;
-    /**< ludev->msg to be printed in case of an error. */
+    /** ludev->msg to be printed in case of an error. */
     DBG_ERR(const char *last_err);
     #if PBDRV_CONFIG_LEGODEV_MODE_INFO
-    /**< Mode value used to keep track of mode in INFO messages while syncing. */
+    /** Mode value used to keep track of mode in INFO messages while syncing. */
     uint8_t new_mode;
-    /**< Flags indicating what information has already been read from the data. */
+    /** Flags indicating what information has already been read from the data. */
     uint32_t info_flags;
     #endif // #define PBDRV_CONFIG_LEGODEV_MODE_INFO
 };

--- a/lib/pbio/drv/legodev/legodev_pup_uart.h
+++ b/lib/pbio/drv/legodev/legodev_pup_uart.h
@@ -35,6 +35,11 @@ static inline pbdrv_legodev_pup_uart_dev_t *pbdrv_legodev_get_uart_dev(pbdrv_leg
     return NULL;
 }
 
+static inline PT_THREAD(pbdrv_legodev_pup_uart_thread(struct pt *pt, pbdrv_legodev_pup_uart_dev_t *port_data)) {
+    PT_BEGIN(pt);
+    PT_END(pt);
+}
+
 static inline void pbdrv_legodev_pup_uart_process_poll(void) {
 }
 

--- a/lib/pbio/drv/legodev/legodev_pup_uart.h
+++ b/lib/pbio/drv/legodev/legodev_pup_uart.h
@@ -6,8 +6,9 @@
 
 #include <pbdrv/config.h>
 
-#include <pbio/dcmotor.h>
+#include <contiki.h>
 
+#include <pbio/dcmotor.h>
 
 /**
  * Opaque handle to a legodev pup UART device instance.
@@ -17,13 +18,12 @@ typedef struct _pbdrv_legodev_pup_uart_dev_t pbdrv_legodev_pup_uart_dev_t;
 #if PBDRV_CONFIG_LEGODEV_PUP_UART
 
 pbdrv_legodev_pup_uart_dev_t *pbdrv_legodev_pup_uart_configure(uint8_t device_index, uint8_t uart_driver_index, pbio_dcmotor_t *dcmotor);
-void pbdrv_legodev_pup_uart_process_start(void);
-void pbdrv_legodev_pup_uart_process_poll(void);
-void pbdrv_legodev_pup_uart_process_exit(void);
-
-void pbdrv_legodev_pup_uart_start_sync(pbdrv_legodev_pup_uart_dev_t *dev);
 
 pbdrv_legodev_pup_uart_dev_t *pbdrv_legodev_get_uart_dev(pbdrv_legodev_dev_t *legodev);
+
+PT_THREAD(pbdrv_legodev_pup_uart_thread(struct pt *pt, pbdrv_legodev_pup_uart_dev_t *port_data));
+
+void pbdrv_legodev_pup_uart_process_poll(void);
 
 #else // PBDRV_CONFIG_LEGODEV_PUP_UART
 
@@ -31,20 +31,11 @@ static inline pbdrv_legodev_pup_uart_dev_t *pbdrv_legodev_pup_uart_configure(uin
     return NULL;
 }
 
-static inline void pbdrv_legodev_pup_uart_process_start(void) {
+static inline pbdrv_legodev_pup_uart_dev_t *pbdrv_legodev_get_uart_dev(pbdrv_legodev_dev_t *legodev) {
+    return NULL;
 }
 
 static inline void pbdrv_legodev_pup_uart_process_poll(void) {
-}
-
-static inline void pbdrv_legodev_pup_uart_process_exit(void) {
-}
-
-static inline void pbdrv_legodev_pup_uart_start_sync(pbdrv_legodev_pup_uart_dev_t *dev) {
-}
-
-static inline pbdrv_legodev_pup_uart_dev_t *pbdrv_legodev_get_uart_dev(pbdrv_legodev_dev_t *legodev) {
-    return NULL;
 }
 
 #endif // PBDRV_CONFIG_LEGODEV_PUP_UART

--- a/lib/pbio/drv/legodev/legodev_test.h
+++ b/lib/pbio/drv/legodev/legodev_test.h
@@ -22,6 +22,8 @@ typedef struct {
 extern const pbdrv_legodev_test_platform_data_t
     pbdrv_legodev_test_platform_data[PBDRV_CONFIG_LEGODEV_TEST_NUM_DEV];
 
+void pbdrv_legodev_test_start_process(void);
+
 #endif // PBDRV_CONFIG_LEGODEV_TEST
 
 #endif // _INTERNAL_PBDRV_LEGODEV_TEST_H_

--- a/lib/pbio/drv/uart/uart.h
+++ b/lib/pbio/drv/uart/uart.h
@@ -17,7 +17,8 @@ void pbdrv_uart_init(void);
 
 #else // PBDRV_CONFIG_UART
 
-#define pbdrv_uart_init()
+static inline void pbdrv_uart_init() {
+}
 
 #endif // PBDRV_CONFIG_UART
 

--- a/lib/pbio/drv/uart/uart.h
+++ b/lib/pbio/drv/uart/uart.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2022 The Pybricks Authors
+// Copyright (c) 2023 The Pybricks Authors
 
 // Common interface shared by UART drivers
 

--- a/lib/pbio/drv/uart/uart.h
+++ b/lib/pbio/drv/uart/uart.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022 The Pybricks Authors
+
+// Common interface shared by UART drivers
+
+#ifndef _INTERNAL_PBDRV_UART_H_
+#define _INTERNAL_PBDRV_UART_H_
+
+#include <pbdrv/config.h>
+
+#if PBDRV_CONFIG_UART
+
+/**
+ * Initializes the UART driver.
+ */
+void pbdrv_uart_init(void);
+
+#else // PBDRV_CONFIG_UART
+
+#define pbdrv_uart_init()
+
+#endif // PBDRV_CONFIG_UART
+
+#endif // _INTERNAL_PBDRV_UART_H_

--- a/lib/pbio/drv/uart/uart_stm32f0.c
+++ b/lib/pbio/drv/uart/uart_stm32f0.c
@@ -22,6 +22,7 @@
 #include <pbio/util.h>
 
 #include "../../src/processes.h"
+#include "../core.h"
 
 #include "stm32f0xx.h"
 #include "uart_stm32f0.h"
@@ -244,11 +245,17 @@ static void handle_exit(void) {
     }
 }
 
+void pbdrv_uart_init(void) {
+    process_start(&pbdrv_uart_process);
+}
+
 PROCESS_THREAD(pbdrv_uart_process, ev, data) {
     PROCESS_POLLHANDLER(handle_poll());
     PROCESS_EXITHANDLER(handle_exit());
 
     PROCESS_BEGIN();
+
+    pbdrv_init_busy_up();
 
     for (int i = 0; i < PBDRV_CONFIG_UART_STM32F0_NUM_UART; i++) {
         const pbdrv_uart_stm32f0_platform_data_t *pdata = &pbdrv_uart_stm32f0_platform_data[i];
@@ -264,6 +271,8 @@ PROCESS_THREAD(pbdrv_uart_process, ev, data) {
 
         uart->initialized = true;
     }
+
+    pbdrv_init_busy_down();
 
     while (true) {
         PROCESS_WAIT_EVENT();

--- a/lib/pbio/drv/uart/uart_stm32f0.c
+++ b/lib/pbio/drv/uart/uart_stm32f0.c
@@ -246,6 +246,7 @@ static void handle_exit(void) {
 }
 
 void pbdrv_uart_init(void) {
+    pbdrv_init_busy_up();
     process_start(&pbdrv_uart_process);
 }
 
@@ -254,8 +255,6 @@ PROCESS_THREAD(pbdrv_uart_process, ev, data) {
     PROCESS_EXITHANDLER(handle_exit());
 
     PROCESS_BEGIN();
-
-    pbdrv_init_busy_up();
 
     for (int i = 0; i < PBDRV_CONFIG_UART_STM32F0_NUM_UART; i++) {
         const pbdrv_uart_stm32f0_platform_data_t *pdata = &pbdrv_uart_stm32f0_platform_data[i];

--- a/lib/pbio/drv/uart/uart_stm32f4_ll_irq.c
+++ b/lib/pbio/drv/uart/uart_stm32f4_ll_irq.c
@@ -249,6 +249,7 @@ static void handle_exit(void) {
 }
 
 void pbdrv_uart_init(void) {
+    pbdrv_init_busy_up();
     process_start(&pbdrv_uart_process);
 }
 
@@ -257,8 +258,6 @@ PROCESS_THREAD(pbdrv_uart_process, ev, data) {
     PROCESS_EXITHANDLER(handle_exit());
 
     PROCESS_BEGIN();
-
-    pbdrv_init_busy_up();
 
     for (int i = 0; i < PBDRV_CONFIG_UART_STM32F4_LL_IRQ_NUM_UART; i++) {
         const pbdrv_uart_stm32f4_ll_irq_platform_data_t *pdata = &pbdrv_uart_stm32f4_ll_irq_platform_data[i];

--- a/lib/pbio/drv/uart/uart_stm32l4_ll_dma.c
+++ b/lib/pbio/drv/uart/uart_stm32l4_ll_dma.c
@@ -384,6 +384,7 @@ static void handle_exit(void) {
 }
 
 void pbdrv_uart_init(void) {
+    pbdrv_init_busy_up();
     process_start(&pbdrv_uart_process);
 }
 
@@ -392,8 +393,6 @@ PROCESS_THREAD(pbdrv_uart_process, ev, data) {
     PROCESS_EXITHANDLER(handle_exit());
 
     PROCESS_BEGIN();
-
-    pbdrv_init_busy_up();
 
     for (int i = 0; i < PBDRV_CONFIG_UART_STM32L4_LL_DMA_NUM_UART; i++) {
         const pbdrv_uart_stm32l4_ll_dma_platform_data_t *pdata = &pbdrv_uart_stm32l4_ll_dma_platform_data[i];

--- a/lib/pbio/platform/city_hub/pbdrvconfig.h
+++ b/lib/pbio/platform/city_hub/pbdrvconfig.h
@@ -45,6 +45,7 @@
 #define PBDRV_CONFIG_IOPORT                         (1)
 #define PBDRV_CONFIG_IOPORT_PUP                     (1)
 #define PBDRV_CONFIG_IOPORT_NUM_DEV                 (2)
+#define PBDRV_CONFIG_IOPORT_PUP_QUIRK_POWER_CYCLE   (1)
 
 #define PBDRV_CONFIG_LED                            (1)
 #define PBDRV_CONFIG_LED_NUM_DEV                    (1)
@@ -53,7 +54,6 @@
 
 #define PBDRV_CONFIG_LEGODEV                        (1)
 #define PBDRV_CONFIG_LEGODEV_PUP                    (1)
-#define PBDRV_CONFIG_LEGODEV_PUP_POWER_CYCLE_PORTS  (1)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_INT_DEV        (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV        (2)
 #define PBDRV_CONFIG_LEGODEV_PUP_UART               (1)

--- a/lib/pbio/platform/city_hub/pbdrvconfig.h
+++ b/lib/pbio/platform/city_hub/pbdrvconfig.h
@@ -53,6 +53,7 @@
 
 #define PBDRV_CONFIG_LEGODEV                        (1)
 #define PBDRV_CONFIG_LEGODEV_PUP                    (1)
+#define PBDRV_CONFIG_LEGODEV_PUP_POWER_CYCLE_PORTS  (1)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_INT_DEV        (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV        (2)
 #define PBDRV_CONFIG_LEGODEV_PUP_UART               (1)

--- a/lib/pbio/platform/essential_hub/pbdrvconfig.h
+++ b/lib/pbio/platform/essential_hub/pbdrvconfig.h
@@ -68,6 +68,7 @@
 #define PBDRV_CONFIG_IOPORT                         (1)
 #define PBDRV_CONFIG_IOPORT_PUP                     (1)
 #define PBDRV_CONFIG_IOPORT_NUM_DEV                 (2)
+#define PBDRV_CONFIG_IOPORT_PUP_QUIRK_POWER_CYCLE   (0)
 
 #define PBDRV_CONFIG_LED                            (1)
 #define PBDRV_CONFIG_LED_NUM_DEV                    (2)
@@ -76,7 +77,6 @@
 
 #define PBDRV_CONFIG_LEGODEV                        (1)
 #define PBDRV_CONFIG_LEGODEV_PUP                    (1)
-#define PBDRV_CONFIG_LEGODEV_PUP_POWER_CYCLE_PORTS  (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_INT_DEV        (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV        (2)
 #define PBDRV_CONFIG_LEGODEV_PUP_UART               (1)

--- a/lib/pbio/platform/essential_hub/pbdrvconfig.h
+++ b/lib/pbio/platform/essential_hub/pbdrvconfig.h
@@ -76,6 +76,7 @@
 
 #define PBDRV_CONFIG_LEGODEV                        (1)
 #define PBDRV_CONFIG_LEGODEV_PUP                    (1)
+#define PBDRV_CONFIG_LEGODEV_PUP_POWER_CYCLE_PORTS  (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_INT_DEV        (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV        (2)
 #define PBDRV_CONFIG_LEGODEV_PUP_UART               (1)

--- a/lib/pbio/platform/move_hub/pbdrvconfig.h
+++ b/lib/pbio/platform/move_hub/pbdrvconfig.h
@@ -43,6 +43,7 @@
 #define PBDRV_CONFIG_IOPORT                         (1)
 #define PBDRV_CONFIG_IOPORT_PUP                     (1)
 #define PBDRV_CONFIG_IOPORT_NUM_DEV                 (2)
+#define PBDRV_CONFIG_IOPORT_PUP_QUIRK_POWER_CYCLE   (0)
 
 #define PBDRV_CONFIG_LED                            (1)
 #define PBDRV_CONFIG_LED_NUM_DEV                    (1)
@@ -51,7 +52,6 @@
 
 #define PBDRV_CONFIG_LEGODEV                        (1)
 #define PBDRV_CONFIG_LEGODEV_PUP                    (1)
-#define PBDRV_CONFIG_LEGODEV_PUP_POWER_CYCLE_PORTS  (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_INT_DEV        (2)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV        (2)
 #define PBDRV_CONFIG_LEGODEV_PUP_UART               (1)

--- a/lib/pbio/platform/move_hub/pbdrvconfig.h
+++ b/lib/pbio/platform/move_hub/pbdrvconfig.h
@@ -51,6 +51,7 @@
 
 #define PBDRV_CONFIG_LEGODEV                        (1)
 #define PBDRV_CONFIG_LEGODEV_PUP                    (1)
+#define PBDRV_CONFIG_LEGODEV_PUP_POWER_CYCLE_PORTS  (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_INT_DEV        (2)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV        (2)
 #define PBDRV_CONFIG_LEGODEV_PUP_UART               (1)

--- a/lib/pbio/platform/prime_hub/pbdrvconfig.h
+++ b/lib/pbio/platform/prime_hub/pbdrvconfig.h
@@ -84,6 +84,7 @@
 
 #define PBDRV_CONFIG_LEGODEV                        (1)
 #define PBDRV_CONFIG_LEGODEV_PUP                    (1)
+#define PBDRV_CONFIG_LEGODEV_PUP_POWER_CYCLE_PORTS  (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_INT_DEV        (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV        (6)
 #define PBDRV_CONFIG_LEGODEV_PUP_UART               (1)

--- a/lib/pbio/platform/prime_hub/pbdrvconfig.h
+++ b/lib/pbio/platform/prime_hub/pbdrvconfig.h
@@ -69,6 +69,7 @@
 #define PBDRV_CONFIG_IOPORT                         (1)
 #define PBDRV_CONFIG_IOPORT_PUP                     (1)
 #define PBDRV_CONFIG_IOPORT_NUM_DEV                 (6)
+#define PBDRV_CONFIG_IOPORT_PUP_QUIRK_POWER_CYCLE   (0)
 
 #define PBDRV_CONFIG_LED                            (1)
 #define PBDRV_CONFIG_LED_NUM_DEV                    (5)
@@ -84,7 +85,6 @@
 
 #define PBDRV_CONFIG_LEGODEV                        (1)
 #define PBDRV_CONFIG_LEGODEV_PUP                    (1)
-#define PBDRV_CONFIG_LEGODEV_PUP_POWER_CYCLE_PORTS  (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_INT_DEV        (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV        (6)
 #define PBDRV_CONFIG_LEGODEV_PUP_UART               (1)

--- a/lib/pbio/platform/technic_hub/pbdrvconfig.h
+++ b/lib/pbio/platform/technic_hub/pbdrvconfig.h
@@ -62,6 +62,7 @@
 
 #define PBDRV_CONFIG_LEGODEV                        (1)
 #define PBDRV_CONFIG_LEGODEV_PUP                    (1)
+#define PBDRV_CONFIG_LEGODEV_PUP_POWER_CYCLE_PORTS  (1)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_INT_DEV        (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV        (4)
 #define PBDRV_CONFIG_LEGODEV_PUP_UART               (1)

--- a/lib/pbio/platform/technic_hub/pbdrvconfig.h
+++ b/lib/pbio/platform/technic_hub/pbdrvconfig.h
@@ -54,6 +54,7 @@
 #define PBDRV_CONFIG_IOPORT                         (1)
 #define PBDRV_CONFIG_IOPORT_PUP                     (1)
 #define PBDRV_CONFIG_IOPORT_NUM_DEV                 (4)
+#define PBDRV_CONFIG_IOPORT_PUP_QUIRK_POWER_CYCLE   (1)
 
 #define PBDRV_CONFIG_LED                            (1)
 #define PBDRV_CONFIG_LED_NUM_DEV                    (1)
@@ -62,7 +63,6 @@
 
 #define PBDRV_CONFIG_LEGODEV                        (1)
 #define PBDRV_CONFIG_LEGODEV_PUP                    (1)
-#define PBDRV_CONFIG_LEGODEV_PUP_POWER_CYCLE_PORTS  (1)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_INT_DEV        (0)
 #define PBDRV_CONFIG_LEGODEV_PUP_NUM_EXT_DEV        (4)
 #define PBDRV_CONFIG_LEGODEV_PUP_UART               (1)

--- a/lib/pbio/src/main.c
+++ b/lib/pbio/src/main.c
@@ -31,9 +31,6 @@ AUTOSTART_PROCESSES(
 #if PBDRV_CONFIG_ADC
     &pbdrv_adc_process,
 #endif
-#if PBDRV_CONFIG_UART
-    &pbdrv_uart_process,
-#endif
     NULL);
 
 /**

--- a/lib/pbio/test/src/test_uartdev.c
+++ b/lib/pbio/test/src/test_uartdev.c
@@ -19,7 +19,9 @@
 #include <pbio/util.h>
 #include <test-pbio.h>
 
+#include "../drv/legodev/legodev.h"
 #include "../drv/legodev/legodev_pup_uart.h"
+#include "../drv/legodev/legodev_test.h"
 
 #include "../src/processes.h"
 #include "../drv/clock/clock_test.h"
@@ -229,12 +231,11 @@ static PT_THREAD(test_boost_color_distance_sensor(struct pt *pt)) {
 
     PT_BEGIN(pt);
 
+    pbdrv_legodev_test_start_process();
+
     // Expect no device at first.
     pbdrv_legodev_type_id_t id = PBDRV_LEGODEV_TYPE_ID_NONE;
     tt_uint_op(pbdrv_legodev_get_device(PBIO_PORT_ID_D, &id, &legodev), ==, PBIO_SUCCESS);
-
-    pbdrv_legodev_pup_uart_process_start();
-    pbdrv_legodev_pup_uart_start_sync(pbdrv_legodev_get_uart_dev(legodev));
 
     // starting baud rate of hub
     PT_WAIT_UNTIL(pt, ({
@@ -467,7 +468,6 @@ static PT_THREAD(test_boost_color_distance_sensor(struct pt *pt)) {
     PT_YIELD(pt);
 
 end:
-    pbdrv_legodev_pup_uart_process_exit();
 
     PT_END(pt);
 }
@@ -526,12 +526,11 @@ static PT_THREAD(test_boost_interactive_motor(struct pt *pt)) {
 
     PT_BEGIN(pt);
 
+    pbdrv_legodev_test_start_process();
+
     // Expect no device at first.
     pbdrv_legodev_type_id_t id = PBDRV_LEGODEV_TYPE_ID_NONE;
     tt_uint_op(pbdrv_legodev_get_device(PBIO_PORT_ID_D, &id, &legodev), ==, PBIO_SUCCESS);
-
-    pbdrv_legodev_pup_uart_process_start();
-    pbdrv_legodev_pup_uart_start_sync(pbdrv_legodev_get_uart_dev(legodev));
 
     // starting baud rate of hub
     PT_WAIT_UNTIL(pt, ({
@@ -631,7 +630,6 @@ static PT_THREAD(test_boost_interactive_motor(struct pt *pt)) {
     PT_YIELD(pt);
 
 end:
-    pbdrv_legodev_pup_uart_process_exit();
 
     PT_END(pt);
 }
@@ -709,12 +707,11 @@ static PT_THREAD(test_technic_large_motor(struct pt *pt)) {
 
     PT_BEGIN(pt);
 
+    pbdrv_legodev_test_start_process();
+
     // Expect no device at first.
     pbdrv_legodev_type_id_t id = PBDRV_LEGODEV_TYPE_ID_NONE;
     tt_uint_op(pbdrv_legodev_get_device(PBIO_PORT_ID_D, &id, &legodev), ==, PBIO_SUCCESS);
-
-    pbdrv_legodev_pup_uart_process_start();
-    pbdrv_legodev_pup_uart_start_sync(pbdrv_legodev_get_uart_dev(legodev));
 
     // baud rate for sync messages
     PT_WAIT_UNTIL(pt, ({
@@ -836,8 +833,6 @@ static PT_THREAD(test_technic_large_motor(struct pt *pt)) {
     PT_YIELD(pt);
 
 end:
-    pbdrv_legodev_pup_uart_process_exit();
-
     PT_END(pt);
 }
 
@@ -914,12 +909,11 @@ static PT_THREAD(test_technic_xl_motor(struct pt *pt)) {
 
     PT_BEGIN(pt);
 
+    pbdrv_legodev_test_start_process();
+
     // Expect no device at first.
     pbdrv_legodev_type_id_t id = PBDRV_LEGODEV_TYPE_ID_NONE;
     tt_uint_op(pbdrv_legodev_get_device(PBIO_PORT_ID_D, &id, &legodev), ==, PBIO_SUCCESS);
-
-    pbdrv_legodev_pup_uart_process_start();
-    pbdrv_legodev_pup_uart_start_sync(pbdrv_legodev_get_uart_dev(legodev));
 
     // baud rate for sync messages
     PT_WAIT_UNTIL(pt, ({
@@ -1041,8 +1035,6 @@ static PT_THREAD(test_technic_xl_motor(struct pt *pt)) {
     PT_YIELD(pt);
 
 end:
-    pbdrv_legodev_pup_uart_process_exit();
-
     PT_END(pt);
 }
 
@@ -1064,6 +1056,11 @@ void pbdrv_uart_set_baud_rate(pbdrv_uart_dev_t *uart, uint32_t baud) {
 }
 
 void pbdrv_uart_flush(pbdrv_uart_dev_t *uart_dev) {
+}
+
+extern bool pbio_legodev_test_process_auto_start;
+
+void pbdrv_uart_init(void) {
 }
 
 pbio_error_t pbdrv_uart_read_begin(pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout) {


### PR DESCRIPTION
This implements a start to https://github.com/pybricks/support/issues/1140:

- This is a start to separating the device connection manager and the uart device code.
- Device synchronization is more likely to work in one go
- Disconnecting is handled more quickly because we can drop various timeouts
- Reduces code size on Move Hub by about 350 bytes

I have intentionally avoided much change to the `dcm` and `uartdev` code in this commit to make the change easier to process. We could do a few more cleanups though:

- Fix mixed use of `uartdev`, `data`, `port_data` name for the main data structure
- Fix names of the various protothreads: `data->pt` is not the same as `data_pt`, which can make it harder to follow.
- Now that the dcm and uartdev run separately from start to end, each can be a proper protothread that reads from start to finish, instead of needing an external loop with a function call that causes it to run to the next yield. This will work the same but it could make the code easier to follow, especially since we omit the `PT_SCHEDULE` macro in a few places when we don't need the return value.