### PR TITLE
pybricks.common: Dynamically create button enum.

### DIFF
--- a/bricks/movehub/mpconfigport.h
+++ b/bricks/movehub/mpconfigport.h
@@ -30,6 +30,7 @@
 #define PYBRICKS_PY_MEDIA                       (0)
 #define PYBRICKS_PY_PARAMETERS                  (1)
 #define PYBRICKS_PY_PARAMETERS_BUTTON           (1)
+#define PYBRICKS_PY_PARAMETERS_BUTTON_REMOTE_ONLY (1)
 #define PYBRICKS_PY_PARAMETERS_ICON             (0)
 #define PYBRICKS_PY_DEVICES                     (1)
 #define PYBRICKS_PY_PUPDEVICES                  (1)

--- a/pybricks/common.h
+++ b/pybricks/common.h
@@ -20,6 +20,7 @@
 #include <pybricks/util_mp/pb_obj_helper.h>
 
 #include <pybricks/parameters.h>
+#include <pybricks/parameters/pb_type_button.h>
 #include <pybricks/pupdevices.h>
 #include <pybricks/tools.h>
 #include <pybricks/tools/pb_type_awaitable.h>
@@ -69,7 +70,7 @@ void pb_type_LightMatrix_display_char(pbio_light_matrix_t *light_matrix, mp_obj_
 
 #if PYBRICKS_PY_COMMON_KEYPAD
 // pybricks._common.KeyPad()
-mp_obj_t pb_type_Keypad_obj_new(uint8_t number_of_buttons, const pb_obj_enum_member_t **buttons, pbio_button_is_pressed_func_t is_pressed);
+mp_obj_t pb_type_Keypad_obj_new(pb_type_button_get_pressed_t get_pressed);
 #endif
 
 // pybricks._common.Battery()

--- a/pybricks/common/pb_type_keypad.c
+++ b/pybricks/common/pb_type_keypad.c
@@ -10,40 +10,20 @@
 #include "py/obj.h"
 
 #include <pybricks/common.h>
-#include <pybricks/parameters.h>
+#include <pybricks/parameters/pb_type_button.h>
 
 #include <pybricks/util_pb/pb_error.h>
 
 // pybricks._common.Keypad class object
 typedef struct _common_Keypad_obj_t {
     mp_obj_base_t base;
-    uint8_t number_of_buttons;
-    const pb_obj_enum_member_t **buttons;
-    pbio_button_is_pressed_func_t is_pressed;
+    pb_type_button_get_pressed_t get_pressed;
 } common_Keypad_obj_t;
 
 // pybricks._common.Keypad.pressed
 STATIC mp_obj_t common_Keypad_pressed(mp_obj_t self_in) {
     common_Keypad_obj_t *self = MP_OBJ_TO_PTR(self_in);
-
-    // Read button combination code.
-    pbio_button_flags_t pressed;
-    pb_assert(self->is_pressed(&pressed));
-
-    mp_obj_t button_list[PBIO_BUTTON_NUM_BUTTONS];
-    uint8_t size = 0;
-
-    for (uint8_t i = 0; i < self->number_of_buttons; i++) {
-        if (pressed & self->buttons[i]->value) {
-            button_list[size++] = MP_OBJ_FROM_PTR(self->buttons[i]);
-        }
-    }
-
-    #if MICROPY_PY_BUILTINS_SET
-    return mp_obj_new_set(size, button_list);
-    #else
-    return mp_obj_new_tuple(size, button_list);
-    #endif
+    return self->get_pressed();
 }
 MP_DEFINE_CONST_FUN_OBJ_1(common_Keypad_pressed_obj, common_Keypad_pressed);
 
@@ -60,14 +40,9 @@ STATIC MP_DEFINE_CONST_OBJ_TYPE(pb_type_Keypad,
     locals_dict, &common_Keypad_locals_dict);
 
 // pybricks._common.Keypad.__init__
-mp_obj_t pb_type_Keypad_obj_new(uint8_t number_of_buttons, const pb_obj_enum_member_t **buttons, pbio_button_is_pressed_func_t is_pressed) {
+mp_obj_t pb_type_Keypad_obj_new(pb_type_button_get_pressed_t get_pressed) {
     common_Keypad_obj_t *self = mp_obj_malloc(common_Keypad_obj_t, &pb_type_Keypad);
-
-    // Store hub specific button info
-    self->number_of_buttons = number_of_buttons;
-    self->buttons = buttons;
-    self->is_pressed = is_pressed;
-
+    self->get_pressed = get_pressed;
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/pybricks/common/pb_type_system.c
+++ b/pybricks/common/pb_type_system.c
@@ -55,7 +55,7 @@ STATIC mp_obj_t pb_type_System_set_stop_button(mp_obj_t buttons_in) {
             mp_obj_t iter = mp_getiter(buttons_in, NULL);
             mp_obj_t item;
             while ((item = mp_iternext(iter)) != MP_OBJ_STOP_ITERATION) {
-                buttons |= pb_type_enum_get_value(item, &pb_enum_type_Button);
+                buttons |= pb_type_button_get_button_flag(item);
             }
             nlr_pop();
         } else {
@@ -64,7 +64,7 @@ STATIC mp_obj_t pb_type_System_set_stop_button(mp_obj_t buttons_in) {
             // button enum value. Technically there could be other error that
             // get us here, but they should be rare and will likely be a ValueError
             // which is the same error that will be raised here.
-            buttons = pb_type_enum_get_value(buttons_in, &pb_enum_type_Button);
+            buttons = pb_type_button_get_button_flag(buttons_in);
         }
         #else // PYBRICKS_PY_COMMON_KEYPAD_HUB_BUTTONS > 1
         buttons = PBIO_BUTTON_CENTER;

--- a/pybricks/ev3devices/pb_type_ev3devices_infraredsensor.c
+++ b/pybricks/ev3devices/pb_type_ev3devices_infraredsensor.c
@@ -89,43 +89,43 @@ STATIC mp_obj_t ev3devices_InfraredSensor_buttons(size_t n_args, const mp_obj_t 
         case 0:
             break;
         case 1:
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_LEFT_UP_obj);
+            pressed[len++] = pb_type_button_new(MP_QSTR_LEFT_UP);
             break;
         case 2:
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_LEFT_DOWN_obj);
+            pressed[len++] = pb_type_button_new(MP_QSTR_LEFT_DOWN);
             break;
         case 3:
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_RIGHT_UP_obj);
+            pressed[len++] = pb_type_button_new(MP_QSTR_RIGHT_UP);
             break;
         case 4:
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_RIGHT_DOWN_obj);
+            pressed[len++] = pb_type_button_new(MP_QSTR_RIGHT_DOWN);
             break;
         case 5:
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_LEFT_UP_obj);
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_RIGHT_UP_obj);
+            pressed[len++] = pb_type_button_new(MP_QSTR_LEFT_UP);
+            pressed[len++] = pb_type_button_new(MP_QSTR_RIGHT_UP);
             break;
         case 6:
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_LEFT_UP_obj);
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_RIGHT_DOWN_obj);
+            pressed[len++] = pb_type_button_new(MP_QSTR_LEFT_UP);
+            pressed[len++] = pb_type_button_new(MP_QSTR_RIGHT_DOWN);
             break;
         case 7:
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_LEFT_DOWN_obj);
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_RIGHT_UP_obj);
+            pressed[len++] = pb_type_button_new(MP_QSTR_LEFT_DOWN);
+            pressed[len++] = pb_type_button_new(MP_QSTR_RIGHT_UP);
             break;
         case 8:
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_LEFT_DOWN_obj);
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_RIGHT_DOWN_obj);
+            pressed[len++] = pb_type_button_new(MP_QSTR_LEFT_DOWN);
+            pressed[len++] = pb_type_button_new(MP_QSTR_RIGHT_DOWN);
             break;
         case 9:
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_BEACON_obj);
+            pressed[len++] = pb_type_button_new(MP_QSTR_BEACON);
             break;
         case 10:
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_LEFT_UP_obj);
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_LEFT_DOWN_obj);
+            pressed[len++] = pb_type_button_new(MP_QSTR_LEFT_UP);
+            pressed[len++] = pb_type_button_new(MP_QSTR_LEFT_DOWN);
             break;
         case 11:
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_RIGHT_UP_obj);
-            pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_RIGHT_DOWN_obj);
+            pressed[len++] = pb_type_button_new(MP_QSTR_RIGHT_UP);
+            pressed[len++] = pb_type_button_new(MP_QSTR_RIGHT_DOWN);
             break;
         default:
             pb_assert(PBIO_ERROR_IO);
