### PR TITLE
pbio/drivebase: Reverse turn rate for negative drive speed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 - Added `MoveHub.imu.tilt()` ([support#539]).
 - Enabled hub init orientation support for Move Hub ([support#539]).
 
+### Changed
+- Changed steering direction with `DriveBase.drive()` when reversing. Now, 
+  a positive angle or turn rate means the robot travels along a circle to
+  its right. The speed or radius can be negated to travel in reverse along
+  that same circle ([support#1191]).
+
 ### Fixed
 - Fixed Move Hub accelerometer not working since v3.3.0b5 ([support#1269]).
 - Fixed Bluetooth chip locking up on Technic and City hubs when broadcasting ([support#1095]).

--- a/lib/pbio/src/drivebase.c
+++ b/lib/pbio/src/drivebase.c
@@ -641,6 +641,12 @@ static pbio_error_t pbio_drivebase_drive_time_common(pbio_drivebase_t *db, int32
         return err;
     }
 
+    // When reversing, also reverse steering. This way, driving backwards without
+    // changing the steering sign means driving along the same circle, backwards.
+    if (drive_speed < 0) {
+        turn_speed = -turn_speed;
+    }
+
     err = pbio_control_start_timed_control(&db->control_heading, time_now, &state_heading, duration, turn_speed, on_completion);
     if (err != PBIO_SUCCESS) {
         return err;


### PR DESCRIPTION
Changed steering direction with `DriveBase.drive()` when reversing. Now,   a positive angle or turn rate means the robot travels along a circle to   its right. The speed or radius can be negated to travel in reverse along  that same circle.

See https://github.com/pybricks/support/issues/1191