### PR TITLE
pbio/sys/program_stop: Drop hack to stop Bluetooth.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix Bluetooth locking up when connecting Bluetooth adapter with small MTU to Technic and City hubs ([support#947]).
 - Fix Technic Hub not always starting automatically after firmware exiting
   update mode ([support#1408]). Also apply this to Move Hub and City Hub.
+- Fix hub not shutting down while a program runs ([support#1438]).
 
 ### Changed
 - Changed polarity of output in the `Light` class. This makes no difference for
@@ -23,6 +24,7 @@
 [support#947]: https://github.com/pybricks/support/issues/947
 [support#1096]: https://github.com/pybricks/support/issues/1096
 [support#1408]: https://github.com/pybricks/support/issues/1408
+[support#1438]: https://github.com/pybricks/support/issues/1438
 [pybricks-micropython#222]: https://github.com/pybricks/pybricks-micropython/pull/222
 
 

--- a/lib/pbio/sys/program_stop.c
+++ b/lib/pbio/sys/program_stop.c
@@ -32,12 +32,6 @@ static bool stop_button_pressed;
  */
 void pbsys_program_stop(bool force_stop) {
     if (pbsys_status_test(PBIO_PYBRICKS_STATUS_USER_PROGRAM_RUNNING)) {
-        if (force_stop) {
-            // HACK: Bluetooth drivers have issues with pending tasks not being
-            // cancellable, so this should force them to be canceled and avoid
-            // undefined behavior due to use after free.
-            pbdrv_bluetooth_power_on(false);
-        }
         pbsys_main_stop_program(force_stop);
     }
 }


### PR DESCRIPTION
We have an old hack that shuts down the bluetooth process. When starting a new task after that in a cleanup routine such as added in 04fd2e770d97ab4771e77072bab0d9d61bcdeb45, the hub will never finish the task, which prevents the user program from stopping.

We have several proper fixes in place now, and we are about to merge some updates that will make all Bluetooth task objects static, so we should remove this hack.

Fixes https://github.com/pybricks/support/issues/1438