@@ -149,16 +149,16 @@ STATIC mp_obj_t ev3devices_InfraredSensor_keypad(mp_obj_t self_in) {
     uint8_t len = 0;
 
     if (keypad_data & 0x10) {
-        pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_LEFT_UP_obj);
+        pressed[len++] = pb_type_button_new(MP_QSTR_LEFT_UP);
     }
     if (keypad_data & 0x20) {
-        pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_LEFT_UP_obj);
+        pressed[len++] = pb_type_button_new(MP_QSTR_LEFT_UP);
     }
     if (keypad_data & 0x40) {
-        pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_RIGHT_UP_obj);
+        pressed[len++] = pb_type_button_new(MP_QSTR_RIGHT_UP);
     }
     if (keypad_data & 0x80) {
-        pressed[len++] = MP_OBJ_FROM_PTR(&pb_Button_RIGHT_DOWN_obj);
+        pressed[len++] = pb_type_button_new(MP_QSTR_RIGHT_DOWN);
     }
 
     return mp_obj_new_list(len, pressed);

--- a/pybricks/hubs/pb_type_cityhub.c
+++ b/pybricks/hubs/pb_type_cityhub.c
@@ -25,10 +25,6 @@ typedef struct _hubs_CityHub_obj_t {
     mp_obj_t system;
 } hubs_CityHub_obj_t;
 
