### PR TITLE
pybricks.tools: Add hostbuffer to receive IDE data

### DIFF
--- a/bricks/_common/sources.mk
+++ b/bricks/_common/sources.mk
@@ -98,7 +98,7 @@ PYBRICKS_PYBRICKS_SRC_C = $(addprefix pybricks/,\
 	robotics/pb_type_spikebase.c \
 	tools/pb_module_tools.c \
 	tools/pb_type_awaitable.c \
-	tools/pb_type_hostbuffer.c \
+	tools/pb_type_app_data.c \
 	tools/pb_type_matrix.c \
 	tools/pb_type_stopwatch.c \
 	tools/pb_type_task.c \

--- a/bricks/_common/sources.mk
+++ b/bricks/_common/sources.mk
@@ -98,6 +98,7 @@ PYBRICKS_PYBRICKS_SRC_C = $(addprefix pybricks/,\
 	robotics/pb_type_spikebase.c \
 	tools/pb_module_tools.c \
 	tools/pb_type_awaitable.c \
+	tools/pb_type_hostbuffer.c \
 	tools/pb_type_matrix.c \
 	tools/pb_type_stopwatch.c \
 	tools/pb_type_task.c \

--- a/bricks/cityhub/mpconfigport.h
+++ b/bricks/cityhub/mpconfigport.h
@@ -45,6 +45,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (0)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
+#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/cityhub/mpconfigport.h
+++ b/bricks/cityhub/mpconfigport.h
@@ -45,7 +45,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (0)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
-#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (1)
+#define PYBRICKS_PY_TOOLS_APP_DATA              (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/debug/mpconfigport.h
+++ b/bricks/debug/mpconfigport.h
@@ -38,7 +38,7 @@
 #define PYBRICKS_PY_ROBOTICS                    (0)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
-#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (1)
+#define PYBRICKS_PY_TOOLS_APP_DATA              (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (0)

--- a/bricks/debug/mpconfigport.h
+++ b/bricks/debug/mpconfigport.h
@@ -38,6 +38,7 @@
 #define PYBRICKS_PY_ROBOTICS                    (0)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
+#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (0)

--- a/bricks/essentialhub/mpconfigport.h
+++ b/bricks/essentialhub/mpconfigport.h
@@ -46,7 +46,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (1)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
-#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (1)
+#define PYBRICKS_PY_TOOLS_APP_DATA              (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/essentialhub/mpconfigport.h
+++ b/bricks/essentialhub/mpconfigport.h
@@ -46,6 +46,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (1)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
+#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/ev3/mpconfigport.h
+++ b/bricks/ev3/mpconfigport.h
@@ -41,7 +41,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (0)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
-#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (1)
+#define PYBRICKS_PY_TOOLS_APP_DATA              (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/ev3/mpconfigport.h
+++ b/bricks/ev3/mpconfigport.h
@@ -41,6 +41,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (0)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
+#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/ev3dev/brickconfig.h
+++ b/bricks/ev3dev/brickconfig.h
@@ -46,4 +46,5 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE (0)
 #define PYBRICKS_PY_TOOLS               (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU      (0)
+#define PYBRICKS_PY_TOOLS_HOSTBUFFER    (0)
 #define PYBRICKS_PY_USIGNAL             (1)

--- a/bricks/ev3dev/brickconfig.h
+++ b/bricks/ev3dev/brickconfig.h
@@ -46,5 +46,5 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE (0)
 #define PYBRICKS_PY_TOOLS               (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU      (0)
-#define PYBRICKS_PY_TOOLS_HOSTBUFFER    (0)
+#define PYBRICKS_PY_TOOLS_APP_DATA      (0)
 #define PYBRICKS_PY_USIGNAL             (1)

--- a/bricks/ev3rt/mpconfigport.h
+++ b/bricks/ev3rt/mpconfigport.h
@@ -45,7 +45,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE (0)
 #define PYBRICKS_PY_TOOLS               (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU      (0)
-#define PYBRICKS_PY_TOOLS_HOSTBUFFER    (0)
+#define PYBRICKS_PY_TOOLS_APP_DATA      (0)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/ev3rt/mpconfigport.h
+++ b/bricks/ev3rt/mpconfigport.h
@@ -45,6 +45,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE (0)
 #define PYBRICKS_PY_TOOLS               (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU      (0)
+#define PYBRICKS_PY_TOOLS_HOSTBUFFER    (0)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/movehub/mpconfigport.h
+++ b/bricks/movehub/mpconfigport.h
@@ -41,7 +41,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (0)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
-#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (0)
+#define PYBRICKS_PY_TOOLS_APP_DATA              (0)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (0)

--- a/bricks/movehub/mpconfigport.h
+++ b/bricks/movehub/mpconfigport.h
@@ -41,6 +41,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (0)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
+#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (0)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (0)

--- a/bricks/nxt/mpconfigport.h
+++ b/bricks/nxt/mpconfigport.h
@@ -44,6 +44,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (0)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
+#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (0)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/nxt/mpconfigport.h
+++ b/bricks/nxt/mpconfigport.h
@@ -44,7 +44,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (0)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
-#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (0)
+#define PYBRICKS_PY_TOOLS_APP_DATA              (0)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/primehub/mpconfigport.h
+++ b/bricks/primehub/mpconfigport.h
@@ -47,6 +47,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (1)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (1)
+#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/primehub/mpconfigport.h
+++ b/bricks/primehub/mpconfigport.h
@@ -47,7 +47,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (1)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (1)
-#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (1)
+#define PYBRICKS_PY_TOOLS_APP_DATA              (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/technichub/mpconfigport.h
+++ b/bricks/technichub/mpconfigport.h
@@ -45,6 +45,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (0)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
+#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/technichub/mpconfigport.h
+++ b/bricks/technichub/mpconfigport.h
@@ -45,7 +45,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE    (0)
 #define PYBRICKS_PY_TOOLS                       (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU              (0)
-#define PYBRICKS_PY_TOOLS_HOSTBUFFER            (1)
+#define PYBRICKS_PY_TOOLS_APP_DATA              (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/virtualhub/mpconfigvariant.h
+++ b/bricks/virtualhub/mpconfigvariant.h
@@ -39,6 +39,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE (0)
 #define PYBRICKS_PY_TOOLS               (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU      (0)
+#define PYBRICKS_PY_TOOLS_HOSTBUFFER    (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/bricks/virtualhub/mpconfigvariant.h
+++ b/bricks/virtualhub/mpconfigvariant.h
@@ -39,7 +39,7 @@
 #define PYBRICKS_PY_ROBOTICS_DRIVEBASE_SPIKE (0)
 #define PYBRICKS_PY_TOOLS               (1)
 #define PYBRICKS_PY_TOOLS_HUB_MENU      (0)
-#define PYBRICKS_PY_TOOLS_HOSTBUFFER    (1)
+#define PYBRICKS_PY_TOOLS_APP_DATA      (1)
 
 // Pybricks options
 #define PYBRICKS_OPT_COMPILER                   (1)

--- a/lib/pbio/drv/bluetooth/bluetooth_stm32_bluenrg.c
+++ b/lib/pbio/drv/bluetooth/bluetooth_stm32_bluenrg.c
@@ -402,7 +402,9 @@ success:
     task->status = PBIO_SUCCESS;
 
 done:
-    send->done();
+    if (send->done) {
+        send->done();
+    }
 
     PT_END(pt);
 }
@@ -410,6 +412,10 @@ done:
 void pbdrv_bluetooth_send(pbdrv_bluetooth_send_context_t *context) {
     static pbio_task_t task;
     start_task(&task, send_value_notification, context);
+}
+
+void pbdrv_bluetooth_send_queued(pbio_task_t *task, pbdrv_bluetooth_send_context_t *context) {
+    start_task(task, send_value_notification, context);
 }
 
 void pbdrv_bluetooth_set_receive_handler(pbdrv_bluetooth_receive_handler_t handler) {

--- a/lib/pbio/drv/bluetooth/bluetooth_stm32_cc2640.c
+++ b/lib/pbio/drv/bluetooth/bluetooth_stm32_cc2640.c
@@ -475,7 +475,9 @@ retry:
     task->status = PBIO_SUCCESS;
 
 done:
-    send->done();
+    if (send->done) {
+        send->done();
+    }
 
     PT_END(pt);
 }
@@ -483,6 +485,10 @@ done:
 void pbdrv_bluetooth_send(pbdrv_bluetooth_send_context_t *context) {
     static pbio_task_t task;
     start_task(&task, send_value_notification, context);
+}
+
+void pbdrv_bluetooth_send_queued(pbio_task_t *task, pbdrv_bluetooth_send_context_t *context) {
+    start_task(task, send_value_notification, context);
 }
 
 void pbdrv_bluetooth_set_receive_handler(pbdrv_bluetooth_receive_handler_t handler) {

--- a/lib/pbio/include/pbdrv/bluetooth.h
+++ b/lib/pbio/include/pbdrv/bluetooth.h
@@ -287,6 +287,16 @@ void pbdrv_bluetooth_set_on_event(pbdrv_bluetooth_on_event_t on_event);
 void pbdrv_bluetooth_send(pbdrv_bluetooth_send_context_t *context);
 
 /**
+ * Requests for @p data to be sent via a characteristic notification.
+ *
+ * Works just like ::pbdrv_bluetooth_send, but can be run as an awaitable task
+ * that gets queued with other pbio tasks.
+ *
+ * @param [in]  context     The data to be sent and where to send it.
+ */
+void pbdrv_bluetooth_send_queued(pbio_task_t *task, pbdrv_bluetooth_send_context_t *context);
+
+/**
  * Registers a callback that will be called when data is received via a
  * characteristic write.
  *
@@ -412,7 +422,15 @@ static inline bool pbdrv_bluetooth_is_connected(pbdrv_bluetooth_connection_t con
 }
 
 static inline void pbdrv_bluetooth_send(pbdrv_bluetooth_send_context_t *context) {
-    context->done();
+    if (context->done) {
+        context->done();
+    }
+}
+
+static inline void pbdrv_bluetooth_send_queued(pbio_task_t *task, pbdrv_bluetooth_send_context_t *context) {
+    if (context->done) {
+        context->done();
+    }
 }
 
 static inline void pbdrv_bluetooth_peripheral_scan_and_connect(

--- a/lib/pbio/include/pbio/protocol.h
+++ b/lib/pbio/include/pbio/protocol.h
@@ -126,8 +126,10 @@ typedef enum {
     /**
      * Requests to write to a buffer that is pre-allocated by a user program.
      *
+     * This is typically used by an app such as Pybricks Code to set
+     *
      * It is up to the user program to determine what to with the received
-     * data.
+     * data or how to decode it.
      *
      * Unlike writing to stdin, this data is not queued but overwriten from the
      * given offset.

--- a/lib/pbio/include/pbio/protocol.h
+++ b/lib/pbio/include/pbio/protocol.h
@@ -122,6 +122,28 @@ typedef enum {
      * @since Pybricks Profile v1.3.0
      */
     PBIO_PYBRICKS_COMMAND_WRITE_STDIN = 6,
+
+    /**
+     * Requests to write to a buffer that is pre-allocated by a user program.
+     *
+     * It is up to the user program to determine what to with the received
+     * data.
+     *
+     * Unlike writing to stdin, this data is not queued but overwriten from the
+     * given offset.
+     *
+     * It is up to the sender to ensure that the written data chunks keep the
+     * overal data valid, assuming that the user can read it in whole at any
+     * time between subsequent writes.
+     *
+     * Parameters:
+     * - offset: The offset from the buffer base address (16-bit little-endian
+     *   unsigned integer).
+     * - payload: The data to write.
+     *
+     * @since Pybricks Profile v1.4.0
+     */
+    PBIO_PYBRICKS_COMMAND_WRITE_PROGRAM_DATA_BUFFER = 7,
 } pbio_pybricks_command_t;
 
 /**

--- a/lib/pbio/include/pbio/protocol.h
+++ b/lib/pbio/include/pbio/protocol.h
@@ -24,7 +24,7 @@
 #define PBIO_PROTOCOL_VERSION_MAJOR 1
 
 /** The minor version number for the protocol. */
-#define PBIO_PROTOCOL_VERSION_MINOR 3
+#define PBIO_PROTOCOL_VERSION_MINOR 4
 
 /** The patch version number for the protocol. */
 #define PBIO_PROTOCOL_VERSION_PATCH 0
@@ -126,7 +126,8 @@ typedef enum {
     /**
      * Requests to write to a buffer that is pre-allocated by a user program.
      *
-     * This is typically used by an app such as Pybricks Code to set
+     * This is typically used by an app such as Pybricks Code to set data that
+     * can be polled by a user program.
      *
      * It is up to the user program to determine what to with the received
      * data or how to decode it.
@@ -135,7 +136,7 @@ typedef enum {
      * given offset.
      *
      * It is up to the sender to ensure that the written data chunks keep the
-     * overal data valid, assuming that the user can read it in whole at any
+     * overall data valid, assuming that the user can read it in whole at any
      * time between subsequent writes.
      *
      * Parameters:
@@ -145,7 +146,7 @@ typedef enum {
      *
      * @since Pybricks Profile v1.4.0
      */
-    PBIO_PYBRICKS_COMMAND_WRITE_PROGRAM_DATA_BUFFER = 7,
+    PBIO_PYBRICKS_COMMAND_WRITE_APP_DATA = 7,
 } pbio_pybricks_command_t;
 
 /**
@@ -203,6 +204,17 @@ typedef enum {
      * @since Pybricks Profile v1.3.0
      */
     PBIO_PYBRICKS_EVENT_WRITE_STDOUT = 1,
+
+    /**
+     * App data sent from the hub to the host. This is similar to stdout, but
+     * typically used for data that should not be shown in the user terminal,
+     * such as sensor telemetry.
+     *
+     * The payload is a variable number of bytes that was written to app data.
+     *
+     * @since Pybricks Profile v1.4.0
+     */
+    PBIO_PYBRICKS_EVENT_WRITE_APP_DATA = 2,
 } pbio_pybricks_event_t;
 
 /**

--- a/lib/pbio/include/pbsys/command.h
+++ b/lib/pbio/include/pbsys/command.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2021-2022 The Pybricks Authors
+// Copyright (c) 2021-2024 The Pybricks Authors
 
 /**
  * @addtogroup SysCommand System: Command Parser
@@ -18,6 +18,17 @@
 #include <pbio/protocol.h>
 
 pbio_pybricks_error_t pbsys_command(const uint8_t *data, uint32_t size);
+
+/**
+ * Callback called when the write program data buffer command is given.
+ *
+ * @param [in]  offset  Offset from the start of the buffer.
+ * @param [in]  size    Size of the data to be written.
+ * @param [in]  data    The data to write.
+ */
+typedef void (*pbsys_command_write_program_data_buffer_callback_t)(uint16_t offset, uint32_t size, const uint8_t *data);
+
+void pbsys_command_set_write_program_data_buffer_callback(pbsys_command_write_program_data_buffer_callback_t callback);
 
 #endif // _PBSYS_COMMAND_H_
 

