### PR TITLE
pbio/sys/hmi: Reduce time needed to power off hub.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   correction of the `hub.imu.heading()` value ([support#1678]).
 - Added `update_heading_correction` to interactively set the heading
   correction value ([support#1678]).
+- Reduced hub poweroff time from 3 to 2 second to make it easier to turn off
+  the hub ([pybricks-micropython#250]).
 
 ### Changed
 
@@ -21,6 +23,7 @@
 - The `angular_velocity_threshold`, and `acceleration_threshold` settings
   in `hub.imu.settings` are now persistent between reboots.
 
+[pybricks-micropython#250]: https://github.com/pybricks/pybricks-micropython/pull/250
 [support#1615]: https://github.com/pybricks/support/issues/1615
 [support#1622]: https://github.com/pybricks/support/issues/1622
 [support#1678]: https://github.com/pybricks/support/issues/1678

--- a/lib/pbio/sys/hmi.c
+++ b/lib/pbio/sys/hmi.c
@@ -129,8 +129,8 @@ void pbsys_hmi_poll(void) {
             pbsys_status_set(PBIO_PYBRICKS_STATUS_POWER_BUTTON_PRESSED);
             update_program_run_button_wait_state(true);
 
-            // power off when button is held down for 3 seconds
-            if (pbsys_status_test_debounce(PBIO_PYBRICKS_STATUS_POWER_BUTTON_PRESSED, true, 3000)) {
+            // power off when button is held down for 2 seconds
+            if (pbsys_status_test_debounce(PBIO_PYBRICKS_STATUS_POWER_BUTTON_PRESSED, true, 2000)) {
                 pbsys_status_set(PBIO_PYBRICKS_STATUS_SHUTDOWN_REQUEST);
             }
         } else {


### PR DESCRIPTION
Reduces the power off time from 3 to 2 seconds. This has been requested occasionally. I think this is OK.

If it makes certain use cases harder, like long press menus, we could now quite easily add a user setting to make this timeout configurable due to https://github.com/pybricks/support/issues/1622 now being implemented.