-static const pb_obj_enum_member_t *cityhub_buttons[] = {
-    &pb_Button_CENTER_obj,
-};
-
 STATIC mp_obj_t hubs_CityHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     #if PYBRICKS_PY_COMMON_BLE
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
@@ -41,7 +37,7 @@ STATIC mp_obj_t hubs_CityHub_make_new(const mp_obj_type_t *type, size_t n_args, 
     #if PYBRICKS_PY_COMMON_BLE
     self->ble = pb_type_BLE_new(broadcast_channel_in, observe_channels_in);
     #endif
-    self->button = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(cityhub_buttons), cityhub_buttons, pbio_button_is_pressed);
+    self->button = pb_type_Keypad_obj_new(pb_type_button_pressed_hub_single_button);
     self->light = common_ColorLight_internal_obj_new(pbsys_status_light);
     self->system = MP_OBJ_FROM_PTR(&pb_type_System);
     return MP_OBJ_FROM_PTR(self);

--- a/pybricks/hubs/pb_type_essentialhub.c
+++ b/pybricks/hubs/pb_type_essentialhub.c
@@ -37,10 +37,6 @@ typedef struct _hubs_EssentialHub_obj_t {
     mp_obj_t system;
 } hubs_EssentialHub_obj_t;
 
-static const pb_obj_enum_member_t *essentialhub_buttons[] = {
-    &pb_Button_CENTER_obj,
-};
-
 STATIC mp_obj_t hubs_EssentialHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_DEFAULT_OBJ(top_side, pb_type_Axis_Z_obj),
@@ -56,7 +52,7 @@ STATIC mp_obj_t hubs_EssentialHub_make_new(const mp_obj_type_t *type, size_t n_a
     #if PYBRICKS_PY_COMMON_BLE
     self->ble = pb_type_BLE_new(broadcast_channel_in, observe_channels_in);
     #endif
-    self->buttons = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(essentialhub_buttons), essentialhub_buttons, pbio_button_is_pressed);
+    self->buttons = pb_type_Keypad_obj_new(pb_type_button_pressed_hub_single_button);
     self->charger = pb_type_Charger_obj_new();
     self->imu = pb_type_IMU_obj_new(top_side_in, front_side_in);
     self->light = common_ColorLight_internal_obj_new(pbsys_status_light);

--- a/pybricks/hubs/pb_type_ev3brick.c
+++ b/pybricks/hubs/pb_type_ev3brick.c
@@ -9,6 +9,7 @@
 #include <pybricks/common.h>
 #include <pybricks/hubs.h>
 #include <pybricks/util_mp/pb_obj_helper.h>
+#include <pybricks/util_pb/pb_error.h>
 
 #include "pb_ev3dev_types.h"
 
@@ -26,19 +27,34 @@ typedef struct _hubs_EV3Brick_obj_t {
     mp_obj_t system;
 } hubs_EV3Brick_obj_t;
 
-static const pb_obj_enum_member_t *ev3brick_buttons[] = {
-    &pb_Button_LEFT_obj,
-    &pb_Button_RIGHT_obj,
-    &pb_Button_UP_obj,
-    &pb_Button_DOWN_obj,
-    &pb_Button_CENTER_obj,
-};
+STATIC mp_obj_t pb_type_ev3brick_button_pressed(void) {
+    pbio_button_flags_t flags;
+    pb_assert(pbio_button_is_pressed(&flags));
+    mp_obj_t pressed[5];
+    size_t num = 0;
+    if (flags & PBIO_BUTTON_LEFT) {
+        pressed[num++] = pb_type_button_new(MP_QSTR_LEFT);
+    }
+    if (flags & PBIO_BUTTON_RIGHT) {
+        pressed[num++] = pb_type_button_new(MP_QSTR_RIGHT);
+    }
+    if (flags & PBIO_BUTTON_CENTER) {
+        pressed[num++] = pb_type_button_new(MP_QSTR_CENTER);
+    }
+    if (flags & PBIO_BUTTON_UP) {
+        pressed[num++] = pb_type_button_new(MP_QSTR_UP);
+    }
+    if (flags & PBIO_BUTTON_DOWN) {
+        pressed[num++] = pb_type_button_new(MP_QSTR_DOWN);
+    }
+    return mp_obj_new_set(num, pressed);
+}
 
 STATIC mp_obj_t hubs_EV3Brick_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     hubs_EV3Brick_obj_t *self = mp_obj_malloc(hubs_EV3Brick_obj_t, type);
 
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
-    self->buttons = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(ev3brick_buttons), ev3brick_buttons, pbio_button_is_pressed);
+    self->buttons = pb_type_Keypad_obj_new(pb_type_ev3brick_button_pressed);
     self->light = common_ColorLight_internal_obj_new(ev3dev_status_light);
     mp_obj_t screen_args[] = { MP_ROM_QSTR(MP_QSTR__screen_) };
     self->screen = MP_OBJ_TYPE_GET_SLOT(&pb_type_ev3dev_Image, make_new)(&pb_type_ev3dev_Image, 1, 0, screen_args);

