### PR TITLE
pbio/sys/program_load: Allow reading user program.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,13 @@
 ### Changed
 - Raise a descriptive error when the `Car` class can't find a steering mechanism
   end stop within 10 seconds ([support#1564]).
+- Extended region of readable data with `hub.system.storage` to include
+  user program ([pybricks-micropython#243]).
 
 ### Fixed
 - Fixed hubs not shutting down when holding hub button ([support#1419]).
 
+[pybricks-micropython#243]: https://github.com/pybricks/pybricks-micropython/pull/243
 [support#802]: https://github.com/pybricks/support/issues/802
 [support#1419]: https://github.com/pybricks/support/issues/1419
 [support#1564]: https://github.com/pybricks/support/issues/1564

--- a/lib/pbio/sys/program_load.c
+++ b/lib/pbio/sys/program_load.c
@@ -66,7 +66,7 @@ pbio_error_t pbsys_program_load_set_user_data(uint32_t offset, const uint8_t *da
 }
 
 /**
- * Gets pointer to user data.
+ * Gets pointer to user data or user program.
  *
  * @param [in]  offset  Offset from the base address.
  * @param [in]  data    The data reference.
@@ -75,7 +75,7 @@ pbio_error_t pbsys_program_load_set_user_data(uint32_t offset, const uint8_t *da
  *                      Otherwise, ::PBIO_SUCCESS.
  */
 pbio_error_t pbsys_program_load_get_user_data(uint32_t offset, uint8_t **data, uint32_t size) {
-    if (offset + size > sizeof(map->header.user_data)) {
+    if (offset + size > sizeof(map->header.user_data) + sizeof(map->header.program_size) + map->header.program_size) {
         return PBIO_ERROR_INVALID_ARG;
     }
     *data = map->header.user_data + offset;


### PR DESCRIPTION
This is an experimental pull request to facilitate the use case in https://github.com/orgs/pybricks/discussions/1567.

This extends the readable region of user data to include the user code. This seems like a reasonable case for advanced users, so we might even choose to merge this.

The write-able region is not extended.

**NOTE**
If your purpose is to recover an existing program, naturally you mustn't override it with a new program to use this feature. Instead, use the REPL!

----------------------------

The ` hub.system.storage` method is normally used to read and store user data. Such as user light sensor calibration values. This is `512` bytes on SPIKE Prime. The user program size (4 bytes) and program follow immediately thereafter.

So, you can theoretically extract your user code using the REPL as follows:

```
>>> PROGRAM_START = 512 # For SPIKE Prime. Everything before this is user data.
>>> size = hub.system.storage(PROGRAM_START, read=1)[0]
>>> print(size)
61
>>> hub.system.storage(PROGRAM_START + 4, read=61) # For large programs, read it chunk by chunk.
b'0\x00\x00\x00__main__\x00M\x06\x00\x1f\x03\x01\x10hello.py\x00\x0f\x81w\x05\rHello, world!\x00`\x08\x02\x01\x11\x02#\x004\x01YQc'
```
