### PR TITLE
pybricks.iodevices.PUPDevice: Fix data input checks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Fixes
+- Fix `pybricks.iodevices` not allowing writig -128 value ([support#1366]) and
+  raise informative error messages instead of clamping the input.
+
+[support#1366]: https://github.com/pybricks/support/issues/1366
+
 ## [3.4.0b1] - 2024-02-10
 
 ### Added

--- a/pybricks/common/pb_type_device.c
+++ b/pybricks/common/pb_type_device.c
@@ -63,7 +63,7 @@ void *pb_type_device_get_data_blocking(mp_obj_t self_in, uint8_t mode) {
  * the mode is ready. For writing, this means that the mode has been set and
  * data has been written to the device, including the neccessary delays for
  * discarding stale data or the time needed to externally process written data.
- * 
+ *
  * @param [in]  self_in     The sensor object instance.
  * @param [in]  end_time    Not used.
  * @return                  True if operation is complete (device ready),

--- a/pybricks/common/pb_type_device.h
+++ b/pybricks/common/pb_type_device.h
@@ -26,7 +26,11 @@ typedef struct _pb_type_device_obj_base_t {
 #if PYBRICKS_PY_DEVICES
 
 /**
- * Callable sensor method with a particular mode and return map.
+ * Callable sensor method with a particular mode and return map. Instances of
+ * these are used similar to normal callable methods in classes, in its locals
+ * dict table. The call handler is the same for all such methods. Instead, what
+ * makes each sensor method unique is the mode and return map that creates the
+ * MicroPython object return data when the data is available.
  */
 typedef struct {
     mp_obj_base_t base;
@@ -34,8 +38,20 @@ typedef struct {
     uint8_t mode;
 } pb_type_device_method_obj_t;
 
+/**
+ * The type object for the sensor method callable. See the implementation
+ * of this type for more details.
+ */
 extern const mp_obj_type_t pb_type_device_method;
 
+/**
+ * Define a constant sensor method object. Plays a role similar to
+ * MP_DEFINE_CONST_FUN and friends in normal MicroPython methods, thus creating
+ * the constant entries in the locals dict table of the sensor class. The
+ * difference is that this contains a constant reference not to the method
+ * called now (which is handled by the same call handler for all sensors), but
+ * to the mapping function called later, when the data is available.
+ */
 #define PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(obj_name, mode_id, get_values_func) \
     const pb_type_device_method_obj_t obj_name = \
     {{&pb_type_device_method}, .mode = mode_id, .get_values = get_values_func}


### PR DESCRIPTION
Fix `pybricks.iodevices` not allowing writing -128 value (https://github.com/pybricks/support/issues/1366) and  raise informative error messages instead of clamping the input.

------

@antonvh - when this finishes building later this afternoon, you'll see zip files with the firmware with this fix. You can [install it using the advanced install option during hub selection](https://pybricks.com/install/spike-mindstorms/#installing-the-latest-build-advanced).

Does this fix the issue? You should be able to write -127 now.