--- a/pybricks/hubs/pb_type_movehub.c
+++ b/pybricks/hubs/pb_type_movehub.c
@@ -313,9 +313,6 @@ typedef struct _hubs_MoveHub_obj_t {
     mp_obj_t system;
 } hubs_MoveHub_obj_t;
 
-static const pb_obj_enum_member_t *movehub_buttons[] = {
-    &pb_Button_CENTER_obj,
-};
 
 STATIC mp_obj_t hubs_MoveHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
@@ -332,7 +329,7 @@ STATIC mp_obj_t hubs_MoveHub_make_new(const mp_obj_type_t *type, size_t n_args, 
     #if PYBRICKS_PY_COMMON_BLE
     self->ble = pb_type_BLE_new(broadcast_channel_in, observe_channels_in);
     #endif
-    self->button = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(movehub_buttons), movehub_buttons, pbio_button_is_pressed);
+    self->button = pb_type_Keypad_obj_new(pb_type_button_pressed_hub_single_button);
     self->imu = hubs_MoveHub_IMU_make_new(top_side_in, front_side_in);
     self->light = common_ColorLight_internal_obj_new(pbsys_status_light);
     self->system = MP_OBJ_FROM_PTR(&pb_type_System);

--- a/pybricks/hubs/pb_type_nxtbrick.c
+++ b/pybricks/hubs/pb_type_nxtbrick.c
@@ -11,6 +11,7 @@
 #include <pybricks/hubs.h>
 
 #include <pybricks/util_mp/pb_obj_helper.h>
+#include <pybricks/util_pb/pb_error.h>
 
 #include "py/misc.h"
 #include "py/obj.h"
@@ -24,16 +25,30 @@ typedef struct _hubs_NXTBrick_obj_t {
     mp_obj_t system;
 } hubs_NXTBrick_obj_t;
 
-static const pb_obj_enum_member_t *nxtbrick_buttons[] = {
-    &pb_Button_LEFT_obj,
-    &pb_Button_RIGHT_obj,
-    &pb_Button_CENTER_obj,
-};
+STATIC mp_obj_t pb_type_nxtbrick_button_pressed(void) {
+    pbio_button_flags_t flags;
+    pb_assert(pbio_button_is_pressed(&flags));
+    mp_obj_t pressed[4];
+    size_t num = 0;
+    if (flags & PBIO_BUTTON_LEFT) {
+        pressed[num++] = pb_type_button_new(MP_QSTR_LEFT);
+    }
+    if (flags & PBIO_BUTTON_RIGHT) {
+        pressed[num++] = pb_type_button_new(MP_QSTR_RIGHT);
+    }
+    if (flags & PBIO_BUTTON_CENTER) {
+        pressed[num++] = pb_type_button_new(MP_QSTR_CENTER);
+    }
+    if (flags & PBIO_BUTTON_DOWN) {
+        pressed[num++] = pb_type_button_new(MP_QSTR_DOWN);
+    }
+    return mp_obj_new_set(num, pressed);
+}
 
 STATIC mp_obj_t hubs_NXTBrick_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     hubs_NXTBrick_obj_t *self = mp_obj_malloc(hubs_NXTBrick_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
-    self->buttons = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(nxtbrick_buttons), nxtbrick_buttons, pbio_button_is_pressed);
+    self->buttons = pb_type_Keypad_obj_new(pb_type_nxtbrick_button_pressed);
     self->speaker = mp_call_function_0(MP_OBJ_FROM_PTR(&pb_type_Speaker));
     self->system = MP_OBJ_FROM_PTR(&pb_type_System);
     return MP_OBJ_FROM_PTR(self);

--- a/pybricks/hubs/pb_type_technichub.c
+++ b/pybricks/hubs/pb_type_technichub.c
@@ -27,10 +27,6 @@ typedef struct _hubs_TechnicHub_obj_t {
     mp_obj_t system;
 } hubs_TechnicHub_obj_t;
 
