### PR TITLE
pbio/sys/storage: Implement persistent storage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@
 ### Added
 
 - Allow Bluetooth to be toggled off and on with the Bluetooth button on the
-  Prime Hub and the Inventor Hub ([support#1615]).
+  Prime Hub and the Inventor Hub ([support#1615]), and have this state persist
+  between reboots.
+
+### Changed
+
+- When upgrading the firmware to a new version, the user program will now
+  be erased. This avoids issues with incompatible program files ([support#1622]).
 
 [support#1615]: https://github.com/pybricks/support/issues/1615
+[support#1622]: https://github.com/pybricks/support/issues/1622
 
 ## [3.5.0] - 2024-04-11
 

--- a/bricks/_common/sources.mk
+++ b/bricks/_common/sources.mk
@@ -233,6 +233,7 @@ PBIO_SRC_C = $(addprefix lib/pbio/,\
 	sys/program_stop.c \
 	sys/status.c \
 	sys/storage.c \
+	sys/storage_settings.c \
 	sys/supervisor.c \
 	sys/user_program.c \
 	)

--- a/lib/pbio/include/pbsys/bluetooth.h
+++ b/lib/pbio/include/pbsys/bluetooth.h
@@ -32,8 +32,6 @@ uint32_t pbsys_bluetooth_rx_get_available(void);
 pbio_error_t pbsys_bluetooth_rx(uint8_t *data, uint32_t *size);
 pbio_error_t pbsys_bluetooth_tx(const uint8_t *data, uint32_t *size);
 bool pbsys_bluetooth_tx_is_idle(void);
-bool pbsys_bluetooth_is_user_enabled(void);
-void pbsys_bluetooth_is_user_enabled_request_toggle(void);
 
 #else // PBSYS_CONFIG_BLUETOOTH
 
@@ -50,11 +48,6 @@ static inline pbio_error_t pbsys_bluetooth_tx(const uint8_t *data, uint32_t *siz
 }
 static inline bool pbsys_bluetooth_tx_is_idle(void) {
     return false;
-}
-static inline void pbsys_bluetooth_is_user_enabled_request_toggle(void) {
-}
-static inline bool pbsys_bluetooth_is_user_enabled(void) {
-    return true;
 }
 
 #endif // PBSYS_CONFIG_BLUETOOTH

--- a/lib/pbio/include/pbsys/storage.h
+++ b/lib/pbio/include/pbsys/storage.h
@@ -24,7 +24,7 @@
 #endif
 
 /**
- * Header of loaded data. All data types are little-endian.
+ * Map of loaded data. All data types are little-endian.
  */
 typedef struct _pbsys_storage_data_map_t {
     /**
@@ -41,6 +41,12 @@ typedef struct _pbsys_storage_data_map_t {
      */
     volatile uint32_t checksum_complement;
     #endif
+    /**
+     * Firmware version used to create the stored data. See pbio/version.
+     * Human-readable when printed as hex. If this value does not match
+     * the version of the running firmware, user data will be reset to 0.
+     */
+    uint32_t stored_firmware_version;
     /**
      * End-user read-write accessible data.
      */

--- a/lib/pbio/include/pbsys/storage.h
+++ b/lib/pbio/include/pbsys/storage.h
@@ -84,7 +84,7 @@ pbio_error_t pbsys_storage_get_user_data(uint32_t offset, uint8_t **data, uint32
 
 pbio_error_t pbsys_storage_get_settings(pbsys_storage_settings_t **settings);
 
-void pbsys_storage_request_settings_write(void);
+void pbsys_storage_request_write(void);
 
 #else
 
@@ -104,7 +104,7 @@ static inline pbio_error_t pbsys_storage_get_settings(pbsys_storage_settings_t *
     return PBIO_ERROR_NOT_SUPPORTED;
 }
 
-static inline void pbsys_storage_request_settings_write(void) {
+static inline void pbsys_storage_request_write(void) {
 }
 
 #endif // PBSYS_CONFIG_STORAGE

--- a/lib/pbio/include/pbsys/storage.h
+++ b/lib/pbio/include/pbsys/storage.h
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2022 The Pybricks Authors
+// Copyright (c) 2022-2024 The Pybricks Authors
 
 /**
- * @addtogroup SysProgramLoad System: Load user programs.
+ * @addtogroup SysStorage System: Load user programs, data, and settings.
  *
- * Configuration for loading data.
+ * Load user programs, data, and settings.
  *
  * @{
  */
@@ -15,16 +15,7 @@
 #include <stdint.h>
 
 #include <pbsys/config.h>
-
-/**
- * System settings. All data types are little-endian.
- */
-typedef struct _pbsys_storage_settings_t {
-    /**
-     * User has enabled Bluetooth Low Energy.
-     */
-    bool bluetooth_ble_user_enabled : 1;
-} pbsys_storage_settings_t;
+#include <pbsys/storage_settings.h>
 
 #if PBSYS_CONFIG_STORAGE
 
@@ -82,10 +73,6 @@ pbio_error_t pbsys_storage_set_user_data(uint32_t offset, const uint8_t *data, u
 
 pbio_error_t pbsys_storage_get_user_data(uint32_t offset, uint8_t **data, uint32_t size);
 
-pbio_error_t pbsys_storage_get_settings(pbsys_storage_settings_t **settings);
-
-void pbsys_storage_request_write(void);
-
 #else
 
 #define PBSYS_STORAGE_MAX_PROGRAM_SIZE (0)
@@ -93,18 +80,9 @@ void pbsys_storage_request_write(void);
 static inline pbio_error_t pbsys_storage_set_user_data(uint32_t offset, const uint8_t *data, uint32_t size) {
     return PBIO_ERROR_NOT_SUPPORTED;
 }
-
 static inline pbio_error_t pbsys_storage_get_user_data(uint32_t offset, uint8_t **data, uint32_t size) {
     *data = NULL;
     return PBIO_ERROR_NOT_SUPPORTED;
-}
-
-static inline pbio_error_t pbsys_storage_get_settings(pbsys_storage_settings_t **settings) {
-    *settings = NULL;
-    return PBIO_ERROR_NOT_SUPPORTED;
-}
-
-static inline void pbsys_storage_request_write(void) {
 }
 
 #endif // PBSYS_CONFIG_STORAGE

--- a/lib/pbio/include/pbsys/storage.h
+++ b/lib/pbio/include/pbsys/storage.h
@@ -49,7 +49,8 @@ typedef struct _pbsys_storage_data_map_t {
      */
     uint32_t stored_firmware_version;
     /**
-     * End-user read-write accessible data.
+     * End-user read-write accessible data. Everything after this is also
+     * user-readable but not writable.
      */
     uint8_t user_data[PBSYS_CONFIG_STORAGE_USER_DATA_SIZE];
     /**

--- a/lib/pbio/include/pbsys/storage.h
+++ b/lib/pbio/include/pbsys/storage.h
@@ -16,6 +16,16 @@
 
 #include <pbsys/config.h>
 
+/**
+ * System settings. All data types are little-endian.
+ */
+typedef struct _pbsys_storage_settings_t {
+    /**
+     * User has enabled Bluetooth Low Energy.
+     */
+    bool bluetooth_ble_user_enabled : 1;
+} pbsys_storage_settings_t;
+
 #if PBSYS_CONFIG_STORAGE
 
 // Sanity check that application RAM is enough to load ROM and still do something useful
@@ -52,6 +62,11 @@ typedef struct _pbsys_storage_data_map_t {
      */
     uint8_t user_data[PBSYS_CONFIG_STORAGE_USER_DATA_SIZE];
     /**
+     * System settings. Settings will be reset to defaults when the firmware
+     * version changes due to an update.
+     */
+    pbsys_storage_settings_t settings;
+    /**
      * Size of the application program (size of code only).
      */
     uint32_t program_size;
@@ -67,6 +82,10 @@ pbio_error_t pbsys_storage_set_user_data(uint32_t offset, const uint8_t *data, u
 
 pbio_error_t pbsys_storage_get_user_data(uint32_t offset, uint8_t **data, uint32_t size);
 
+pbio_error_t pbsys_storage_get_settings(pbsys_storage_settings_t **settings);
+
+void pbsys_storage_request_settings_write(void);
+
 #else
 
 #define PBSYS_STORAGE_MAX_PROGRAM_SIZE (0)
@@ -80,6 +99,13 @@ static inline pbio_error_t pbsys_storage_get_user_data(uint32_t offset, uint8_t 
     return PBIO_ERROR_NOT_SUPPORTED;
 }
 
+static inline pbio_error_t pbsys_storage_get_settings(pbsys_storage_settings_t **settings) {
+    *settings = NULL;
+    return PBIO_ERROR_NOT_SUPPORTED;
+}
+
+static inline void pbsys_storage_request_settings_write(void) {
+}
 
 #endif // PBSYS_CONFIG_STORAGE
 

--- a/lib/pbio/include/pbsys/storage_settings.h
+++ b/lib/pbio/include/pbsys/storage_settings.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 The Pybricks Authors
+
+/**
+ * @addtogroup SysStorageSettings System: Load user settings.
+ *
+ * Interface for reading and storing user system settings.
+ *
+ * @{
+ */
+
+#ifndef _PBSYS_STORAGE_SETTINGS_H_
+#define _PBSYS_STORAGE_SETTINGS_H_
+
+#include <stdint.h>
+
+#include <pbio/error.h>
+
+#include <pbsys/config.h>
+
+/**
+ * System settings. All data types are little-endian.
+ */
+typedef struct _pbsys_storage_settings_t {
+    #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
+    /**
+     * User has enabled Bluetooth Low Energy.
+     */
+    bool bluetooth_ble_user_enabled : 1;
+    #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE
+} pbsys_storage_settings_t;
+
+#if PBSYS_CONFIG_STORAGE
+
+void pbsys_storage_set_default_settings(pbsys_storage_settings_t *settings);
+
+bool pbsys_storage_settings_bluetooth_enabled(void);
+
+void pbsys_storage_settings_bluetooth_enabled_request_toggle(void);
+
+#else
+
+static inline void pbsys_storage_set_default_settings(pbsys_storage_settings_t *settings) {
+}
+static inline bool pbsys_storage_settings_bluetooth_enabled(void) {
+    return true;
+}
+static inline void pbsys_storage_settings_bluetooth_enabled_request_toggle(void) {
+}
+
+#endif // PBSYS_CONFIG_STORAGE
+
+#endif // _PBSYS_STORAGE_SETTINGS_H_
+
+/** @} */

--- a/lib/pbio/include/pbsys/storage_settings.h
+++ b/lib/pbio/include/pbsys/storage_settings.h
@@ -19,15 +19,20 @@
 #include <pbsys/config.h>
 
 /**
+ * System setting flags
+ */
+typedef enum {
+    /**
+     * Bluetooth is enabled by the user (defaults to true).
+     */
+    PBSYS_STORAGE_SETTINGS_FLAGS_BLUETOOTH_ENABLED = (1 << 0),
+} pbsys_storage_settings_flags_t;
+
+/**
  * System settings. All data types are little-endian.
  */
 typedef struct _pbsys_storage_settings_t {
-    #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
-    /**
-     * User has enabled Bluetooth Low Energy.
-     */
-    bool bluetooth_ble_user_enabled : 1;
-    #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE
+    uint32_t flags;
 } pbsys_storage_settings_t;
 
 #if PBSYS_CONFIG_STORAGE

--- a/lib/pbio/sys/bluetooth.c
+++ b/lib/pbio/sys/bluetooth.c
@@ -203,6 +203,7 @@ bool pbsys_bluetooth_tx_is_idle(void) {
     return !send_busy && lwrb_get_full(&stdout_ring_buf) == 0;
 }
 
+#if PBSYS_CONFIG_STORAGE && PBSYS_CONFIG_BLUETOOTH_TOGGLE
 static pbsys_storage_settings_t *settings;
 
 bool pbsys_bluetooth_is_user_enabled(void) {
@@ -233,6 +234,13 @@ void pbsys_bluetooth_is_user_enabled_request_toggle(void) {
     pbsys_storage_request_write();
     pbsys_bluetooth_process_poll();
 }
+#else // PBSYS_CONFIG_STORAGE && PBSYS_CONFIG_BLUETOOTH_TOGGLE
+bool pbsys_bluetooth_is_user_enabled(void) {
+    return true;
+}
+void pbsys_bluetooth_is_user_enabled_request_toggle(void) {
+}
+#endif // PBSYS_CONFIG_STORAGE && PBSYS_CONFIG_BLUETOOTH_TOGGLE
 
 // Contiki process
 
@@ -321,7 +329,9 @@ PROCESS_THREAD(pbsys_bluetooth_process, ev, data) {
 
     PROCESS_BEGIN();
 
+    #if PBSYS_CONFIG_STORAGE && PBSYS_CONFIG_BLUETOOTH_TOGGLE
     PROCESS_WAIT_EVENT_UNTIL(pbsys_storage_get_settings(&settings) == PBIO_SUCCESS);
+    #endif // PBSYS_CONFIG_STORAGE && PBSYS_CONFIG_BLUETOOTH_TOGGLE
 
     pbdrv_bluetooth_set_on_event(pbsys_bluetooth_process_poll);
     pbdrv_bluetooth_set_receive_handler(handle_receive);
@@ -330,7 +340,7 @@ PROCESS_THREAD(pbsys_bluetooth_process, ev, data) {
 
         // Show inactive status only if user requested Bluetooth as disabled to
         // avoid always flashing red in between program runs when disconnected.
-        if (!settings->bluetooth_ble_user_enabled) {
+        if (!pbsys_bluetooth_is_user_enabled()) {
             pbsys_status_light_bluetooth_set_color(PBIO_COLOR_RED);
         }
 
@@ -339,7 +349,7 @@ PROCESS_THREAD(pbsys_bluetooth_process, ev, data) {
         PROCESS_WAIT_EVENT_UNTIL(ev == PROCESS_EVENT_TIMER && etimer_expired(&timer));
 
         // Wait until Bluetooth enabled requested by user, but stop waiting on shutdown.
-        PROCESS_WAIT_UNTIL(settings->bluetooth_ble_user_enabled || pbsys_status_test(PBIO_PYBRICKS_STATUS_SHUTDOWN));
+        PROCESS_WAIT_UNTIL(pbsys_bluetooth_is_user_enabled() || pbsys_status_test(PBIO_PYBRICKS_STATUS_SHUTDOWN));
         if (pbsys_status_test(PBIO_PYBRICKS_STATUS_SHUTDOWN)) {
             break;
         }
@@ -360,7 +370,7 @@ PROCESS_THREAD(pbsys_bluetooth_process, ev, data) {
             pbdrv_bluetooth_is_connected(PBDRV_BLUETOOTH_CONNECTION_LE)
             || pbsys_status_test(PBIO_PYBRICKS_STATUS_USER_PROGRAM_RUNNING)
             || pbsys_status_test(PBIO_PYBRICKS_STATUS_SHUTDOWN)
-            || !settings->bluetooth_ble_user_enabled);
+            || !pbsys_bluetooth_is_user_enabled());
 
         // Now change the state depending on which of the above was triggered.
 
@@ -379,7 +389,7 @@ PROCESS_THREAD(pbsys_bluetooth_process, ev, data) {
         // The Bluetooth enabled flag can only change while disconnected and
         // while no program is running. So here it just serves to skip the
         // Bluetooth loop below and go directly to the disable step below it.
-        while (settings->bluetooth_ble_user_enabled
+        while (pbsys_bluetooth_is_user_enabled()
                && pbdrv_bluetooth_is_connected(PBDRV_BLUETOOTH_CONNECTION_LE)
                && !pbsys_status_test(PBIO_PYBRICKS_STATUS_SHUTDOWN)) {
 

--- a/lib/pbio/sys/bluetooth.c
+++ b/lib/pbio/sys/bluetooth.c
@@ -327,6 +327,13 @@ PROCESS_THREAD(pbsys_bluetooth_process, ev, data) {
     pbdrv_bluetooth_set_receive_handler(handle_receive);
 
     while (!pbsys_status_test(PBIO_PYBRICKS_STATUS_SHUTDOWN)) {
+
+        // Show inactive status only if user requested Bluetooth as disabled to
+        // avoid always flashing red in between program runs when disconnected.
+        if (!settings->bluetooth_ble_user_enabled) {
+            pbsys_status_light_bluetooth_set_color(PBIO_COLOR_RED);
+        }
+
         // make sure the Bluetooth chip is in reset long enough to actually reset
         etimer_set(&timer, 150);
         PROCESS_WAIT_EVENT_UNTIL(ev == PROCESS_EVENT_TIMER && etimer_expired(&timer));
@@ -410,12 +417,6 @@ PROCESS_THREAD(pbsys_bluetooth_process, ev, data) {
 
         reset_all();
         PROCESS_WAIT_WHILE(pbsys_status_test(PBIO_PYBRICKS_STATUS_USER_PROGRAM_RUNNING));
-
-        // Indicate status only if user requested Bluetooth to be disabled to
-        // avoid always flashing red in between program runs when disconnected.
-        if (!settings->bluetooth_ble_user_enabled) {
-            pbsys_status_light_bluetooth_set_color(PBIO_COLOR_RED);
-        }
 
         // reset Bluetooth chip
         pbdrv_bluetooth_power_on(false);

--- a/lib/pbio/sys/bluetooth.c
+++ b/lib/pbio/sys/bluetooth.c
@@ -230,7 +230,7 @@ void pbsys_bluetooth_is_user_enabled_request_toggle(void) {
 
     // Toggle the user enabled state and poll process to take action.
     settings->bluetooth_ble_user_enabled = !settings->bluetooth_ble_user_enabled;
-    pbsys_storage_request_settings_write();
+    pbsys_storage_request_write();
     pbsys_bluetooth_process_poll();
 }
 

--- a/lib/pbio/sys/bluetooth.h
+++ b/lib/pbio/sys/bluetooth.h
@@ -8,5 +8,6 @@
 
 uint32_t pbsys_bluetooth_rx_get_free(void);
 void pbsys_bluetooth_rx_write(const uint8_t *data, uint32_t size);
+void pbsys_bluetooth_process_poll(void);
 
 #endif // _PBSYS_SYS_BLUETOOTH_H_

--- a/lib/pbio/sys/command.c
+++ b/lib/pbio/sys/command.c
@@ -7,6 +7,8 @@
 #include <pbdrv/reset.h>
 #include <pbio/protocol.h>
 
+#include <pbsys/storage.h>
+
 #include "./bluetooth.h"
 #include "./storage.h"
 #include "./program_stop.h"

--- a/lib/pbio/sys/hmi.c
+++ b/lib/pbio/sys/hmi.c
@@ -19,9 +19,9 @@
 #include <pbio/color.h>
 #include <pbio/event.h>
 #include <pbio/light.h>
-#include <pbsys/bluetooth.h>
 #include <pbsys/config.h>
 #include <pbsys/status.h>
+#include <pbsys/storage_settings.h>
 
 #include "light_matrix.h"
 #include "light.h"
@@ -81,7 +81,7 @@ static PT_THREAD(update_bluetooth_button_wait_state(bool button_pressed)) {
         // button may still be pressed during user program
         PT_WAIT_UNTIL(pt, !button_pressed);
         PT_WAIT_UNTIL(pt, button_pressed);
-        pbsys_bluetooth_is_user_enabled_request_toggle();
+        pbsys_storage_settings_bluetooth_enabled_request_toggle();
     }
 
     PT_END(pt);

--- a/lib/pbio/sys/storage.c
+++ b/lib/pbio/sys/storage.c
@@ -14,6 +14,7 @@
 #include <pbdrv/block_device.h>
 #include <pbio/main.h>
 #include <pbio/protocol.h>
+#include <pbio/version.h>
 #include <pbsys/main.h>
 #include <pbsys/storage.h>
 #include <pbsys/status.h>
@@ -222,6 +223,18 @@ PROCESS_THREAD(pbsys_storage_process, ev, data) {
 
     // Reset write size, so we don't write data if nothing changed.
     map->write_size = 0;
+
+    // Test that storage matches current firmware version.
+    if (map->stored_firmware_version != PBIO_HEXVERSION) {
+        // Reset storage except for program data. It is sufficient to set its
+        // size to 0, which is what happens here since it is in the map.
+        memset(map, 0, sizeof(pbsys_storage_data_map_t));
+
+        // Make sure the new version will be written on shutdown, even if no
+        // new program is uploaded.
+        map->stored_firmware_version = PBIO_HEXVERSION;
+        update_write_size();
+    }
 
     // Initialization done.
     pbsys_init_busy_down();

--- a/lib/pbio/sys/storage.c
+++ b/lib/pbio/sys/storage.c
@@ -72,7 +72,7 @@ pbio_error_t pbsys_storage_set_user_data(uint32_t offset, const uint8_t *data, u
 }
 
 /**
- * Gets pointer to user data or user program.
+ * Gets pointer to user data, settings, or program.
  *
  * @param [in]  offset  Offset from the base address.
  * @param [in]  data    The data reference.
@@ -81,8 +81,9 @@ pbio_error_t pbsys_storage_set_user_data(uint32_t offset, const uint8_t *data, u
  *                      Otherwise, ::PBIO_SUCCESS.
  */
 pbio_error_t pbsys_storage_get_user_data(uint32_t offset, uint8_t **data, uint32_t size) {
-    // User is allowed to read beyond user storage to include program data.
-    if (offset + size > sizeof(map->user_data) + sizeof(map->program_size) + map->program_size) {
+    // User is allowed to read beyond user storage to include settings and
+    // program data.
+    if (offset + size > (map->program_data - map->user_data) + map->program_size) {
         return PBIO_ERROR_INVALID_ARG;
     }
     *data = map->user_data + offset;
@@ -112,7 +113,8 @@ static void pbsys_storage_update_checksum(void) {
     // Add checksum for each word in the written data and empty checked size.
     for (uint32_t offset = 0; offset < checksize; offset += sizeof(uint32_t)) {
         uint32_t *word = (uint32_t *)((uint8_t *)map + offset);
-        // Assume that everything after written data is erased.
+        // Assume that everything after written data is erased by the block
+        // device driver prior to writing.
         checksum += offset < map->write_size ? *word : 0xFFFFFFFF;
     }
 

--- a/lib/pbio/sys/storage.h
+++ b/lib/pbio/sys/storage.h
@@ -9,6 +9,7 @@
 #include <pbio/error.h>
 #include <pbsys/config.h>
 #include <pbsys/main.h>
+#include <pbsys/storage_settings.h>
 
 #if PBSYS_CONFIG_STORAGE
 
@@ -18,11 +19,16 @@ pbio_error_t pbsys_storage_set_program_size(uint32_t size);
 pbio_error_t pbsys_storage_set_program_data(uint32_t offset, const void *data, uint32_t size);
 pbio_error_t pbsys_storage_assert_program_valid(void);
 void pbsys_storage_get_program_data(pbsys_main_program_t *program);
+pbsys_storage_settings_t *pbsys_storage_get_settings(void);
+void pbsys_storage_request_write(void);
 
 #else
 static inline void pbsys_storage_init(void) {
 }
 static inline void pbsys_storage_deinit(void) {
+}
+static inline pbsys_storage_settings_t *pbsys_storage_get_settings(void) {
+    return NULL;
 }
 static inline pbio_error_t pbsys_storage_set_program_size(uint32_t size) {
     return PBIO_ERROR_NOT_SUPPORTED;
@@ -34,6 +40,8 @@ static inline pbio_error_t pbsys_storage_assert_program_valid(void) {
     return PBIO_ERROR_NOT_SUPPORTED;
 }
 static inline void pbsys_storage_get_program_data(pbsys_main_program_t *program) {
+}
+static inline void pbsys_storage_request_write(void) {
 }
 
 #endif // PBSYS_CONFIG_STORAGE

--- a/lib/pbio/sys/storage_settings.c
+++ b/lib/pbio/sys/storage_settings.c
@@ -25,7 +25,7 @@
  */
 void pbsys_storage_set_default_settings(pbsys_storage_settings_t *settings) {
     #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
-    settings->bluetooth_ble_user_enabled = true;
+    settings->flags |= PBSYS_STORAGE_SETTINGS_FLAGS_BLUETOOTH_ENABLED;
     #endif
 }
 
@@ -35,7 +35,7 @@ bool pbsys_storage_settings_bluetooth_enabled(void) {
     if (!settings) {
         return true;
     }
-    return settings->bluetooth_ble_user_enabled;
+    return settings->flags & PBSYS_STORAGE_SETTINGS_FLAGS_BLUETOOTH_ENABLED;
     #else
     return true;
     #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE
@@ -55,13 +55,13 @@ void pbsys_storage_settings_bluetooth_enabled_request_toggle(void) {
         || pbdrv_bluetooth_is_connected(PBDRV_BLUETOOTH_CONNECTION_LE)
         || pbdrv_bluetooth_is_connected(PBDRV_BLUETOOTH_CONNECTION_PERIPHERAL)
         // Ignore if last request not yet finished processing.
-        || settings->bluetooth_ble_user_enabled != pbdrv_bluetooth_is_ready()
+        || pbsys_storage_settings_bluetooth_enabled() != pbdrv_bluetooth_is_ready()
         ) {
         return;
     }
 
     // Toggle the user enabled state and poll process to take action.
-    settings->bluetooth_ble_user_enabled = !settings->bluetooth_ble_user_enabled;
+    settings->flags ^= PBSYS_STORAGE_SETTINGS_FLAGS_BLUETOOTH_ENABLED;
     pbsys_storage_request_write();
     pbsys_bluetooth_process_poll();
     #endif

--- a/lib/pbio/sys/storage_settings.c
+++ b/lib/pbio/sys/storage_settings.c
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2022 The Pybricks Authors
+
+#include <pbsys/config.h>
+
+#if PBSYS_CONFIG_STORAGE
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <pbdrv/bluetooth.h>
+
+#include <pbio/error.h>
+#include <pbsys/status.h>
+#include <pbsys/storage_settings.h>
+
+#include "bluetooth.h"
+#include "storage.h"
+
+/**
+ * Sets the default settings after an erase.
+ *
+ * @param [in]  settings  Settings to populate.
+ */
+void pbsys_storage_set_default_settings(pbsys_storage_settings_t *settings) {
+    #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
+    settings->bluetooth_ble_user_enabled = true;
+    #endif
+}
+
+bool pbsys_storage_settings_bluetooth_enabled(void) {
+    #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
+    pbsys_storage_settings_t *settings = pbsys_storage_get_settings();
+    if (!settings) {
+        return true;
+    }
+    return settings->bluetooth_ble_user_enabled;
+    #else
+    return true;
+    #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE
+}
+
+void pbsys_storage_settings_bluetooth_enabled_request_toggle(void) {
+    #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
+    pbsys_storage_settings_t *settings = pbsys_storage_get_settings();
+
+    // Ignore toggle request in all but idle system status.
+    if (!settings
+        || pbsys_status_test(PBIO_PYBRICKS_STATUS_USER_PROGRAM_RUNNING)
+        || pbsys_status_test(PBIO_PYBRICKS_STATUS_POWER_BUTTON_PRESSED)
+        || pbsys_status_test(PBIO_PYBRICKS_STATUS_SHUTDOWN)
+        || pbsys_status_test(PBIO_PYBRICKS_STATUS_SHUTDOWN_REQUEST)
+        // Ignore toggle is Bluetooth is currently being used in a connection.
+        || pbdrv_bluetooth_is_connected(PBDRV_BLUETOOTH_CONNECTION_LE)
+        || pbdrv_bluetooth_is_connected(PBDRV_BLUETOOTH_CONNECTION_PERIPHERAL)
+        // Ignore if last request not yet finished processing.
+        || settings->bluetooth_ble_user_enabled != pbdrv_bluetooth_is_ready()
+        ) {
+        return;
+    }
+
+    // Toggle the user enabled state and poll process to take action.
+    settings->bluetooth_ble_user_enabled = !settings->bluetooth_ble_user_enabled;
+    pbsys_storage_request_write();
+    pbsys_bluetooth_process_poll();
+    #endif
+}
+
+#endif // PBSYS_CONFIG_STORAGE

--- a/pybricks/common/pb_type_ble.c
+++ b/pybricks/common/pb_type_ble.c
@@ -12,7 +12,7 @@
 #include <pbdrv/bluetooth.h>
 
 #include <pbsys/config.h>
-#include <pbsys/bluetooth.h>
+#include <pbsys/storage_settings.h>
 
 #include "py/obj.h"
 #include "py/misc.h"
@@ -267,7 +267,7 @@ STATIC mp_obj_t pb_module_ble_broadcast(size_t n_args, const mp_obj_t *pos_args,
     // but it may still pass there since 0 is a valid broadcast channel. That
     // should be fixed by defaulting to None if no broadcast channel is provided.
     #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
-    if (!pbsys_bluetooth_is_user_enabled()) {
+    if (!pbsys_storage_settings_bluetooth_enabled()) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Bluetooth not enabled"));
     }
     #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE
@@ -534,7 +534,7 @@ mp_obj_t pb_type_BLE_new(mp_obj_t broadcast_channel_in, mp_obj_t observe_channel
     mp_int_t num_channels = mp_obj_get_int(mp_obj_len(observe_channels_in));
 
     #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
-    if (!pbsys_bluetooth_is_user_enabled() && (num_channels > 0 || broadcast_channel)) {
+    if (!pbsys_storage_settings_bluetooth_enabled() && (num_channels > 0 || broadcast_channel)) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Bluetooth not enabled"));
     }
     #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE

--- a/pybricks/iodevices/pb_type_iodevices_lwp3device.c
+++ b/pybricks/iodevices/pb_type_iodevices_lwp3device.c
@@ -16,7 +16,7 @@
 #include <pbio/task.h>
 
 #include <pbsys/config.h>
-#include <pbsys/bluetooth.h>
+#include <pbsys/storage_settings.h>
 
 #include <pybricks/common.h>
 #include <pybricks/parameters.h>
@@ -380,7 +380,7 @@ STATIC mp_obj_t pb_type_pupdevices_Remote_make_new(const mp_obj_type_t *type, si
         PB_ARG_DEFAULT_INT(timeout, 10000));
 
     #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
-    if (!pbsys_bluetooth_is_user_enabled()) {
+    if (!pbsys_storage_settings_bluetooth_enabled()) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Bluetooth not enabled"));
     }
     #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE

--- a/pybricks/iodevices/pb_type_iodevices_xbox_controller.c
+++ b/pybricks/iodevices/pb_type_iodevices_xbox_controller.c
@@ -16,7 +16,7 @@
 #include <pbio/task.h>
 
 #include <pbsys/config.h>
-#include <pbsys/bluetooth.h>
+#include <pbsys/storage_settings.h>
 
 #include <pybricks/common.h>
 #include <pybricks/parameters.h>
@@ -288,7 +288,7 @@ STATIC mp_obj_t pb_type_xbox_make_new(const mp_obj_type_t *type, size_t n_args, 
         );
 
     #if PBSYS_CONFIG_BLUETOOTH_TOGGLE
-    if (!pbsys_bluetooth_is_user_enabled()) {
+    if (!pbsys_storage_settings_bluetooth_enabled()) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Bluetooth not enabled"));
     }
     #endif // PBSYS_CONFIG_BLUETOOTH_TOGGLE


### PR DESCRIPTION
Implements https://github.com/pybricks/support/issues/1622

Since validity is checked against the firmware version and programs are erased, we shouldn't need to reserve space for spare or yet unknown settings. This adds a single bool setting for the Bluetooth enabled state.

NB: This PR is against a non-master branch specifically to make review easier. This skips one blanket rename commit that didn't change any code.

------

Should `program_size` below also manually forced to be word aligned? It does seem to do it automatically right now.

Could also require the settings size to be word sized, but I'd be curious to hear what's the cleanest way to do it.

```c
/**
 * System settings. All data types are little-endian.
 */
typedef struct _pbsys_storage_settings_t {
    /**
     * User has enabled Bluetooth Low Energy.
     */
    bool bluetooth_ble_user_enabled : 1;
} pbsys_storage_settings_t;
```

```c
    (...)
    uint8_t user_data[PBSYS_CONFIG_STORAGE_USER_DATA_SIZE];
    /**
     * System settings. Settings will be reset to defaults when the firmware
     * version changes due to an update.
     */
    pbsys_storage_settings_t settings;
    /**
     * Size of the application program (size of code only).
     */
    uint32_t program_size;
    /**
     * Data of the application program (code + heap).
     */
    uint8_t program_data[] __attribute__((aligned(sizeof(void *))));
} pbsys_storage_data_map_t;
```