--- a/lib/pbio/include/pbsys/command.h
+++ b/lib/pbio/include/pbsys/command.h
@@ -20,15 +20,15 @@
 pbio_pybricks_error_t pbsys_command(const uint8_t *data, uint32_t size);
 
 /**
- * Callback called when the write program data buffer command is given.
+ * Callback called when the write app data command is given by the host.
  *
  * @param [in]  offset  Offset from the start of the buffer.
  * @param [in]  size    Size of the data to be written.
  * @param [in]  data    The data to write.
  */
-typedef void (*pbsys_command_write_program_data_buffer_callback_t)(uint16_t offset, uint32_t size, const uint8_t *data);
+typedef void (*pbsys_command_write_app_data_callback_t)(uint16_t offset, uint32_t size, const uint8_t *data);
 
-void pbsys_command_set_write_program_data_buffer_callback(pbsys_command_write_program_data_buffer_callback_t callback);
+void pbsys_command_set_write_app_data_callback(pbsys_command_write_app_data_callback_t callback);
 
 #endif // _PBSYS_COMMAND_H_
 

--- a/lib/pbio/include/pbsys/command.h
+++ b/lib/pbio/include/pbsys/command.h
@@ -25,8 +25,9 @@ pbio_pybricks_error_t pbsys_command(const uint8_t *data, uint32_t size);
  * @param [in]  offset  Offset from the start of the buffer.
  * @param [in]  size    Size of the data to be written.
  * @param [in]  data    The data to write.
