### PR TITLE
pybricks.pupdevices.Light: Invert default polarity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,15 @@
 - Fix observing stopping on City and Technic hubs after some time ([support#1096]).
 - Fix Bluetooth locking up when connecting Bluetooth adapter with small MTU to Technic and City hubs ([support#947]).
 
+### Changed
+- Changed polarity of output in the `Light` class. This makes no difference for
+  the Light class, but it makes the class usable for certain custom
+  devices ([pybricks-micropython#166]).
+
 [support#947]: https://github.com/pybricks/support/issues/947
 [support#1096]: https://github.com/pybricks/support/issues/1096
+[pybricks-micropython#222]: https://github.com/pybricks/pybricks-micropython/pull/222
+
 
 ## [3.3.0] - 2023-11-24
 

--- a/pybricks/pupdevices/pb_type_pupdevices_light.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_light.c
@@ -50,7 +50,7 @@ STATIC mp_obj_t pupdevices_Light_on(size_t n_args, const mp_obj_t *pos_args, mp_
 
     // Set the brightness
     int32_t voltage = pbio_battery_get_voltage_from_duty_pct(pb_obj_get_pct(brightness_in));
-    pb_assert(pbio_dcmotor_user_command(self->dcmotor, false, -voltage));
+    pb_assert(pbio_dcmotor_user_command(self->dcmotor, false, voltage));
 
     return mp_const_none;
 }


### PR DESCRIPTION
This makes no difference for the Light class, but it makes the class usable for certain custom devices.

-------------

This was requested by PV Productions to support their [USB output](https://pv-productions.com/product/usb-socket-cable/).

I'm not necessarily against this, although it might be better to add this kind of functionality to the `PUPDevice` class (or something like it) instead. Then it could be general purpose and useful for other third-party devices that might be wired up the other way around as well.