-static const pb_obj_enum_member_t *technichub_buttons[] = {
-    &pb_Button_CENTER_obj,
-};
-
 STATIC mp_obj_t hubs_TechnicHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_DEFAULT_OBJ(top_side, pb_type_Axis_Z_obj),
@@ -46,7 +42,7 @@ STATIC mp_obj_t hubs_TechnicHub_make_new(const mp_obj_type_t *type, size_t n_arg
     #if PYBRICKS_PY_COMMON_BLE
     self->ble = pb_type_BLE_new(broadcast_channel_in, observe_channels_in);
     #endif
-    self->button = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(technichub_buttons), technichub_buttons, pbio_button_is_pressed);
+    self->button = pb_type_Keypad_obj_new(pb_type_button_pressed_hub_single_button);
     self->imu = pb_type_IMU_obj_new(top_side_in, front_side_in);
     self->light = common_ColorLight_internal_obj_new(pbsys_status_light);
     self->system = MP_OBJ_FROM_PTR(&pb_type_System);

--- a/pybricks/hubs/pb_type_virtualhub.c
+++ b/pybricks/hubs/pb_type_virtualhub.c
@@ -26,14 +26,10 @@ typedef struct _hubs_VirtualHub_obj_t {
     mp_obj_t system;
 } hubs_VirtualHub_obj_t;
 
-static const pb_obj_enum_member_t *virtualhub_buttons[] = {
-    &pb_Button_CENTER_obj,
-};
-
 STATIC mp_obj_t hubs_VirtualHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     hubs_VirtualHub_obj_t *self = mp_obj_malloc(hubs_VirtualHub_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
-    self->buttons = pb_type_Keypad_obj_new(MP_ARRAY_SIZE(virtualhub_buttons), virtualhub_buttons, pbio_button_is_pressed);
+    self->buttons = pb_type_Keypad_obj_new(pb_type_button_pressed_hub_single_button);
     // FIXME: Implement lights.
     // self->light = common_ColorLight_internal_obj_new(pbsys_status_light);
     self->system = MP_OBJ_FROM_PTR(&pb_type_System);

--- a/pybricks/parameters.h
+++ b/pybricks/parameters.h
@@ -8,6 +8,7 @@
 
 #if PYBRICKS_PY_PARAMETERS
 
+#include <pbio/button.h>
 #include <pbio/color.h>
 
 #include "py/obj.h"
@@ -28,28 +29,6 @@ extern const pb_type_Matrix_obj_t pb_type_Axis_Z_obj;
 #define pb_type_Axis_Y_int_enum (2)
 #define pb_type_Axis_Z_int_enum (3)
 #endif // MICROPY_PY_BUILTINS_FLOAT
-
-#if PYBRICKS_PY_PARAMETERS_BUTTON
-
-extern const mp_obj_type_t pb_enum_type_Button;
-
-extern const pb_obj_enum_member_t pb_Button_UP_obj;
-extern const pb_obj_enum_member_t pb_Button_DOWN_obj;
-extern const pb_obj_enum_member_t pb_Button_LEFT_obj;
-extern const pb_obj_enum_member_t pb_Button_RIGHT_obj;
-extern const pb_obj_enum_member_t pb_Button_RIGHT_PLUS_obj;
-extern const pb_obj_enum_member_t pb_Button_RIGHT_MINUS_obj;
-extern const pb_obj_enum_member_t pb_Button_CENTER_obj;
-extern const pb_obj_enum_member_t pb_Button_LEFT_UP_obj;
-extern const pb_obj_enum_member_t pb_Button_LEFT_DOWN_obj;
-extern const pb_obj_enum_member_t pb_Button_LEFT_PLUS_obj;
-extern const pb_obj_enum_member_t pb_Button_LEFT_MINUS_obj;
-extern const pb_obj_enum_member_t pb_Button_RIGHT_UP_obj;
-extern const pb_obj_enum_member_t pb_Button_RIGHT_DOWN_obj;
-extern const pb_obj_enum_member_t pb_Button_BEACON_obj;
-extern const pb_obj_enum_member_t pb_Button_BLUETOOTH_obj;
-
-#endif // PYBRICKS_PY_PARAMETERS_BUTTON
 
 extern const mp_obj_type_t pb_type_Color;
 extern const mp_obj_base_t pb_type_Color_obj;

--- a/pybricks/parameters/pb_module_parameters.c
+++ b/pybricks/parameters/pb_module_parameters.c
@@ -6,12 +6,13 @@
 #if PYBRICKS_PY_PARAMETERS
 
 #include <pybricks/parameters.h>
+#include <pybricks/parameters/pb_type_button.h>
 
 STATIC const mp_rom_map_elem_t parameters_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),    MP_ROM_QSTR(MP_QSTR_parameters)     },
     { MP_ROM_QSTR(MP_QSTR_Axis),        MP_ROM_PTR(&pb_enum_type_Axis)      },
     #if PYBRICKS_PY_PARAMETERS_BUTTON