+ * @returns             Error code.
  */
-typedef void (*pbsys_command_write_app_data_callback_t)(uint16_t offset, uint32_t size, const uint8_t *data);
+typedef pbio_error_t (*pbsys_command_write_app_data_callback_t)(uint16_t offset, uint32_t size, const uint8_t *data);
 
 void pbsys_command_set_write_app_data_callback(pbsys_command_write_app_data_callback_t callback);
 

--- a/lib/pbio/sys/command.c
+++ b/lib/pbio/sys/command.c
@@ -15,15 +15,15 @@
 #include "./program_stop.h"
 #include "./user_program.h"
 
-static pbsys_command_write_program_data_buffer_callback_t write_program_data_buffer_callback = NULL;
+static pbsys_command_write_app_data_callback_t write_app_data_callback = NULL;
 
 /**
  * Sets callback for the write program data buffer command.
  *
  * @param [in]  callback  The callback to set or @c NULL to unset.
  */
-void pbsys_command_set_write_program_data_buffer_callback(pbsys_command_write_program_data_buffer_callback_t callback) {
-    write_program_data_buffer_callback = callback;
+void pbsys_command_set_write_app_data_callback(pbsys_command_write_app_data_callback_t callback) {
+    write_app_data_callback = callback;
 }
 
 /**
@@ -64,11 +64,11 @@ pbio_pybricks_error_t pbsys_command(const uint8_t *data, uint32_t size) {
             // If no consumers are configured, goes to "/dev/null" without error
             return PBIO_PYBRICKS_ERROR_OK;
         case PBIO_PYBRICKS_COMMAND_WRITE_PROGRAM_DATA_BUFFER:
-            if (write_program_data_buffer_callback && size > 3) {
+            if (write_app_data_callback && size > 3) {
                 uint16_t offset = pbio_get_uint16_le(&data[1]);
                 uint16_t data_size = size - 3;
                 const uint8_t *data_write = &data[3];
-                write_program_data_buffer_callback(offset, data_size, data_write);
+                write_app_data_callback(offset, data_size, data_write);
             }
             // If no consumers are configured, goes to "/dev/null" without error
             return PBIO_PYBRICKS_ERROR_OK;

--- a/pybricks/tools.h
+++ b/pybricks/tools.h
@@ -24,6 +24,8 @@ mp_obj_t pb_module_tools_pbio_task_wait_or_await(pbio_task_t *task);
 
 extern const mp_obj_type_t pb_type_StopWatch;
 
+extern const mp_obj_type_t pb_type_hostbuffer;
+
 extern const mp_obj_type_t pb_type_Task;
 
 #endif // PYBRICKS_PY_TOOLS

--- a/pybricks/tools.h
+++ b/pybricks/tools.h
@@ -24,7 +24,7 @@ mp_obj_t pb_module_tools_pbio_task_wait_or_await(pbio_task_t *task);
 
 extern const mp_obj_type_t pb_type_StopWatch;
 
-extern const mp_obj_type_t pb_type_hostbuffer;
+extern const mp_obj_type_t pb_type_app_data;
 
 extern const mp_obj_type_t pb_type_Task;
 

--- a/pybricks/tools/pb_module_tools.c
+++ b/pybricks/tools/pb_module_tools.c
@@ -367,9 +367,9 @@ static const mp_rom_map_elem_t tools_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),    MP_ROM_QSTR(MP_QSTR_tools)                    },
     { MP_ROM_QSTR(MP_QSTR_wait),        MP_ROM_PTR(&pb_module_tools_wait_obj)         },
     { MP_ROM_QSTR(MP_QSTR_read_input_byte), MP_ROM_PTR(&pb_module_tools_read_input_byte_obj) },
-    #if PYBRICKS_PY_TOOLS_HOSTBUFFER
-    { MP_ROM_QSTR(MP_QSTR_HostBuffer),  MP_ROM_PTR(&pb_type_hostbuffer)               },
-    #endif // PYBRICKS_PY_TOOLS_HOSTBUFFER
+    #if PYBRICKS_PY_TOOLS_APP_DATA
+    { MP_ROM_QSTR(MP_QSTR_AppData),  MP_ROM_PTR(&pb_type_app_data)               },
+    #endif // PYBRICKS_PY_TOOLS_APP_DATA
     #if PYBRICKS_PY_TOOLS_HUB_MENU
     { MP_ROM_QSTR(MP_QSTR_hub_menu),    MP_ROM_PTR(&pb_module_tools_hub_menu_obj)     },
     #endif // PYBRICKS_PY_TOOLS_HUB_MENU

--- a/pybricks/tools/pb_module_tools.c
+++ b/pybricks/tools/pb_module_tools.c
@@ -367,6 +367,9 @@ static const mp_rom_map_elem_t tools_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),    MP_ROM_QSTR(MP_QSTR_tools)                    },
     { MP_ROM_QSTR(MP_QSTR_wait),        MP_ROM_PTR(&pb_module_tools_wait_obj)         },
     { MP_ROM_QSTR(MP_QSTR_read_input_byte), MP_ROM_PTR(&pb_module_tools_read_input_byte_obj) },
+    #if PYBRICKS_PY_TOOLS_HOSTBUFFER
+    { MP_ROM_QSTR(MP_QSTR_HostBuffer),  MP_ROM_PTR(&pb_type_hostbuffer)               },
+    #endif // PYBRICKS_PY_TOOLS_HOSTBUFFER
     #if PYBRICKS_PY_TOOLS_HUB_MENU
     { MP_ROM_QSTR(MP_QSTR_hub_menu),    MP_ROM_PTR(&pb_module_tools_hub_menu_obj)     },
     #endif // PYBRICKS_PY_TOOLS_HUB_MENU

--- a/pybricks/tools/pb_type_app_data.c
+++ b/pybricks/tools/pb_type_app_data.c
@@ -26,7 +26,7 @@ typedef struct _pb_type_app_data_obj_t {
     pbdrv_bluetooth_send_context_t tx_context;
     mp_obj_t rx_format;
     mp_obj_str_t rx_bytes_obj;
-    uint8_t tx_buffer[PBDRV_BLUETOOTH_MAX_MTU_SIZE];
+    uint8_t tx_buffer[20]; // REVISIT: Could be the negotiated MTU - 3 for better throughput https://github.com/pybricks/support/issues/1727
     uint8_t rx_buffer[] __attribute__((aligned(4)));
 } pb_type_app_data_obj_t;
 
@@ -71,9 +71,9 @@ STATIC mp_obj_t pb_type_app_data_write_bytes(mp_obj_t self_in, mp_obj_t data_in)
     size_t len;
     const char *data = mp_obj_str_get_data(data_in, &len);
 
-    if (len > PBDRV_BLUETOOTH_MAX_MTU_SIZE - 1) {
+    if (len > sizeof(self->tx_buffer) - 1) {
         mp_raise_msg_varg(&mp_type_ValueError,
-            MP_ERROR_TEXT("Cannot send more than %d bytes\n"), PBDRV_BLUETOOTH_MAX_MTU_SIZE - 1);
+            MP_ERROR_TEXT("Cannot send more than %d bytes\n"), sizeof(self->tx_buffer) - 1);
     }
 
     memcpy(self->tx_buffer + 1, data, len);

--- a/pybricks/tools/pb_type_app_data.c
+++ b/pybricks/tools/pb_type_app_data.c
@@ -84,10 +84,12 @@ STATIC mp_obj_t pb_type_app_data_write_bytes(mp_obj_t self_in, mp_obj_t data_in)
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(pb_type_app_data_write_bytes_obj, pb_type_app_data_write_bytes);
 
+static const mp_obj_str_t pb_const_empty_str_obj = {{&mp_type_str}, 0, 0, (const byte *)""};
+
 STATIC mp_obj_t pb_type_app_data_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
 
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_REQUIRED(rx_format));
+        PB_ARG_DEFAULT_OBJ(rx_format, pb_const_empty_str_obj));
 
     // Use ustruct.calcsize to parse user rx_format for size.
     mp_obj_t ustruct_calcsize = pb_function_import_helper(MP_QSTR_ustruct, MP_QSTR_calcsize);

--- a/pybricks/tools/pb_type_app_data.c
+++ b/pybricks/tools/pb_type_app_data.c
@@ -3,7 +3,7 @@
 
 #include "py/mpconfig.h"
 
-#if PYBRICKS_PY_TOOLS_HOSTBUFFER
+#if PYBRICKS_PY_TOOLS_APP_DATA
 
 #include <string.h>
 
@@ -18,34 +18,34 @@
 #include <pybricks/util_mp/pb_obj_helper.h>
 #include <pybricks/util_pb/pb_error.h>
 
-typedef struct _pb_type_hostbuffer_obj_t {
+typedef struct _pb_type_app_data_obj_t {
     mp_obj_base_t base;
     mp_obj_t format;
     mp_obj_str_t bytes_obj;
     uint8_t buffer[];
-} pb_type_hostbuffer_obj_t;
+} pb_type_app_data_obj_t;
 
-// pointer to dynamically allocated hostbuffer singleton for driver callback.
-static pb_type_hostbuffer_obj_t *hostbuffer_instance;
+// pointer to dynamically allocated app_data singleton for driver callback.
+static pb_type_app_data_obj_t *app_data_instance;
 
 static void handle_write_data_buffer(uint16_t offset, uint32_t size, const uint8_t *data) {
     // Can't write if buffer does not exist or isn't big enough.
-    if (!hostbuffer_instance || offset + size > hostbuffer_instance->bytes_obj.len) {
+    if (!app_data_instance || offset + size > app_data_instance->bytes_obj.len) {
         return;
     }
-    memcpy(hostbuffer_instance->buffer + offset, data, size);
+    memcpy(app_data_instance->buffer + offset, data, size);
 }
 
-STATIC mp_obj_t pb_type_hostbuffer_get_bytes(mp_obj_t self_in) {
-    pb_type_hostbuffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
+STATIC mp_obj_t pb_type_app_data_get_bytes(mp_obj_t self_in) {
+    pb_type_app_data_obj_t *self = MP_OBJ_TO_PTR(self_in);
     // Don't return internal bytes object but make a copy so the user bytes
     // object is constant as would be expected. Revisit: enable and return
     // a memoryview, especially if using large buffers.
     return mp_obj_new_bytes(self->bytes_obj.data, self->bytes_obj.len);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_hostbuffer_get_bytes_obj, pb_type_hostbuffer_get_bytes);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_app_data_get_bytes_obj, pb_type_app_data_get_bytes);
 
-STATIC mp_obj_t pb_type_hostbuffer_get_values(mp_obj_t self_in) {
+STATIC mp_obj_t pb_type_app_data_get_values(mp_obj_t self_in) {
 
     // One-off import for ustruct.unpack.
     static mp_obj_t ustruct_unpack = NULL;
@@ -56,13 +56,13 @@ STATIC mp_obj_t pb_type_hostbuffer_get_values(mp_obj_t self_in) {
     // Host (sender) is responsible for making sure that each individual
     // value remains valid, i.e. is written in a single chunk, since the
     // following may allocate, and thus be updated between unpacking values.
-    pb_type_hostbuffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    pb_type_app_data_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_call_function_2(ustruct_unpack, self->format, MP_OBJ_FROM_PTR(&self->bytes_obj));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_hostbuffer_get_values_obj, pb_type_hostbuffer_get_values);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_app_data_get_values_obj, pb_type_app_data_get_values);
 
 
-STATIC mp_obj_t pb_type_hostbuffer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t pb_type_app_data_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
 
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(format));
@@ -72,47 +72,47 @@ STATIC mp_obj_t pb_type_hostbuffer_make_new(const mp_obj_type_t *type, size_t n_
     size_t size = mp_obj_get_int(mp_call_function_1(ustruct_calcsize, format_in));
 
     // Can only create one instance for now.
-    if (hostbuffer_instance) {
+    if (app_data_instance) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("host buffer already allocated"));
     }
 
     // Use finalizer so we can deactivate the data callback when buffer is garbage collected.
-    hostbuffer_instance = m_new_obj_var_with_finaliser(pb_type_hostbuffer_obj_t, uint8_t, size);
-    hostbuffer_instance->base.type = type;
-    hostbuffer_instance->format = format_in;
+    app_data_instance = m_new_obj_var_with_finaliser(pb_type_app_data_obj_t, uint8_t, size);
+    app_data_instance->base.type = type;
+    app_data_instance->format = format_in;
 
     // Keep buffer in bytes object format for compatibility with unpack.
-    hostbuffer_instance->bytes_obj.base.type = &mp_type_bytes;
-    hostbuffer_instance->bytes_obj.len = size;
-    hostbuffer_instance->bytes_obj.data = hostbuffer_instance->buffer;
+    app_data_instance->bytes_obj.base.type = &mp_type_bytes;
+    app_data_instance->bytes_obj.len = size;
+    app_data_instance->bytes_obj.data = app_data_instance->buffer;
 
     // Activate callback now that we have allocated the buffer.
     pbsys_command_set_write_program_data_buffer_callback(handle_write_data_buffer);
 
-    return MP_OBJ_FROM_PTR(hostbuffer_instance);
+    return MP_OBJ_FROM_PTR(app_data_instance);
 }
 
-mp_obj_t pb_type_hostbuffer_close(mp_obj_t stream) {
-    if (hostbuffer_instance) {
+mp_obj_t pb_type_app_data_close(mp_obj_t stream) {
+    if (app_data_instance) {
         pbsys_command_set_write_program_data_buffer_callback(NULL);
-        hostbuffer_instance = NULL;
+        app_data_instance = NULL;
     }
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_1(pb_type_hostbuffer_close_obj, pb_type_hostbuffer_close);
+MP_DEFINE_CONST_FUN_OBJ_1(pb_type_app_data_close_obj, pb_type_app_data_close);
 
-STATIC const mp_rom_map_elem_t pb_type_hostbuffer_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR___del__),      MP_ROM_PTR(&pb_type_hostbuffer_close_obj) },
-    { MP_ROM_QSTR(MP_QSTR_close),        MP_ROM_PTR(&pb_type_hostbuffer_close_obj) },
-    { MP_ROM_QSTR(MP_QSTR_get_bytes),    MP_ROM_PTR(&pb_type_hostbuffer_get_bytes_obj) },
-    { MP_ROM_QSTR(MP_QSTR_get_values),   MP_ROM_PTR(&pb_type_hostbuffer_get_values_obj) },
+STATIC const mp_rom_map_elem_t pb_type_app_data_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___del__),      MP_ROM_PTR(&pb_type_app_data_close_obj) },
+    { MP_ROM_QSTR(MP_QSTR_close),        MP_ROM_PTR(&pb_type_app_data_close_obj) },
+    { MP_ROM_QSTR(MP_QSTR_get_bytes),    MP_ROM_PTR(&pb_type_app_data_get_bytes_obj) },
+    { MP_ROM_QSTR(MP_QSTR_get_values),   MP_ROM_PTR(&pb_type_app_data_get_values_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_type_hostbuffer_locals_dict, pb_type_hostbuffer_locals_dict_table);
+STATIC MP_DEFINE_CONST_DICT(pb_type_app_data_locals_dict, pb_type_app_data_locals_dict_table);
 
-MP_DEFINE_CONST_OBJ_TYPE(pb_type_hostbuffer,
-    MP_QSTR_HostBuffer,
+MP_DEFINE_CONST_OBJ_TYPE(pb_type_app_data,
+    MP_QSTR_AppData,
     MP_TYPE_FLAG_NONE,
-    make_new, pb_type_hostbuffer_make_new,
-    locals_dict, &pb_type_hostbuffer_locals_dict);
+    make_new, pb_type_app_data_make_new,
+    locals_dict, &pb_type_app_data_locals_dict);
 
-#endif // PYBRICKS_PY_TOOLS_HOSTBUFFER
+#endif // PYBRICKS_PY_TOOLS_APP_DATA

--- a/pybricks/tools/pb_type_app_data.c
+++ b/pybricks/tools/pb_type_app_data.c
@@ -8,11 +8,13 @@
 #include <string.h>
 
 #include <pbsys/command.h>
+#include <pbdrv/bluetooth.h>
 
 #include "py/mphal.h"
 #include "py/objstr.h"
 
 #include <pybricks/tools.h>
+#include <pybricks/tools/pb_type_awaitable.h>
 
 #include <pybricks/util_mp/pb_kwarg_helper.h>
 #include <pybricks/util_mp/pb_obj_helper.h>
@@ -20,20 +22,24 @@
 
 typedef struct _pb_type_app_data_obj_t {
     mp_obj_base_t base;
-    mp_obj_t format;
-    mp_obj_str_t bytes_obj;
-    uint8_t rx_buffer[];
+    pbio_task_t tx_task;
+    pbdrv_bluetooth_send_context_t tx_context;
+    mp_obj_t rx_format;
+    mp_obj_str_t rx_bytes_obj;
+    uint8_t tx_buffer[PBDRV_BLUETOOTH_MAX_MTU_SIZE];
+    uint8_t rx_buffer[] __attribute__((aligned(4)));
 } pb_type_app_data_obj_t;
 
 // pointer to dynamically allocated app_data singleton for driver callback.
 static pb_type_app_data_obj_t *app_data_instance;
 
-static void handle_incoming_app_data(uint16_t offset, uint32_t size, const uint8_t *data) {
+static pbio_error_t handle_incoming_app_data(uint16_t offset, uint32_t size, const uint8_t *data) {
     // Can't write if rx_buffer does not exist or isn't big enough.
-    if (!app_data_instance || offset + size > app_data_instance->bytes_obj.len) {
-        return;
+    if (!app_data_instance || offset + size > app_data_instance->rx_bytes_obj.len) {
+        return PBIO_ERROR_INVALID_ARG;
     }
     memcpy(app_data_instance->rx_buffer + offset, data, size);
+    return PBIO_SUCCESS;
 }
 
 STATIC mp_obj_t pb_type_app_data_get_bytes(mp_obj_t self_in) {
@@ -41,35 +47,51 @@ STATIC mp_obj_t pb_type_app_data_get_bytes(mp_obj_t self_in) {
     // Don't return internal bytes object but make a copy so the user bytes
     // object is constant as would be expected. Revisit: enable and return
     // a memoryview, especially if using large buffers.
-    return mp_obj_new_bytes(self->bytes_obj.data, self->bytes_obj.len);
+    return mp_obj_new_bytes(self->rx_bytes_obj.data, self->rx_bytes_obj.len);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_app_data_get_bytes_obj, pb_type_app_data_get_bytes);
 
 STATIC mp_obj_t pb_type_app_data_get_values(mp_obj_t self_in) {
 
-    // One-off import for ustruct.unpack.
-    static mp_obj_t ustruct_unpack = NULL;
-    if (!ustruct_unpack) {
-        ustruct_unpack = pb_function_import_helper(MP_QSTR_ustruct, MP_QSTR_unpack);
-    }
+    // Implementation in MicroPython is static, so import from ustruct.unpack.
+    mp_obj_t ustruct_unpack = pb_function_import_helper(MP_QSTR_ustruct, MP_QSTR_unpack);
 
     // Host (sender) is responsible for making sure that each individual
     // value remains valid, i.e. is written in a single chunk, since the
     // following may allocate, and thus be updated between unpacking values.
     pb_type_app_data_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    return mp_call_function_2(ustruct_unpack, self->format, MP_OBJ_FROM_PTR(&self->bytes_obj));
+    return mp_call_function_2(ustruct_unpack, self->rx_format, MP_OBJ_FROM_PTR(&self->rx_bytes_obj));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_app_data_get_values_obj, pb_type_app_data_get_values);
 
+STATIC mp_obj_t pb_type_app_data_write_bytes(mp_obj_t self_in, mp_obj_t data_in) {
+    pb_type_app_data_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    // Copy data to local buffer. Needs to remain valid while sending.
+    size_t len;
+    const char *data = mp_obj_str_get_data(data_in, &len);
+
+    if (len > PBDRV_BLUETOOTH_MAX_MTU_SIZE - 1) {
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("Cannot send more than %d bytes\n"), PBDRV_BLUETOOTH_MAX_MTU_SIZE - 1);
+    }
+
+    memcpy(self->tx_buffer + 1, data, len);
+    self->tx_context.size = len + 1;
+
+    pbdrv_bluetooth_send_queued(&self->tx_task, &self->tx_context);
+    return pb_module_tools_pbio_task_wait_or_await(&self->tx_task);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(pb_type_app_data_write_bytes_obj, pb_type_app_data_write_bytes);
 
 STATIC mp_obj_t pb_type_app_data_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
 
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_REQUIRED(format));
+        PB_ARG_REQUIRED(rx_format));
 
-    // Use ustruct.calcsize to parse user format for size.
+    // Use ustruct.calcsize to parse user rx_format for size.
     mp_obj_t ustruct_calcsize = pb_function_import_helper(MP_QSTR_ustruct, MP_QSTR_calcsize);
-    size_t size = mp_obj_get_int(mp_call_function_1(ustruct_calcsize, format_in));
+    size_t size = mp_obj_get_int(mp_call_function_1(ustruct_calcsize, rx_format_in));
 
     // Can only create one instance for now.
     if (app_data_instance) {
@@ -79,15 +101,21 @@ STATIC mp_obj_t pb_type_app_data_make_new(const mp_obj_type_t *type, size_t n_ar
     // Use finalizer so we can deactivate the data callback when rx_buffer is garbage collected.
     app_data_instance = m_new_obj_var_with_finaliser(pb_type_app_data_obj_t, uint8_t, size);
     app_data_instance->base.type = type;
-    app_data_instance->format = format_in;
+    app_data_instance->rx_format = rx_format_in;
 
-    // Keep rx_buffer in bytes object format for compatibility with unpack.
-    app_data_instance->bytes_obj.base.type = &mp_type_bytes;
-    app_data_instance->bytes_obj.len = size;
-    app_data_instance->bytes_obj.data = app_data_instance->rx_buffer;
+    // Keep rx_buffer in bytes object rx_format for compatibility with unpack.
+    app_data_instance->rx_bytes_obj.base.type = &mp_type_bytes;
+    app_data_instance->rx_bytes_obj.len = size;
+    app_data_instance->rx_bytes_obj.data = app_data_instance->rx_buffer;
 
     // Activate callback now that we have allocated the rx_buffer.
     pbsys_command_set_write_app_data_callback(handle_incoming_app_data);
+
+    // Prepare tx context. Only the length and data is variable.
+    app_data_instance->tx_context.done = NULL;
+    app_data_instance->tx_context.connection = PBDRV_BLUETOOTH_CONNECTION_PYBRICKS;
+    app_data_instance->tx_context.data = app_data_instance->tx_buffer;
+    app_data_instance->tx_buffer[0] = PBIO_PYBRICKS_EVENT_WRITE_APP_DATA;
 
     return MP_OBJ_FROM_PTR(app_data_instance);
 }
@@ -106,6 +134,7 @@ STATIC const mp_rom_map_elem_t pb_type_app_data_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_close),        MP_ROM_PTR(&pb_type_app_data_close_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_bytes),    MP_ROM_PTR(&pb_type_app_data_get_bytes_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_values),   MP_ROM_PTR(&pb_type_app_data_get_values_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write_bytes),    MP_ROM_PTR(&pb_type_app_data_write_bytes_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(pb_type_app_data_locals_dict, pb_type_app_data_locals_dict_table);
 

--- a/pybricks/tools/pb_type_hostbuffer.c
+++ b/pybricks/tools/pb_type_hostbuffer.c
@@ -5,6 +5,10 @@
 
 #if PYBRICKS_PY_TOOLS_HOSTBUFFER
 
+#include <string.h>
+
+#include <pbsys/command.h>
+
 #include "py/mphal.h"
 
 #include <pybricks/tools.h>
@@ -15,22 +19,65 @@
 
 typedef struct _pb_type_hostbuffer_obj_t {
     mp_obj_base_t base;
+    uint32_t size;
+    uint8_t buffer[];
 } pb_type_hostbuffer_obj_t;
 
-STATIC mp_obj_t pb_type_hostbuffer_time(mp_obj_t self_in) {
-    pb_type_hostbuffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    (void)self;
-    return mp_obj_new_int(0);
+// pointer to dynamically allocated buffer_obj_singleton for driver callback.
+static pb_type_hostbuffer_obj_t *buffer_obj_singleton;
+
+static void handle_write_data_buffer(uint16_t offset, uint32_t size, const uint8_t *data) {
+    // Can't write if buffer does not exist or isn't big enough.
+    if (!buffer_obj_singleton || offset + size > buffer_obj_singleton->size) {
+        return;
+    }
+    memcpy(buffer_obj_singleton->buffer + offset, data, size);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_hostbuffer_time_obj, pb_type_hostbuffer_time);
+
+STATIC mp_obj_t pb_type_hostbuffer_get_data(mp_obj_t self_in) {
+    pb_type_hostbuffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    // REVISIT
+    // - offset and size args to read only what's needed
+    // - (python-level?) wrapper API using ustruct
+    return mp_obj_new_bytes(self->buffer, self->size);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_hostbuffer_get_data_obj, pb_type_hostbuffer_get_data);
 
 STATIC mp_obj_t pb_type_hostbuffer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    pb_type_hostbuffer_obj_t *self = mp_obj_malloc(pb_type_hostbuffer_obj_t, type);
-    return MP_OBJ_FROM_PTR(self);
+
+    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
+        PB_ARG_REQUIRED(size));
+
+    // Can only create one instance for now.
+    if (buffer_obj_singleton) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("host buffer already allocated"));
+    }
+
+    size_t size = mp_obj_get_int(size_in);
+
+    // Use finalizer so we can deactivate the data callback when buffer is garbage collected.
+    buffer_obj_singleton = m_new_obj_var_with_finaliser(pb_type_hostbuffer_obj_t, uint8_t, size);
+    buffer_obj_singleton->base.type = type;
+    buffer_obj_singleton->size = size;
+
+    pbsys_command_set_write_program_data_buffer_callback(handle_write_data_buffer);
+
+    return MP_OBJ_FROM_PTR(buffer_obj_singleton);
 }
 
+mp_obj_t pb_type_hostbuffer_close(mp_obj_t stream) {
+    if (buffer_obj_singleton) {
+        pbsys_command_set_write_program_data_buffer_callback(NULL);
+        buffer_obj_singleton = NULL;
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(pb_type_hostbuffer_close_obj, pb_type_hostbuffer_close);
+
 STATIC const mp_rom_map_elem_t pb_type_hostbuffer_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_time), MP_ROM_PTR(&pb_type_hostbuffer_time_obj) },
+    { MP_ROM_QSTR(MP_QSTR___del__),         MP_ROM_PTR(&pb_type_hostbuffer_close_obj) },
+    { MP_ROM_QSTR(MP_QSTR_close),           MP_ROM_PTR(&pb_type_hostbuffer_close_obj) },
+    { MP_ROM_QSTR(MP_QSTR_get_data),        MP_ROM_PTR(&pb_type_hostbuffer_get_data_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(pb_type_hostbuffer_locals_dict, pb_type_hostbuffer_locals_dict_table);
 

--- a/pybricks/tools/pb_type_hostbuffer.c
+++ b/pybricks/tools/pb_type_hostbuffer.c
@@ -10,6 +10,7 @@
 #include <pbsys/command.h>
 
 #include "py/mphal.h"
+#include "py/objstr.h"
 
 #include <pybricks/tools.h>
 
@@ -19,70 +20,97 @@
 
 typedef struct _pb_type_hostbuffer_obj_t {
     mp_obj_base_t base;
-    uint32_t size;
+    mp_obj_t format;
+    mp_obj_str_t bytes_obj;
     uint8_t buffer[];
 } pb_type_hostbuffer_obj_t;
 
-// pointer to dynamically allocated buffer_obj_singleton for driver callback.
-static pb_type_hostbuffer_obj_t *buffer_obj_singleton;
+// pointer to dynamically allocated hostbuffer singleton for driver callback.
+static pb_type_hostbuffer_obj_t *hostbuffer_instance;
 
 static void handle_write_data_buffer(uint16_t offset, uint32_t size, const uint8_t *data) {
     // Can't write if buffer does not exist or isn't big enough.
-    if (!buffer_obj_singleton || offset + size > buffer_obj_singleton->size) {
+    if (!hostbuffer_instance || offset + size > hostbuffer_instance->bytes_obj.len) {
         return;
     }
-    memcpy(buffer_obj_singleton->buffer + offset, data, size);
+    memcpy(hostbuffer_instance->buffer + offset, data, size);
 }
 
-STATIC mp_obj_t pb_type_hostbuffer_get_data(mp_obj_t self_in) {
+STATIC mp_obj_t pb_type_hostbuffer_get_bytes(mp_obj_t self_in) {
     pb_type_hostbuffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    // REVISIT
-    // - offset and size args to read only what's needed
-    // - (python-level?) wrapper API using ustruct
-    return mp_obj_new_bytes(self->buffer, self->size);
+    // Don't return internal bytes object but make a copy so the user bytes
+    // object is constant as would be expected. Revisit: enable and return
+    // a memoryview, especially if using large buffers.
+    return mp_obj_new_bytes(self->bytes_obj.data, self->bytes_obj.len);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_hostbuffer_get_data_obj, pb_type_hostbuffer_get_data);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_hostbuffer_get_bytes_obj, pb_type_hostbuffer_get_bytes);
+
+STATIC mp_obj_t pb_type_hostbuffer_get_values(mp_obj_t self_in) {
+
+    // One-off import for ustruct.unpack.
+    static mp_obj_t ustruct_unpack = NULL;
+    if (!ustruct_unpack) {
+        ustruct_unpack = pb_function_import_helper(MP_QSTR_ustruct, MP_QSTR_unpack);
+    }
+
+    // Host (sender) is responsible for making sure that each individual
+    // value remains valid, i.e. is written in a single chunk, since the
+    // following may allocate, and thus be updated between unpacking values.
+    pb_type_hostbuffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_call_function_2(ustruct_unpack, self->format, MP_OBJ_FROM_PTR(&self->bytes_obj));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_hostbuffer_get_values_obj, pb_type_hostbuffer_get_values);
+
 
 STATIC mp_obj_t pb_type_hostbuffer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
 
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_REQUIRED(size));
+        PB_ARG_REQUIRED(format));
+
+    // Use ustruct.calcsize to parse user format for size.
+    mp_obj_t ustruct_calcsize = pb_function_import_helper(MP_QSTR_ustruct, MP_QSTR_calcsize);
+    size_t size = mp_obj_get_int(mp_call_function_1(ustruct_calcsize, format_in));
 
     // Can only create one instance for now.
-    if (buffer_obj_singleton) {
+    if (hostbuffer_instance) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("host buffer already allocated"));
     }
 
-    size_t size = mp_obj_get_int(size_in);
-
     // Use finalizer so we can deactivate the data callback when buffer is garbage collected.
-    buffer_obj_singleton = m_new_obj_var_with_finaliser(pb_type_hostbuffer_obj_t, uint8_t, size);
-    buffer_obj_singleton->base.type = type;
-    buffer_obj_singleton->size = size;
+    hostbuffer_instance = m_new_obj_var_with_finaliser(pb_type_hostbuffer_obj_t, uint8_t, size);
+    hostbuffer_instance->base.type = type;
+    hostbuffer_instance->format = format_in;
 
+    // Keep buffer in bytes object format for compatibility with unpack.
+    hostbuffer_instance->bytes_obj.base.type = &mp_type_bytes;
+    hostbuffer_instance->bytes_obj.len = size;
+    hostbuffer_instance->bytes_obj.data = hostbuffer_instance->buffer;
+
+    // Activate callback now that we have allocated the buffer.
     pbsys_command_set_write_program_data_buffer_callback(handle_write_data_buffer);
 
-    return MP_OBJ_FROM_PTR(buffer_obj_singleton);
+    return MP_OBJ_FROM_PTR(hostbuffer_instance);
 }
 
 mp_obj_t pb_type_hostbuffer_close(mp_obj_t stream) {
-    if (buffer_obj_singleton) {
+    if (hostbuffer_instance) {
         pbsys_command_set_write_program_data_buffer_callback(NULL);
-        buffer_obj_singleton = NULL;
+        hostbuffer_instance = NULL;
     }
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_hostbuffer_close_obj, pb_type_hostbuffer_close);
 
 STATIC const mp_rom_map_elem_t pb_type_hostbuffer_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR___del__),         MP_ROM_PTR(&pb_type_hostbuffer_close_obj) },
-    { MP_ROM_QSTR(MP_QSTR_close),           MP_ROM_PTR(&pb_type_hostbuffer_close_obj) },
-    { MP_ROM_QSTR(MP_QSTR_get_data),        MP_ROM_PTR(&pb_type_hostbuffer_get_data_obj) },
+    { MP_ROM_QSTR(MP_QSTR___del__),      MP_ROM_PTR(&pb_type_hostbuffer_close_obj) },
+    { MP_ROM_QSTR(MP_QSTR_close),        MP_ROM_PTR(&pb_type_hostbuffer_close_obj) },
+    { MP_ROM_QSTR(MP_QSTR_get_bytes),    MP_ROM_PTR(&pb_type_hostbuffer_get_bytes_obj) },
+    { MP_ROM_QSTR(MP_QSTR_get_values),   MP_ROM_PTR(&pb_type_hostbuffer_get_values_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(pb_type_hostbuffer_locals_dict, pb_type_hostbuffer_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_hostbuffer,
-    MP_QSTR_hostbuffer,
+    MP_QSTR_HostBuffer,
     MP_TYPE_FLAG_NONE,
     make_new, pb_type_hostbuffer_make_new,
     locals_dict, &pb_type_hostbuffer_locals_dict);

--- a/pybricks/tools/pb_type_hostbuffer.c
+++ b/pybricks/tools/pb_type_hostbuffer.c
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 The Pybricks Authors
+
+#include "py/mpconfig.h"
+
+#if PYBRICKS_PY_TOOLS_HOSTBUFFER
+
+#include "py/mphal.h"
+
+#include <pybricks/tools.h>
+
+#include <pybricks/util_mp/pb_kwarg_helper.h>
+#include <pybricks/util_mp/pb_obj_helper.h>
+#include <pybricks/util_pb/pb_error.h>
+
+typedef struct _pb_type_hostbuffer_obj_t {
+    mp_obj_base_t base;
+} pb_type_hostbuffer_obj_t;
+
+STATIC mp_obj_t pb_type_hostbuffer_time(mp_obj_t self_in) {
+    pb_type_hostbuffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    (void)self;
+    return mp_obj_new_int(0);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_hostbuffer_time_obj, pb_type_hostbuffer_time);
+
+STATIC mp_obj_t pb_type_hostbuffer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    pb_type_hostbuffer_obj_t *self = mp_obj_malloc(pb_type_hostbuffer_obj_t, type);
+    return MP_OBJ_FROM_PTR(self);
+}
+
+STATIC const mp_rom_map_elem_t pb_type_hostbuffer_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_time), MP_ROM_PTR(&pb_type_hostbuffer_time_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(pb_type_hostbuffer_locals_dict, pb_type_hostbuffer_locals_dict_table);
+
+MP_DEFINE_CONST_OBJ_TYPE(pb_type_hostbuffer,
+    MP_QSTR_hostbuffer,
+    MP_TYPE_FLAG_NONE,
+    make_new, pb_type_hostbuffer_make_new,
+    locals_dict, &pb_type_hostbuffer_locals_dict);
+
+#endif // PYBRICKS_PY_TOOLS_HOSTBUFFER


### PR DESCRIPTION
This adds a class that allows a user program to allocate a buffer for receiving data from an IDE.

It has similarities to receiving data over standard in, but it is a dedicated separate command. The data is not queued but (over)written to a fixed size buffer. This is a bit like downloading a program, but with user-readable data.

This is useful for applications where the buffer contains "sensor data"-like contents prepared by the IDE.

Usage is as follows:

```python
from pybricks.tools import HostBuffer

# Allocates buffer 4 bytes. From here, the program is ready to receive
# data write commands to this buffer from a connected host like Pybricks Code. 
buffer = HostBuffer("hbb")

# Returns tuple with 3 values (int16, int8, int8)
values = buffer.get_values()

# Returns bytes copy of the 4-byte buffer.
data = buffer.get_bytes()

# gc collection of the buffer will automatically stop processing
# received data write commands. If Pybricks Code sends more, they
# are just ignored.
```

Before merging this as-is, it might be useful to thinking about the complementary case as well, where the user program can write data back to the IDE. This could facilitate things like live sensor port view without messing with stdout.