### PR TITLE
Allow Bluetooth to be toggled off/on with Bluetooth button.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- Allow Bluetooth to be toggled off and on with the Bluetooth button on the
+  Prime Hub and the Inventor Hub ([support#1615]).
+
+[support#1615]: https://github.com/pybricks/support/issues/1615
+
 ## [3.5.0] - 2024-04-11
 
 ### Changed

--- a/lib/pbio/include/pbio/protocol.h
+++ b/lib/pbio/include/pbio/protocol.h
@@ -241,12 +241,6 @@ typedef enum {
      * @since Pybricks Profile v1.2.0
      */
     PBIO_PYBRICKS_STATUS_SHUTDOWN_REQUEST = 8,
-    /**
-     * Bluetooth Low Energy is enabled.
-     *
-     * @since Pybricks Profile v1.4.0
-     */
-    PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED = 9,
     /** Total number of indications. */
     NUM_PBIO_PYBRICKS_STATUS,
 } pbio_pybricks_status_t;

--- a/lib/pbio/include/pbio/protocol.h
+++ b/lib/pbio/include/pbio/protocol.h
@@ -241,6 +241,12 @@ typedef enum {
      * @since Pybricks Profile v1.2.0
      */
     PBIO_PYBRICKS_STATUS_SHUTDOWN_REQUEST = 8,
+    /**
+     * Bluetooth Low Energy is enabled.
+     *
+     * @since Pybricks Profile v1.4.0
+     */
+    PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED = 9,
     /** Total number of indications. */
     NUM_PBIO_PYBRICKS_STATUS,
 } pbio_pybricks_status_t;

--- a/lib/pbio/include/pbsys/bluetooth.h
+++ b/lib/pbio/include/pbsys/bluetooth.h
@@ -32,13 +32,7 @@ uint32_t pbsys_bluetooth_rx_get_available(void);
 pbio_error_t pbsys_bluetooth_rx(uint8_t *data, uint32_t *size);
 pbio_error_t pbsys_bluetooth_tx(const uint8_t *data, uint32_t *size);
 bool pbsys_bluetooth_tx_is_idle(void);
-
-#if PBSYS_CONFIG_BLUETOOTH_TOGGLE
 void pbsys_bluetooth_enabled_state_request_toggle(void);
-#else
-static inline void pbsys_bluetooth_enabled_state_request_toggle(void) {
-}
-#endif
 
 #else // PBSYS_CONFIG_BLUETOOTH
 

--- a/lib/pbio/include/pbsys/bluetooth.h
+++ b/lib/pbio/include/pbsys/bluetooth.h
@@ -33,6 +33,13 @@ pbio_error_t pbsys_bluetooth_rx(uint8_t *data, uint32_t *size);
 pbio_error_t pbsys_bluetooth_tx(const uint8_t *data, uint32_t *size);
 bool pbsys_bluetooth_tx_is_idle(void);
 
+#if PBSYS_CONFIG_BLUETOOTH_TOGGLE
+void pbsys_bluetooth_enabled_state_request_toggle(void);
+#else
+static inline void pbsys_bluetooth_enabled_state_request_toggle(void) {
+}
+#endif
+
 #else // PBSYS_CONFIG_BLUETOOTH
 
 #define pbsys_bluetooth_init()
@@ -48,6 +55,8 @@ static inline pbio_error_t pbsys_bluetooth_tx(const uint8_t *data, uint32_t *siz
 }
 static inline bool pbsys_bluetooth_tx_is_idle(void) {
     return false;
+}
+static inline void pbsys_bluetooth_enabled_state_request_toggle(void) {
 }
 
 #endif // PBSYS_CONFIG_BLUETOOTH

--- a/lib/pbio/include/pbsys/bluetooth.h
+++ b/lib/pbio/include/pbsys/bluetooth.h
@@ -32,7 +32,8 @@ uint32_t pbsys_bluetooth_rx_get_available(void);
 pbio_error_t pbsys_bluetooth_rx(uint8_t *data, uint32_t *size);
 pbio_error_t pbsys_bluetooth_tx(const uint8_t *data, uint32_t *size);
 bool pbsys_bluetooth_tx_is_idle(void);
-void pbsys_bluetooth_enabled_state_request_toggle(void);
+bool pbsys_bluetooth_is_user_enabled(void);
+void pbsys_bluetooth_is_user_enabled_request_toggle(void);
 
 #else // PBSYS_CONFIG_BLUETOOTH
 
@@ -50,7 +51,10 @@ static inline pbio_error_t pbsys_bluetooth_tx(const uint8_t *data, uint32_t *siz
 static inline bool pbsys_bluetooth_tx_is_idle(void) {
     return false;
 }
-static inline void pbsys_bluetooth_enabled_state_request_toggle(void) {
+static inline void pbsys_bluetooth_is_user_enabled_request_toggle(void) {
+}
+static inline bool pbsys_bluetooth_is_user_enabled(void) {
+    return true;
 }
 
 #endif // PBSYS_CONFIG_BLUETOOTH

--- a/lib/pbio/platform/city_hub/pbsysconfig.h
+++ b/lib/pbio/platform/city_hub/pbsysconfig.h
@@ -14,4 +14,5 @@
 #define PBSYS_CONFIG_PROGRAM_LOAD_USER_DATA_SIZE    (128)
 #define PBSYS_CONFIG_STATUS_LIGHT                   (1)
 #define PBSYS_CONFIG_STATUS_LIGHT_BATTERY           (0)
+#define PBSYS_CONFIG_STATUS_LIGHT_BLUETOOTH         (0)
 #define PBSYS_CONFIG_PROGRAM_STOP                   (1)

--- a/lib/pbio/platform/debug/pbsysconfig.h
+++ b/lib/pbio/platform/debug/pbsysconfig.h
@@ -12,4 +12,5 @@
 #define PBSYS_CONFIG_PROGRAM_LOAD_USER_DATA_SIZE    (512)
 #define PBSYS_CONFIG_STATUS_LIGHT                   (1)
 #define PBSYS_CONFIG_STATUS_LIGHT_BATTERY           (0)
+#define PBSYS_CONFIG_STATUS_LIGHT_BLUETOOTH         (0)
 #define PBSYS_CONFIG_PROGRAM_STOP                   (1)

--- a/lib/pbio/platform/essential_hub/pbsysconfig.h
+++ b/lib/pbio/platform/essential_hub/pbsysconfig.h
@@ -12,4 +12,5 @@
 #define PBSYS_CONFIG_PROGRAM_LOAD_USER_DATA_SIZE    (512)
 #define PBSYS_CONFIG_STATUS_LIGHT                   (1)
 #define PBSYS_CONFIG_STATUS_LIGHT_BATTERY           (1)
+#define PBSYS_CONFIG_STATUS_LIGHT_BLUETOOTH         (0)
 #define PBSYS_CONFIG_PROGRAM_STOP                   (1)

--- a/lib/pbio/platform/ev3/pbsysconfig.h
+++ b/lib/pbio/platform/ev3/pbsysconfig.h
@@ -10,4 +10,5 @@
 #define PBSYS_CONFIG_PROGRAM_LOAD_AUTO_START        (1)
 #define PBSYS_CONFIG_STATUS_LIGHT                   (0)
 #define PBSYS_CONFIG_STATUS_LIGHT_BATTERY           (0)
+#define PBSYS_CONFIG_STATUS_LIGHT_BLUETOOTH         (0)
 #define PBSYS_CONFIG_PROGRAM_STOP                   (0)

--- a/lib/pbio/platform/ev3rt/pbsysconfig.h
+++ b/lib/pbio/platform/ev3rt/pbsysconfig.h
@@ -8,4 +8,5 @@
 #define PBSYS_CONFIG_PROGRAM_LOAD                   (0)
 #define PBSYS_CONFIG_STATUS_LIGHT                   (0)
 #define PBSYS_CONFIG_STATUS_LIGHT_BATTERY           (0)
+#define PBSYS_CONFIG_STATUS_LIGHT_BLUETOOTH         (0)
 #define PBSYS_CONFIG_PROGRAM_STOP                   (1)

--- a/lib/pbio/platform/move_hub/pbsysconfig.h
+++ b/lib/pbio/platform/move_hub/pbsysconfig.h
@@ -14,4 +14,5 @@
 #define PBSYS_CONFIG_PROGRAM_LOAD_USER_DATA_SIZE    (128)
 #define PBSYS_CONFIG_STATUS_LIGHT                   (1)
 #define PBSYS_CONFIG_STATUS_LIGHT_BATTERY           (0)
+#define PBSYS_CONFIG_STATUS_LIGHT_BLUETOOTH         (0)
 #define PBSYS_CONFIG_PROGRAM_STOP                   (1)

--- a/lib/pbio/platform/nxt/pbsysconfig.h
+++ b/lib/pbio/platform/nxt/pbsysconfig.h
@@ -9,4 +9,5 @@
 #define PBSYS_CONFIG_PROGRAM_LOAD_AUTO_START        (1)
 #define PBSYS_CONFIG_STATUS_LIGHT                   (0)
 #define PBSYS_CONFIG_STATUS_LIGHT_BATTERY           (0)
+#define PBSYS_CONFIG_STATUS_LIGHT_BLUETOOTH         (0)
 #define PBSYS_CONFIG_PROGRAM_STOP                   (1)

--- a/lib/pbio/platform/prime_hub/pbsysconfig.h
+++ b/lib/pbio/platform/prime_hub/pbsysconfig.h
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2020-2023 The Pybricks Authors
 
-#include <pbio/button.h>
-
 #define PBSYS_CONFIG_BATTERY_CHARGER                (1)
 #define PBSYS_CONFIG_BLUETOOTH                      (1)
 #define PBSYS_CONFIG_BLUETOOTH_TOGGLE               (1)
-#define PBSYS_CONFIG_BLUETOOTH_TOGGLE_BUTTON        (512) // PBIO_BUTTON_RIGHT_UP
+#define PBSYS_CONFIG_BLUETOOTH_TOGGLE_BUTTON        (512) // PBIO_BUTTON_RIGHT_UP, but enum value cannot be used here.
 #define PBSYS_CONFIG_HUB_LIGHT_MATRIX               (1)
 #define PBSYS_CONFIG_MAIN                           (1)
 #define PBSYS_CONFIG_PROGRAM_LOAD                   (1)
@@ -16,4 +14,5 @@
 #define PBSYS_CONFIG_PROGRAM_LOAD_USER_DATA_SIZE    (512)
 #define PBSYS_CONFIG_STATUS_LIGHT                   (1)
 #define PBSYS_CONFIG_STATUS_LIGHT_BATTERY           (1)
+#define PBSYS_CONFIG_STATUS_LIGHT_BLUETOOTH         (1)
 #define PBSYS_CONFIG_PROGRAM_STOP                   (1)

--- a/lib/pbio/platform/prime_hub/pbsysconfig.h
+++ b/lib/pbio/platform/prime_hub/pbsysconfig.h
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2020-2023 The Pybricks Authors
 
+#include <pbio/button.h>
+
 #define PBSYS_CONFIG_BATTERY_CHARGER                (1)
 #define PBSYS_CONFIG_BLUETOOTH                      (1)
+#define PBSYS_CONFIG_BLUETOOTH_TOGGLE               (1)
+#define PBSYS_CONFIG_BLUETOOTH_TOGGLE_BUTTON        (512) // PBIO_BUTTON_RIGHT_UP
 #define PBSYS_CONFIG_HUB_LIGHT_MATRIX               (1)
 #define PBSYS_CONFIG_MAIN                           (1)
 #define PBSYS_CONFIG_PROGRAM_LOAD                   (1)

--- a/lib/pbio/platform/technic_hub/pbsysconfig.h
+++ b/lib/pbio/platform/technic_hub/pbsysconfig.h
@@ -14,4 +14,5 @@
 #define PBSYS_CONFIG_PROGRAM_LOAD_USER_DATA_SIZE    (128)
 #define PBSYS_CONFIG_STATUS_LIGHT                   (1)
 #define PBSYS_CONFIG_STATUS_LIGHT_BATTERY           (0)
+#define PBSYS_CONFIG_STATUS_LIGHT_BLUETOOTH         (0)
 #define PBSYS_CONFIG_PROGRAM_STOP                   (1)

--- a/lib/pbio/platform/virtual_hub/pbsysconfig.h
+++ b/lib/pbio/platform/virtual_hub/pbsysconfig.h
@@ -8,4 +8,5 @@
 #define PBSYS_CONFIG_PROGRAM_LOAD                   (0)
 #define PBSYS_CONFIG_STATUS_LIGHT                   (0)
 #define PBSYS_CONFIG_STATUS_LIGHT_BATTERY           (0)
+#define PBSYS_CONFIG_STATUS_LIGHT_BLUETOOTH         (0)
 #define PBSYS_CONFIG_PROGRAM_STOP                   (0)

--- a/lib/pbio/sys/bluetooth.c
+++ b/lib/pbio/sys/bluetooth.c
@@ -200,7 +200,11 @@ bool pbsys_bluetooth_tx_is_idle(void) {
 
 static bool pbsys_bluetooth_user_enabled = true;
 
-void pbsys_bluetooth_enabled_state_request_toggle(void) {
+bool pbsys_bluetooth_is_user_enabled(void) {
+    return pbsys_bluetooth_user_enabled;
+}
+
+void pbsys_bluetooth_is_user_enabled_request_toggle(void) {
 
     // Ignore toggle request in all but idle system status.
     if (pbsys_status_test(PBIO_PYBRICKS_STATUS_USER_PROGRAM_RUNNING)

--- a/lib/pbio/sys/bluetooth.c
+++ b/lib/pbio/sys/bluetooth.c
@@ -22,6 +22,8 @@
 #include <pbsys/command.h>
 #include <pbsys/status.h>
 
+#include "light.h"
+
 // REVISIT: this can be the negotiated MTU - 3 to allow for better throughput
 #define MAX_CHAR_SIZE 20
 
@@ -47,11 +49,13 @@ PROCESS(pbsys_bluetooth_process, "Bluetooth");
 
 static void bluetooth_start(void) {
     pbsys_status_set(PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED);
+    pbsys_status_light_bluetooth_set_color(PBIO_COLOR_BLUE);
     process_start(&pbsys_bluetooth_process);
 }
 
 static void bluetooth_stop(void) {
     pbsys_status_clear(PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED);
+    pbsys_status_light_bluetooth_set_color(PBIO_COLOR_RED);
     process_exit(&pbsys_bluetooth_process);
 }
 

--- a/lib/pbio/sys/bluetooth.c
+++ b/lib/pbio/sys/bluetooth.c
@@ -55,6 +55,8 @@ void pbsys_bluetooth_init(void) {
 
     lwrb_init(&stdout_ring_buf, stdout_buf, PBIO_ARRAY_SIZE(stdout_buf));
     lwrb_init(&stdin_ring_buf, stdin_buf, PBIO_ARRAY_SIZE(stdin_buf));
+
+    pbsys_status_set(PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED);
     process_start(&pbsys_bluetooth_process);
 }
 
@@ -197,8 +199,6 @@ bool pbsys_bluetooth_tx_is_idle(void) {
 
 #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
 
-static bool bluetooth_enabled_by_user = true;
-
 void pbsys_bluetooth_enabled_state_request_toggle(void) {
 
     // Ignore toggle request in all but idle system status.
@@ -213,12 +213,13 @@ void pbsys_bluetooth_enabled_state_request_toggle(void) {
         return;
     }
 
-    bluetooth_enabled_by_user = !bluetooth_enabled_by_user;
-
-    if (bluetooth_enabled_by_user) {
-        process_start(&pbsys_bluetooth_process);
-    } else {
+    // Toggle BLE flag and Bluetooth system process.
+    if (pbsys_status_test(PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED)) {
+        pbsys_status_clear(PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED);
         process_exit(&pbsys_bluetooth_process);
+    } else {
+        pbsys_status_set(PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED);
+        process_start(&pbsys_bluetooth_process);
     }
 }
 #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE

--- a/lib/pbio/sys/core.c
+++ b/lib/pbio/sys/core.c
@@ -13,6 +13,7 @@
 #include "core.h"
 #include "hmi.h"
 #include "io_ports.h"
+#include "light.h"
 #include "program_load.h"
 #include "supervisor.h"
 #include "program_stop.h"
@@ -57,6 +58,8 @@ void pbsys_init(void) {
 }
 
 void pbsys_deinit(void) {
+
+    pbsys_status_light_bluetooth_deinit();
     pbsys_program_load_deinit();
 
     uint32_t start = pbdrv_clock_get_ms();

--- a/lib/pbio/sys/hmi.c
+++ b/lib/pbio/sys/hmi.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2022 The Pybricks Authors
+// Copyright (c) 2018-2024 The Pybricks Authors
 
 // Provides Human Machine Interface (HMI) between hub and user.
 
-// TODO: implement additional buttons and Bluetooth light for SPIKE Prime
+// TODO: implement additional buttons and menu system (via matrix display) for SPIKE Prime
 // TODO: implement additional buttons and menu system (via screen) for NXT
 
 #include <stdbool.h>
@@ -19,6 +19,7 @@
 #include <pbio/color.h>
 #include <pbio/event.h>
 #include <pbio/light.h>
+#include <pbsys/bluetooth.h>
 #include <pbsys/config.h>
 #include <pbsys/status.h>
 
@@ -57,10 +58,45 @@ static PT_THREAD(update_program_run_button_wait_state(bool button_pressed)) {
     PT_END(pt);
 }
 
+#if PBSYS_CONFIG_BLUETOOTH_TOGGLE
+
+static struct pt update_bluetooth_button_wait_state_pt;
+
+/**
+ * Protothread to monitor the button state to toggle Bluetooth.
+ * @param [in]  button_pressed      The current button state.
+ */
+static PT_THREAD(update_bluetooth_button_wait_state(bool button_pressed)) {
+    struct pt *pt = &update_bluetooth_button_wait_state_pt;
+    // HACK: Misuse of protothread to reduce code size. This is the same
+    // as checking if the user program is running after each PT_WAIT.
+    if (pbsys_status_test(PBIO_PYBRICKS_STATUS_USER_PROGRAM_RUNNING)) {
+        goto start;
+    }
+
+    PT_BEGIN(pt);
+
+    for (;;) {
+    start:
+        // button may still be pressed during user program
+        PT_WAIT_UNTIL(pt, !button_pressed);
+        PT_WAIT_UNTIL(pt, button_pressed);
+        pbsys_bluetooth_enabled_state_request_toggle();
+    }
+
+    PT_END(pt);
+}
+
+#endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE
+
 void pbsys_hmi_init(void) {
     pbsys_status_light_init();
     pbsys_hub_light_matrix_init();
     PT_INIT(&update_program_run_button_wait_state_pt);
+
+    #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
+    PT_INIT(&update_bluetooth_button_wait_state_pt);
+    #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE
 }
 
 void pbsys_hmi_handle_event(process_event_t event, process_data_t data) {
@@ -101,6 +137,10 @@ void pbsys_hmi_poll(void) {
             pbsys_status_clear(PBIO_PYBRICKS_STATUS_POWER_BUTTON_PRESSED);
             update_program_run_button_wait_state(false);
         }
+
+        #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
+        update_bluetooth_button_wait_state(btn & PBSYS_CONFIG_BLUETOOTH_TOGGLE_BUTTON);
+        #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE
     }
 
     pbsys_status_light_poll();

--- a/lib/pbio/sys/hmi.c
+++ b/lib/pbio/sys/hmi.c
@@ -81,7 +81,7 @@ static PT_THREAD(update_bluetooth_button_wait_state(bool button_pressed)) {
         // button may still be pressed during user program
         PT_WAIT_UNTIL(pt, !button_pressed);
         PT_WAIT_UNTIL(pt, button_pressed);
-        pbsys_bluetooth_enabled_state_request_toggle();
+        pbsys_bluetooth_is_user_enabled_request_toggle();
     }
 
     PT_END(pt);

--- a/lib/pbio/sys/hmi.c
+++ b/lib/pbio/sys/hmi.c
@@ -26,14 +26,14 @@
 #include "light.h"
 #include "program_load.h"
 
-static struct pt user_program_start_pt;
+static struct pt update_program_run_button_wait_state_pt;
 
 /**
  * Protothread to monitor the button state to trigger starting the user program.
  * @param [in]  button_pressed      The current button state.
  */
-static PT_THREAD(user_program_start(bool button_pressed)) {
-    struct pt *pt = &user_program_start_pt;
+static PT_THREAD(update_program_run_button_wait_state(bool button_pressed)) {
+    struct pt *pt = &update_program_run_button_wait_state_pt;
     // HACK: Misuse of protothread to reduce code size. This is the same
     // as checking if the user program is running after each PT_WAIT.
     if (pbsys_status_test(PBIO_PYBRICKS_STATUS_USER_PROGRAM_RUNNING)) {
@@ -60,7 +60,7 @@ static PT_THREAD(user_program_start(bool button_pressed)) {
 void pbsys_hmi_init(void) {
     pbsys_status_light_init();
     pbsys_hub_light_matrix_init();
-    PT_INIT(&user_program_start_pt);
+    PT_INIT(&update_program_run_button_wait_state_pt);
 }
 
 void pbsys_hmi_handle_event(process_event_t event, process_data_t data) {
@@ -91,7 +91,7 @@ void pbsys_hmi_poll(void) {
     if (pbio_button_is_pressed(&btn) == PBIO_SUCCESS) {
         if (btn & PBIO_BUTTON_CENTER) {
             pbsys_status_set(PBIO_PYBRICKS_STATUS_POWER_BUTTON_PRESSED);
-            user_program_start(true);
+            update_program_run_button_wait_state(true);
 
             // power off when button is held down for 3 seconds
             if (pbsys_status_test_debounce(PBIO_PYBRICKS_STATUS_POWER_BUTTON_PRESSED, true, 3000)) {
@@ -99,7 +99,7 @@ void pbsys_hmi_poll(void) {
             }
         } else {
             pbsys_status_clear(PBIO_PYBRICKS_STATUS_POWER_BUTTON_PRESSED);
-            user_program_start(false);
+            update_program_run_button_wait_state(false);
         }
     }
 

--- a/lib/pbio/sys/light.c
+++ b/lib/pbio/sys/light.c
@@ -392,3 +392,19 @@ void pbsys_status_light_poll(void) {
 }
 
 #endif // PBSYS_CONFIG_STATUS_LIGHT
+
+#if PBSYS_CONFIG_STATUS_LIGHT_BLUETOOTH
+void pbsys_status_light_bluetooth_set_color(pbio_color_t color) {
+    pbdrv_led_dev_t *led;
+    // FIXME: Bluetooth light is currently hard-coded to id 2 on all platforms
+    if (pbdrv_led_get_dev(2, &led) == PBIO_SUCCESS) {
+        pbio_color_hsv_t hsv;
+        pbio_color_to_hsv(color, &hsv);
+        pbdrv_led_set_hsv(led, &hsv);
+    }
+}
+
+void pbsys_status_light_bluetooth_deinit(void) {
+    pbsys_status_light_bluetooth_set_color(PBIO_COLOR_NONE);
+}
+#endif

--- a/lib/pbio/sys/light.h
+++ b/lib/pbio/sys/light.h
@@ -6,6 +6,7 @@
 
 #include <contiki.h>
 
+#include <pbio/color.h>
 #include <pbsys/config.h>
 
 #if PBSYS_CONFIG_STATUS_LIGHT
@@ -16,6 +17,16 @@ void pbsys_status_light_poll(void);
 #define pbsys_status_light_init()
 #define pbsys_status_light_handle_event(event, data)
 #define pbsys_status_light_poll()
+#endif
+
+#if PBSYS_CONFIG_STATUS_LIGHT_BLUETOOTH
+void pbsys_status_light_bluetooth_set_color(pbio_color_t color);
+void pbsys_status_light_bluetooth_deinit(void);
+#else
+static inline void pbsys_status_light_bluetooth_set_color(pbio_color_t color) {
+}
+static inline void pbsys_status_light_bluetooth_deinit(void) {
+}
 #endif
 
 #endif // _PBSYS_SYS_LIGHT_H_

--- a/pybricks/common/pb_type_ble.c
+++ b/pybricks/common/pb_type_ble.c
@@ -12,7 +12,7 @@
 #include <pbdrv/bluetooth.h>
 
 #include <pbsys/config.h>
-#include <pbsys/status.h>
+#include <pbsys/bluetooth.h>
 
 #include "py/obj.h"
 #include "py/misc.h"
@@ -267,7 +267,7 @@ STATIC mp_obj_t pb_module_ble_broadcast(size_t n_args, const mp_obj_t *pos_args,
     // but it may still pass there since 0 is a valid broadcast channel. That
     // should be fixed by defaulting to None if no broadcast channel is provided.
     #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
-    if (!pbsys_status_test(PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED)) {
+    if (!pbsys_bluetooth_is_user_enabled()) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Bluetooth not enabled"));
     }
     #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE
@@ -534,7 +534,7 @@ mp_obj_t pb_type_BLE_new(mp_obj_t broadcast_channel_in, mp_obj_t observe_channel
     mp_int_t num_channels = mp_obj_get_int(mp_obj_len(observe_channels_in));
 
     #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
-    if (!pbsys_status_test(PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED) && (num_channels > 0 || broadcast_channel)) {
+    if (!pbsys_bluetooth_is_user_enabled() && (num_channels > 0 || broadcast_channel)) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Bluetooth not enabled"));
     }
     #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE

--- a/pybricks/iodevices/pb_type_iodevices_lwp3device.c
+++ b/pybricks/iodevices/pb_type_iodevices_lwp3device.c
@@ -16,7 +16,7 @@
 #include <pbio/task.h>
 
 #include <pbsys/config.h>
-#include <pbsys/status.h>
+#include <pbsys/bluetooth.h>
 
 #include <pybricks/common.h>
 #include <pybricks/parameters.h>
@@ -380,7 +380,7 @@ STATIC mp_obj_t pb_type_pupdevices_Remote_make_new(const mp_obj_type_t *type, si
         PB_ARG_DEFAULT_INT(timeout, 10000));
 
     #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
-    if (!pbsys_status_test(PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED)) {
+    if (!pbsys_bluetooth_is_user_enabled()) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Bluetooth not enabled"));
     }
     #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE

--- a/pybricks/iodevices/pb_type_iodevices_lwp3device.c
+++ b/pybricks/iodevices/pb_type_iodevices_lwp3device.c
@@ -9,10 +9,14 @@
 #include <string.h>
 
 #include <pbdrv/bluetooth.h>
+
 #include <pbio/button.h>
 #include <pbio/color.h>
 #include <pbio/error.h>
 #include <pbio/task.h>
+
+#include <pbsys/config.h>
+#include <pbsys/status.h>
 
 #include <pybricks/common.h>
 #include <pybricks/parameters.h>
@@ -374,6 +378,12 @@ STATIC mp_obj_t pb_type_pupdevices_Remote_make_new(const mp_obj_type_t *type, si
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_DEFAULT_NONE(name),
         PB_ARG_DEFAULT_INT(timeout, 10000));
+
+    #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
+    if (!pbsys_status_test(PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED)) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Bluetooth not enabled"));
+    }
+    #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE
 
     pb_type_pupdevices_Remote_obj_t *self = mp_obj_malloc(pb_type_pupdevices_Remote_obj_t, type);
 

--- a/pybricks/iodevices/pb_type_iodevices_xbox_controller.c
+++ b/pybricks/iodevices/pb_type_iodevices_xbox_controller.c
@@ -16,7 +16,7 @@
 #include <pbio/task.h>
 
 #include <pbsys/config.h>
-#include <pbsys/status.h>
+#include <pbsys/bluetooth.h>
 
 #include <pybricks/common.h>
 #include <pybricks/parameters.h>
@@ -288,7 +288,7 @@ STATIC mp_obj_t pb_type_xbox_make_new(const mp_obj_type_t *type, size_t n_args, 
         );
 
     #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
-    if (!pbsys_status_test(PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED)) {
+    if (!pbsys_bluetooth_is_user_enabled()) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Bluetooth not enabled"));
     }
     #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE

--- a/pybricks/iodevices/pb_type_iodevices_xbox_controller.c
+++ b/pybricks/iodevices/pb_type_iodevices_xbox_controller.c
@@ -15,6 +15,9 @@
 #include <pbio/error.h>
 #include <pbio/task.h>
 
+#include <pbsys/config.h>
+#include <pbsys/status.h>
+
 #include <pybricks/common.h>
 #include <pybricks/parameters.h>
 #include <pybricks/tools.h>
@@ -283,6 +286,12 @@ STATIC mp_obj_t pb_type_xbox_make_new(const mp_obj_type_t *type, size_t n_args, 
         , PB_ARG_DEFAULT_FALSE(stay_connected)
         #endif // PYBRICKS_HUB_TECHNICHUB
         );
+
+    #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
+    if (!pbsys_status_test(PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED)) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Bluetooth not enabled"));
+    }
+    #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE
 
     pb_type_xbox_obj_t *self = mp_obj_malloc(pb_type_xbox_obj_t, type);
     self->joystick_deadzone = pb_obj_get_pct(joystick_deadzone_in);


### PR DESCRIPTION
Implements toggling Bluetooth on and off with the Bluetooth button on Spike Prime and Mindstorms Robot Inventor.

See https://github.com/pybricks/support/issues/1615 for context, use cases, and user interface considerations.

This is a slightly more minimalist approach compared to #195. It adds `PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED` to the protocol instead of `PBIO_PYBRICKS_STATUS_BLUETOOTH_BUTTON_PRESSED` and `PBIO_PYBRICKS_STATUS_BLUETOOTH_SHUTDOWN`.

The `hmi` is implemented similar to the existing code for the start/stop program button, and separated from the actual Bluetooth start/stop logic. The `hmi` may request a Bluetooth toggle, but it is up to `sys/bluetooth` whether to do anything with that. This prevents Bluetooth from being toggled if is currently being used or while a program is running.

The `PBIO_PYBRICKS_STATUS_BLUETOOTH_BLE_ENABLED` flag is only used for raising exceptions when the user tries to create remote peripheral or broadcast/observe.

Persistency is a separate task that can be added later. This was holding up previous merges, but we should be able to get started without it.

Thanks to everyone for asking about this feature and thanks to @nkarstens for creating #195!