-    { MP_ROM_QSTR(MP_QSTR_Button),      MP_ROM_PTR(&pb_enum_type_Button)    },
+    { MP_ROM_QSTR(MP_QSTR_Button),      MP_ROM_PTR(&pb_type_button)    },
     #endif
     { MP_ROM_QSTR(MP_QSTR_Color),       MP_ROM_PTR(&pb_type_Color_obj)      },
     { MP_ROM_QSTR(MP_QSTR_Direction),   MP_ROM_PTR(&pb_enum_type_Direction) },

--- a/pybricks/parameters/pb_type_button.c
+++ b/pybricks/parameters/pb_type_button.c
@@ -12,126 +12,143 @@
 #include "py/obj.h"
 #include "py/runtime.h"
 
-#include <pybricks/parameters.h>
+#include <pybricks/parameters/pb_type_button.h>
 
 #include <pybricks/util_mp/pb_type_enum.h>
+#include <pybricks/util_mp/pb_obj_helper.h>
 
-const pb_obj_enum_member_t pb_Button_UP_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_UP,
-    .value = PBIO_BUTTON_UP
+#include <pybricks/util_pb/pb_error.h>
+
+STATIC const qstr buttons[] = {
+    MP_QSTR_LEFT,
+    MP_QSTR_RIGHT,
+    MP_QSTR_CENTER,
+    MP_QSTR_LEFT_PLUS,
+    MP_QSTR_LEFT_MINUS,
+    MP_QSTR_RIGHT_PLUS,
+    MP_QSTR_RIGHT_MINUS,
+    #if !PYBRICKS_PY_PARAMETERS_BUTTON_REMOTE_ONLY
+    MP_QSTR_UP,
+    MP_QSTR_DOWN,
+    MP_QSTR_LEFT_UP,
+    MP_QSTR_LEFT_DOWN,
+    MP_QSTR_RIGHT_UP,
+    MP_QSTR_RIGHT_DOWN,
+    MP_QSTR_BEACON,
+    MP_QSTR_BLUETOOTH
+    #endif
 };
 
-const pb_obj_enum_member_t pb_Button_DOWN_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_DOWN,
-    .value = PBIO_BUTTON_DOWN
-};
+extern const mp_obj_type_t pb_type_button_;
 
-const pb_obj_enum_member_t pb_Button_LEFT_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_LEFT,
-    .value = PBIO_BUTTON_LEFT
-};
+STATIC void pb_type_button_print(const mp_print_t *print,  mp_obj_t self_in, mp_print_kind_t kind) {
+    pb_obj_button_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, self->name == pb_type_button.name ? "%q" : "%q.%q", MP_QSTR_Button, self->name);
+}
 
-const pb_obj_enum_member_t pb_Button_RIGHT_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_RIGHT,
-    .value = PBIO_BUTTON_RIGHT
-};
+mp_obj_t pb_type_button_new(qstr name) {
+    pb_obj_button_t *result = mp_obj_malloc(pb_obj_button_t, &pb_type_button_);
+    result->name = name;
+    return MP_OBJ_FROM_PTR(result);
+}
 
-const pb_obj_enum_member_t pb_Button_CENTER_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_CENTER,
-    .value = PBIO_BUTTON_CENTER
-};
+STATIC void pb_type_button_attribute_handler(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 
-const pb_obj_enum_member_t pb_Button_LEFT_UP_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_LEFT_UP,
-    .value = PBIO_BUTTON_LEFT_UP
-};
+    // Write and delete not supported. Re-reading from an instance also not supported.
+    if (dest[0] != MP_OBJ_NULL || MP_OBJ_TO_PTR(self_in) != &pb_type_button) {
+        return;
+    }
 
-const pb_obj_enum_member_t pb_Button_LEFT_PLUS_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_LEFT_PLUS,
-    .value = PBIO_BUTTON_LEFT_UP
-};
+    // Allocate new button object if the attribute is a valid button.
+    for (size_t i = 0; i < MP_ARRAY_SIZE(buttons); i++) {
+        if (attr == buttons[i]) {
+            dest[0] = pb_type_button_new(attr);
+            return;
+        }
+    }
+}
 
+STATIC mp_obj_t pb_type_button_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
 
-const pb_obj_enum_member_t pb_Button_LEFT_DOWN_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_LEFT_DOWN,
-    .value = PBIO_BUTTON_LEFT_DOWN
-};
+    // Only equality comparison is supported.
+    if (op != MP_BINARY_OP_EQUAL) {
+        return MP_OBJ_NULL;
+    }
+    if (!mp_obj_is_type(lhs_in, &pb_type_button_) || !mp_obj_is_type(rhs_in, &pb_type_button_)) {
+        return mp_const_false;
+    }
 
-const pb_obj_enum_member_t pb_Button_LEFT_MINUS_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_LEFT_MINUS,
-    .value = PBIO_BUTTON_LEFT_DOWN
-};
+    pb_obj_button_t *lhs = MP_OBJ_TO_PTR(lhs_in);
+    pb_obj_button_t *rhs = MP_OBJ_TO_PTR(rhs_in);
+    return mp_obj_new_bool(lhs->name == rhs->name);
+}
 
-const pb_obj_enum_member_t pb_Button_RIGHT_UP_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_RIGHT_UP,
-    .value = PBIO_BUTTON_RIGHT_UP
-};
-
-const pb_obj_enum_member_t pb_Button_RIGHT_PLUS_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_RIGHT_PLUS,
-    .value = PBIO_BUTTON_RIGHT_UP
-};
-
-const pb_obj_enum_member_t pb_Button_RIGHT_DOWN_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_RIGHT_DOWN,
-    .value = PBIO_BUTTON_RIGHT_DOWN
-};
-
-const pb_obj_enum_member_t pb_Button_RIGHT_MINUS_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_RIGHT_MINUS,
-    .value = PBIO_BUTTON_RIGHT_DOWN
-};
-
-const pb_obj_enum_member_t pb_Button_BEACON_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_BEACON,
-    .value = PBIO_BUTTON_UP
-};
-
-const pb_obj_enum_member_t pb_Button_BLUETOOTH_obj = {
-    {&pb_enum_type_Button},
-    .name = MP_QSTR_BLUETOOTH,
-    .value = PBIO_BUTTON_RIGHT_UP
-};
-
-STATIC const mp_rom_map_elem_t pb_enum_Button_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_UP),         MP_ROM_PTR(&pb_Button_UP_obj)        },
-    { MP_ROM_QSTR(MP_QSTR_DOWN),       MP_ROM_PTR(&pb_Button_DOWN_obj)      },
-    { MP_ROM_QSTR(MP_QSTR_LEFT),       MP_ROM_PTR(&pb_Button_LEFT_obj)      },
-    { MP_ROM_QSTR(MP_QSTR_RIGHT),      MP_ROM_PTR(&pb_Button_RIGHT_obj)     },
-    { MP_ROM_QSTR(MP_QSTR_CENTER),     MP_ROM_PTR(&pb_Button_CENTER_obj)    },
-    { MP_ROM_QSTR(MP_QSTR_LEFT_UP),    MP_ROM_PTR(&pb_Button_LEFT_UP_obj)   },
-    { MP_ROM_QSTR(MP_QSTR_LEFT_PLUS),  MP_ROM_PTR(&pb_Button_LEFT_PLUS_obj) },
-    { MP_ROM_QSTR(MP_QSTR_LEFT_DOWN),  MP_ROM_PTR(&pb_Button_LEFT_DOWN_obj) },
-    { MP_ROM_QSTR(MP_QSTR_LEFT_MINUS), MP_ROM_PTR(&pb_Button_LEFT_MINUS_obj)},
-    { MP_ROM_QSTR(MP_QSTR_RIGHT_UP),   MP_ROM_PTR(&pb_Button_RIGHT_UP_obj)  },
-    { MP_ROM_QSTR(MP_QSTR_RIGHT_PLUS), MP_ROM_PTR(&pb_Button_RIGHT_PLUS_obj)},
-    { MP_ROM_QSTR(MP_QSTR_RIGHT_DOWN), MP_ROM_PTR(&pb_Button_RIGHT_DOWN_obj)},
-    { MP_ROM_QSTR(MP_QSTR_RIGHT_MINUS), MP_ROM_PTR(&pb_Button_RIGHT_MINUS_obj)},
-    { MP_ROM_QSTR(MP_QSTR_BEACON),     MP_ROM_PTR(&pb_Button_BEACON_obj)    },
-    { MP_ROM_QSTR(MP_QSTR_BLUETOOTH),  MP_ROM_PTR(&pb_Button_BLUETOOTH_obj) },
-};
-STATIC MP_DEFINE_CONST_DICT(pb_enum_type_Button_locals_dict, pb_enum_Button_table);
-
-MP_DEFINE_CONST_OBJ_TYPE(pb_enum_type_Button,
+MP_DEFINE_CONST_OBJ_TYPE(pb_type_button_,
     MP_QSTR_Button,
     MP_TYPE_FLAG_NONE,
-    print, pb_type_enum_print,
+    print, pb_type_button_print,
+    attr, pb_type_button_attribute_handler,
     unary_op, mp_generic_unary_op,
-    locals_dict, &(pb_enum_type_Button_locals_dict));
+    binary_op, pb_type_button_binary_op
+    );
+
+// The exposed 'type' object is in fact an instance of the type, so we can have
+// an attribute handler for the type that creates new button objects.
+const pb_obj_button_t pb_type_button = {
+    {&pb_type_button_},
+    .name = MP_QSTRnull
+};
+
+#if PYBRICKS_PY_COMMON_KEYPAD_HUB_BUTTONS > 1
+pbio_button_flags_t pb_type_button_get_button_flag(mp_obj_t obj) {
+    pb_assert_type(obj, &pb_type_button_);
+    pb_obj_button_t *button = MP_OBJ_TO_PTR(obj);
+
+    switch (button->name) {
+        case MP_QSTR_UP:
+        case MP_QSTR_BEACON:
+            return PBIO_BUTTON_UP;
+        case MP_QSTR_DOWN:
+            return PBIO_BUTTON_DOWN;
+        case MP_QSTR_LEFT:
+            return PBIO_BUTTON_LEFT;
+        case MP_QSTR_RIGHT:
+            return PBIO_BUTTON_RIGHT;
+        case MP_QSTR_CENTER:
+            return PBIO_BUTTON_CENTER;
+        case MP_QSTR_LEFT_UP:
+        case MP_QSTR_LEFT_PLUS:
+            return PBIO_BUTTON_LEFT_UP;
+        case MP_QSTR_LEFT_DOWN:
+        case MP_QSTR_LEFT_MINUS:
+            return PBIO_BUTTON_LEFT_DOWN;
+        case MP_QSTR_RIGHT_UP:
+        case MP_QSTR_RIGHT_PLUS:
+        case MP_QSTR_BLUETOOTH:
+            return PBIO_BUTTON_RIGHT_UP;
+        case MP_QSTR_RIGHT_DOWN:
+        case MP_QSTR_RIGHT_MINUS:
+            return PBIO_BUTTON_RIGHT_DOWN;
+        default:
+            return 0;
+    }
+}
+#endif
+
+/**
+ * Common button pressed function for single button hubs.
+ */
+mp_obj_t pb_type_button_pressed_hub_single_button(void) {
+    pbio_button_flags_t flags;
+    pb_assert(pbio_button_is_pressed(&flags));
+    mp_obj_t buttons[] = { pb_type_button_new(MP_QSTR_CENTER) };
+
+    #if MICROPY_PY_BUILTINS_SET
+    return mp_obj_new_set(flags ? MP_ARRAY_SIZE(buttons) : 0, buttons);
+    #else
+    return mp_obj_new_tuple(flags ? MP_ARRAY_SIZE(buttons) : 0, buttons);
+    #endif
+}
 
 #endif // PYBRICKS_PY_PARAMETERS_BUTTON
 

--- a/pybricks/parameters/pb_type_button.h
+++ b/pybricks/parameters/pb_type_button.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2023 The Pybricks Authors
+
+#ifndef PYBRICKS_INCLUDED_PYBRICKS_TYPE_BUTTON_H
+#define PYBRICKS_INCLUDED_PYBRICKS_TYPE_BUTTON_H
+
+#if PYBRICKS_PY_PARAMETERS
+
+#if PYBRICKS_PY_PARAMETERS_BUTTON
+
+#include "py/mpconfig.h"
+#include "py/obj.h"
+
+// Dynamically allocated button object.
+typedef struct _pb_obj_button_t {
+    mp_obj_base_t base;
+    qstr name;
+} pb_obj_button_t;
+
+extern const pb_obj_button_t pb_type_button;
+
+mp_obj_t pb_type_button_new(qstr name);
+pbio_button_flags_t pb_type_button_get_button_flag(mp_obj_t obj);
+
+typedef mp_obj_t (*pb_type_button_get_pressed_t)(void);
+mp_obj_t pb_type_button_pressed_hub_single_button(void);
+
+#endif // PYBRICKS_PY_PARAMETERS_BUTTON
+
+#endif // PYBRICKS_PY_PARAMETERS
+
+#endif // PYBRICKS_INCLUDED_PYBRICKS_TYPE_BUTTON_H


### PR DESCRIPTION
This simplifies the button enum to make them more suitable beyond just pbio-specific keypad mappings. This will let them be used for other devices, like the Xbox Controller. (https://github.com/pybricks/support/issues/1488)

This also saves about 100 bytes on Move Hub. About half of this comes from omitting buttons that can't be used on Move Hub or with the remote, which we could theoretically also get without the dynamic enum (https://github.com/pybricks/support/issues/1453)