### PR TITLE
pybricks: drop use of STATIC macro

### DIFF
--- a/bricks/ev3dev/modbluetooth.c
+++ b/bricks/ev3dev/modbluetooth.c
@@ -13,7 +13,7 @@
 // Gets the Bluetooth address for a paired device. name_in can be device name
 // or Bluetooth address. This is intended to be somewhat equivelent to
 // socket.gethostbyname() for IPv4 addresses.
-STATIC mp_obj_t ev3dev_bluetooth_resolve(mp_obj_t name_in) {
+static mp_obj_t ev3dev_bluetooth_resolve(mp_obj_t name_in) {
     const char *name_str = mp_obj_str_get_str(name_in);
     GError *error = NULL;
     MP_THREAD_GIL_EXIT();
@@ -65,13 +65,13 @@ STATIC mp_obj_t ev3dev_bluetooth_resolve(mp_obj_t name_in) {
 
     return match;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(ev3dev_bluetooth_resolve_obj, ev3dev_bluetooth_resolve);
+static MP_DEFINE_CONST_FUN_OBJ_1(ev3dev_bluetooth_resolve_obj, ev3dev_bluetooth_resolve);
 
-STATIC const mp_rom_map_elem_t ev3dev_bluetooth_globals_table[] = {
+static const mp_rom_map_elem_t ev3dev_bluetooth_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_bluetooth_c) },
     { MP_ROM_QSTR(MP_QSTR_resolve), MP_ROM_PTR(&ev3dev_bluetooth_resolve_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(ev3dev_bluetooth_globals, ev3dev_bluetooth_globals_table);
+static MP_DEFINE_CONST_DICT(ev3dev_bluetooth_globals, ev3dev_bluetooth_globals_table);
 
 const mp_obj_module_t pb_module_bluetooth = {
     .base = { &mp_type_module },

--- a/bricks/ev3dev/modmedia_ev3dev.c
+++ b/bricks/ev3dev/modmedia_ev3dev.c
@@ -13,19 +13,19 @@
 #error "media.ev3dev module requires that MICROPY_MODULE_BUILTIN_INIT is enabled"
 #endif
 
-STATIC mp_obj_t media_ev3dev___init__(void) {
+static mp_obj_t media_ev3dev___init__(void) {
     pb_type_ev3dev_Font_init();
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(media_ev3dev___init___obj, media_ev3dev___init__);
+static MP_DEFINE_CONST_FUN_OBJ_0(media_ev3dev___init___obj, media_ev3dev___init__);
 
-STATIC const mp_rom_map_elem_t media_ev3dev_globals_table[] = {
+static const mp_rom_map_elem_t media_ev3dev_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),    MP_ROM_QSTR(MP_QSTR_media_ev3dev)         },
     { MP_ROM_QSTR(MP_QSTR___init__),    MP_ROM_PTR(&media_ev3dev___init___obj)    },
     { MP_ROM_QSTR(MP_QSTR_Font),        MP_ROM_PTR(&pb_type_ev3dev_Font)       },
     { MP_ROM_QSTR(MP_QSTR_Image),       MP_ROM_PTR(&pb_type_ev3dev_Image)      },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_module_media_ev3dev_globals, media_ev3dev_globals_table);
+static MP_DEFINE_CONST_DICT(pb_module_media_ev3dev_globals, media_ev3dev_globals_table);
 
 const mp_obj_module_t pb_module_media_ev3dev = {
     .base = { &mp_type_module },

--- a/bricks/ev3dev/modusignal.c
+++ b/bricks/ev3dev/modusignal.c
@@ -14,7 +14,7 @@
 #include "py/obj.h"
 #include "py/runtime.h"
 
-STATIC mp_obj_t usignal_pause(void) {
+static mp_obj_t usignal_pause(void) {
 
     MP_THREAD_GIL_EXIT();
     pause();
@@ -22,10 +22,10 @@ STATIC mp_obj_t usignal_pause(void) {
     mp_handle_pending(true);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(usignal_pause_obj, usignal_pause);
+static MP_DEFINE_CONST_FUN_OBJ_0(usignal_pause_obj, usignal_pause);
 
 #if MICROPY_PY_THREAD
-STATIC mp_obj_t usignal_pthread_kill(mp_obj_t thread_id_in, mp_obj_t signalnum_in) {
+static mp_obj_t usignal_pthread_kill(mp_obj_t thread_id_in, mp_obj_t signalnum_in) {
 
     mp_int_t thread_id = mp_obj_int_get_truncated(thread_id_in);
     mp_int_t signalnum = mp_obj_get_int(signalnum_in);
@@ -35,10 +35,10 @@ STATIC mp_obj_t usignal_pthread_kill(mp_obj_t thread_id_in, mp_obj_t signalnum_i
     }
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(usignal_pthread_kill_obj, usignal_pthread_kill);
+static MP_DEFINE_CONST_FUN_OBJ_2(usignal_pthread_kill_obj, usignal_pthread_kill);
 #endif // MICROPY_PY_THREAD
 
-STATIC const mp_rom_map_elem_t usignal_globals_table[] = {
+static const mp_rom_map_elem_t usignal_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_usignal) },
     { MP_ROM_QSTR(MP_QSTR_pause), MP_ROM_PTR(&usignal_pause_obj) },
     #if MICROPY_PY_THREAD
@@ -50,7 +50,7 @@ STATIC const mp_rom_map_elem_t usignal_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SIGUSR1), MP_ROM_INT(SIGUSR1) },
     { MP_ROM_QSTR(MP_QSTR_SIGUSR2), MP_ROM_INT(SIGUSR2) },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_module_usignal_globals, usignal_globals_table);
+static MP_DEFINE_CONST_DICT(pb_module_usignal_globals, usignal_globals_table);
 
 const mp_obj_module_t pb_module_usignal = {
     .base = { &mp_type_module },

--- a/bricks/ev3dev/pb_type_ev3dev_font.c
+++ b/bricks/ev3dev/pb_type_ev3dev_font.c
@@ -29,7 +29,7 @@ typedef struct _ev3dev_Font_obj_t {
 
 ev3dev_Font_obj_t pb_const_ev3dev_Font_DEFAULT_obj;
 
-STATIC void ev3dev_Font_init(ev3dev_Font_obj_t *self, GrxFont *font) {
+static void ev3dev_Font_init(ev3dev_Font_obj_t *self, GrxFont *font) {
     self->base.type = &pb_type_ev3dev_Font;
     self->font = font;
 
@@ -60,7 +60,7 @@ void pb_type_ev3dev_Font_init(void) {
     ev3dev_Font_init(&pb_const_ev3dev_Font_DEFAULT_obj, font);
 }
 
-STATIC mp_obj_t ev3dev_Font_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t ev3dev_Font_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     enum { ARG_family, ARG_size, ARG_bold, ARG_monospace, ARG_lang, ARG_script };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_family, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
@@ -115,27 +115,27 @@ STATIC mp_obj_t ev3dev_Font_make_new(const mp_obj_type_t *type, size_t n_args, s
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC mp_obj_t ev3dev_Font___del__(mp_obj_t self_in) {
+static mp_obj_t ev3dev_Font___del__(mp_obj_t self_in) {
     ev3dev_Font_obj_t *self = MP_OBJ_TO_PTR(self_in);
     grx_font_unref(self->font);
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(ev3dev_Font___del___obj, ev3dev_Font___del__);
+static MP_DEFINE_CONST_FUN_OBJ_1(ev3dev_Font___del___obj, ev3dev_Font___del__);
 
-STATIC mp_obj_t ev3dev_Font_text_width(mp_obj_t self_in, mp_obj_t text_in) {
+static mp_obj_t ev3dev_Font_text_width(mp_obj_t self_in, mp_obj_t text_in) {
     ev3dev_Font_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(grx_font_get_text_width(self->font, mp_obj_str_get_str(text_in)));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(ev3dev_Font_text_width_obj, ev3dev_Font_text_width);
+static MP_DEFINE_CONST_FUN_OBJ_2(ev3dev_Font_text_width_obj, ev3dev_Font_text_width);
 
-STATIC mp_obj_t ev3dev_Font_text_height(mp_obj_t self_in, mp_obj_t text_in) {
+static mp_obj_t ev3dev_Font_text_height(mp_obj_t self_in, mp_obj_t text_in) {
     ev3dev_Font_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(grx_font_get_text_height(self->font, mp_obj_str_get_str(text_in)));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(ev3dev_Font_text_height_obj, ev3dev_Font_text_height);
+static MP_DEFINE_CONST_FUN_OBJ_2(ev3dev_Font_text_height_obj, ev3dev_Font_text_height);
 
-STATIC const pb_attr_dict_entry_t ev3dev_Font_attr_dict[] = {
+static const pb_attr_dict_entry_t ev3dev_Font_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_family, ev3dev_Font_obj_t, family),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_style, ev3dev_Font_obj_t, style),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_width, ev3dev_Font_obj_t, width),
@@ -143,13 +143,13 @@ STATIC const pb_attr_dict_entry_t ev3dev_Font_attr_dict[] = {
     PB_ATTR_DICT_SENTINEL
 };
 
-STATIC const mp_rom_map_elem_t ev3dev_Font_locals_dict_table[] = {
+static const mp_rom_map_elem_t ev3dev_Font_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_DEFAULT), MP_ROM_PTR(&pb_const_ev3dev_Font_DEFAULT_obj) },
     { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&ev3dev_Font___del___obj) },
     { MP_ROM_QSTR(MP_QSTR_text_width), MP_ROM_PTR(&ev3dev_Font_text_width_obj) },
     { MP_ROM_QSTR(MP_QSTR_text_height), MP_ROM_PTR(&ev3dev_Font_text_height_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(ev3dev_Font_locals_dict, ev3dev_Font_locals_dict_table);
+static MP_DEFINE_CONST_DICT(ev3dev_Font_locals_dict, ev3dev_Font_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_ev3dev_Font,
     MP_QSTR_Font,

--- a/bricks/ev3dev/pb_type_ev3dev_image.c
+++ b/bricks/ev3dev/pb_type_ev3dev_image.c
@@ -40,7 +40,7 @@ typedef struct _ev3dev_Image_obj_t {
 } ev3dev_Image_obj_t;
 
 // map Pybricks color type to GRX color value.
-STATIC GrxColor map_color(mp_obj_t obj) {
+static GrxColor map_color(mp_obj_t obj) {
     if (obj == mp_const_none) {
         return GRX_COLOR_NONE;
     }
@@ -50,7 +50,7 @@ STATIC GrxColor map_color(mp_obj_t obj) {
     return grx_color_get(rgb.r, rgb.g, rgb.b);
 }
 
-STATIC mp_obj_t ev3dev_Image_new(GrxContext *context) {
+static mp_obj_t ev3dev_Image_new(GrxContext *context) {
     ev3dev_Image_obj_t *self = m_new_obj_with_finaliser(ev3dev_Image_obj_t);
 
     self->base.type = &pb_type_ev3dev_Image;
@@ -69,7 +69,7 @@ STATIC mp_obj_t ev3dev_Image_new(GrxContext *context) {
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC mp_obj_t ev3dev_Image_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t ev3dev_Image_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     enum { ARG_source, ARG_sub, ARG_x1, ARG_y1, ARG_x2, ARG_y2 };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_source, MP_ARG_REQUIRED | MP_ARG_OBJ, { } },
@@ -151,7 +151,7 @@ STATIC mp_obj_t ev3dev_Image_make_new(const mp_obj_type_t *type, size_t n_args, 
     return ev3dev_Image_new(context);
 }
 
-STATIC mp_obj_t ev3dev_Image_empty(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Image_empty(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_width, ARG_height };
     const mp_arg_t allowed_args[] = {
         { MP_QSTR_width, MP_ARG_OBJ, { .u_obj = mp_obj_new_int(grx_get_screen_width())} },
@@ -175,19 +175,19 @@ STATIC mp_obj_t ev3dev_Image_empty(size_t n_args, const mp_obj_t *pos_args, mp_m
     grx_context_clear(context, GRX_COLOR_WHITE);
     return ev3dev_Image_new(context);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_empty_fun_obj, 0, ev3dev_Image_empty);
-STATIC MP_DEFINE_CONST_STATICMETHOD_OBJ(ev3dev_Image_empty_obj, MP_ROM_PTR(&ev3dev_Image_empty_fun_obj));
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_empty_fun_obj, 0, ev3dev_Image_empty);
+static MP_DEFINE_CONST_STATICMETHOD_OBJ(ev3dev_Image_empty_obj, MP_ROM_PTR(&ev3dev_Image_empty_fun_obj));
 
-STATIC mp_obj_t ev3dev_Image___del__(mp_obj_t self_in) {
+static mp_obj_t ev3dev_Image___del__(mp_obj_t self_in) {
     ev3dev_Image_obj_t *self = MP_OBJ_TO_PTR(self_in);
     grx_text_options_unref(self->text_options);
     grx_context_unref(self->context);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(ev3dev_Image___del___obj, ev3dev_Image___del__);
+static MP_DEFINE_CONST_FUN_OBJ_1(ev3dev_Image___del___obj, ev3dev_Image___del__);
 
 // Ensure that screen has been cleared before we start drawing anything else
-STATIC void clear_once(ev3dev_Image_obj_t *self) {
+static void clear_once(ev3dev_Image_obj_t *self) {
     if (self->cleared) {
         return;
     }
@@ -195,7 +195,7 @@ STATIC void clear_once(ev3dev_Image_obj_t *self) {
     self->cleared = TRUE;
 }
 
-STATIC mp_obj_t ev3dev_Image_clear(mp_obj_t self_in) {
+static mp_obj_t ev3dev_Image_clear(mp_obj_t self_in) {
     ev3dev_Image_obj_t *self = MP_OBJ_TO_PTR(self_in);
     clear_once(self);
     grx_context_clear(self->context, GRX_COLOR_WHITE);
@@ -203,9 +203,9 @@ STATIC mp_obj_t ev3dev_Image_clear(mp_obj_t self_in) {
     self->print_y = 0;
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(ev3dev_Image_clear_obj, ev3dev_Image_clear);
+static MP_DEFINE_CONST_FUN_OBJ_1(ev3dev_Image_clear_obj, ev3dev_Image_clear);
 
-STATIC mp_obj_t ev3dev_Image_draw_pixel(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Image_draw_pixel(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3dev_Image_obj_t, self,
         PB_ARG_REQUIRED(x),
@@ -222,9 +222,9 @@ STATIC mp_obj_t ev3dev_Image_draw_pixel(size_t n_args, const mp_obj_t *pos_args,
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_draw_pixel_obj, 1, ev3dev_Image_draw_pixel);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_draw_pixel_obj, 1, ev3dev_Image_draw_pixel);
 
-STATIC mp_obj_t ev3dev_Image_draw_line(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Image_draw_line(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3dev_Image_obj_t, self,
         PB_ARG_REQUIRED(x1),
@@ -252,9 +252,9 @@ STATIC mp_obj_t ev3dev_Image_draw_line(size_t n_args, const mp_obj_t *pos_args, 
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_draw_line_obj, 1, ev3dev_Image_draw_line);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_draw_line_obj, 1, ev3dev_Image_draw_line);
 
-STATIC mp_obj_t ev3dev_Image_draw_box(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Image_draw_box(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3dev_Image_obj_t, self,
         PB_ARG_REQUIRED(x1),
@@ -290,9 +290,9 @@ STATIC mp_obj_t ev3dev_Image_draw_box(size_t n_args, const mp_obj_t *pos_args, m
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_draw_box_obj, 1, ev3dev_Image_draw_box);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_draw_box_obj, 1, ev3dev_Image_draw_box);
 
-STATIC mp_obj_t ev3dev_Image_draw_circle(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Image_draw_circle(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3dev_Image_obj_t, self,
         PB_ARG_REQUIRED(x),
@@ -317,9 +317,9 @@ STATIC mp_obj_t ev3dev_Image_draw_circle(size_t n_args, const mp_obj_t *pos_args
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_draw_circle_obj, 1, ev3dev_Image_draw_circle);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_draw_circle_obj, 1, ev3dev_Image_draw_circle);
 
-STATIC mp_obj_t ev3dev_Image_draw_image(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Image_draw_image(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3dev_Image_obj_t, self,
         PB_ARG_REQUIRED(x),
@@ -346,9 +346,9 @@ STATIC mp_obj_t ev3dev_Image_draw_image(size_t n_args, const mp_obj_t *pos_args,
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_draw_image_obj, 1, ev3dev_Image_draw_image);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_draw_image_obj, 1, ev3dev_Image_draw_image);
 
-STATIC mp_obj_t ev3dev_Image_load_image(mp_obj_t self_in, mp_obj_t source_in) {
+static mp_obj_t ev3dev_Image_load_image(mp_obj_t self_in, mp_obj_t source_in) {
     ev3dev_Image_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     if (mp_obj_is_str(source_in)) {
@@ -395,9 +395,9 @@ STATIC mp_obj_t ev3dev_Image_load_image(mp_obj_t self_in, mp_obj_t source_in) {
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(ev3dev_Image_load_image_obj, ev3dev_Image_load_image);
+static MP_DEFINE_CONST_FUN_OBJ_2(ev3dev_Image_load_image_obj, ev3dev_Image_load_image);
 
-STATIC mp_obj_t ev3dev_Image_draw_text(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Image_draw_text(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3dev_Image_obj_t, self,
         PB_ARG_REQUIRED(x),
@@ -435,9 +435,9 @@ STATIC mp_obj_t ev3dev_Image_draw_text(size_t n_args, const mp_obj_t *pos_args, 
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_draw_text_obj, 1, ev3dev_Image_draw_text);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_draw_text_obj, 1, ev3dev_Image_draw_text);
 
-STATIC mp_obj_t ev3dev_Image_set_font(mp_obj_t self_in, mp_obj_t font_in) {
+static mp_obj_t ev3dev_Image_set_font(mp_obj_t self_in, mp_obj_t font_in) {
     ev3dev_Image_obj_t *self = MP_OBJ_TO_PTR(self_in);
     GrxFont *font = pb_ev3dev_Font_obj_get_font(font_in);
 
@@ -445,10 +445,10 @@ STATIC mp_obj_t ev3dev_Image_set_font(mp_obj_t self_in, mp_obj_t font_in) {
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(ev3dev_Image_set_font_obj, ev3dev_Image_set_font);
+static MP_DEFINE_CONST_FUN_OBJ_2(ev3dev_Image_set_font_obj, ev3dev_Image_set_font);
 
 // copy of mp_builtin_print modified to print to vstr
-STATIC mp_obj_t ev3dev_Image_print(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Image_print(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_sep, ARG_end };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_sep, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_QSTR(MP_QSTR__space_)} },
@@ -524,7 +524,7 @@ STATIC mp_obj_t ev3dev_Image_print(size_t n_args, const mp_obj_t *pos_args, mp_m
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Image_print_obj, 1, ev3dev_Image_print);
 
-STATIC mp_obj_t ev3dev_Image_save(mp_obj_t self_in, mp_obj_t filename_in) {
+static mp_obj_t ev3dev_Image_save(mp_obj_t self_in, mp_obj_t filename_in) {
     ev3dev_Image_obj_t *self = MP_OBJ_TO_PTR(self_in);
     const char *filename = mp_obj_str_get_str(filename_in);
 
@@ -549,13 +549,13 @@ STATIC mp_obj_t ev3dev_Image_save(mp_obj_t self_in, mp_obj_t filename_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(ev3dev_Image_save_obj, ev3dev_Image_save);
 
-STATIC const pb_attr_dict_entry_t ev3dev_Image_attr_dict[] = {
+static const pb_attr_dict_entry_t ev3dev_Image_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_width, ev3dev_Image_obj_t, width),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_height, ev3dev_Image_obj_t, height),
     PB_ATTR_DICT_SENTINEL
 };
 
-STATIC const mp_rom_map_elem_t ev3dev_Image_locals_dict_table[] = {
+static const mp_rom_map_elem_t ev3dev_Image_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_empty),       MP_ROM_PTR(&ev3dev_Image_empty_obj)                    },
     { MP_ROM_QSTR(MP_QSTR___del__),     MP_ROM_PTR(&ev3dev_Image___del___obj)                  },
     { MP_ROM_QSTR(MP_QSTR_clear),       MP_ROM_PTR(&ev3dev_Image_clear_obj)                    },
@@ -570,7 +570,7 @@ STATIC const mp_rom_map_elem_t ev3dev_Image_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_print),       MP_ROM_PTR(&ev3dev_Image_print_obj)                    },
     { MP_ROM_QSTR(MP_QSTR_save),        MP_ROM_PTR(&ev3dev_Image_save_obj)                     },
 };
-STATIC MP_DEFINE_CONST_DICT(ev3dev_Image_locals_dict, ev3dev_Image_locals_dict_table);
+static MP_DEFINE_CONST_DICT(ev3dev_Image_locals_dict, ev3dev_Image_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_ev3dev_Image,
     MP_QSTR_Image,

--- a/bricks/ev3dev/pb_type_ev3dev_speaker.c
+++ b/bricks/ev3dev/pb_type_ev3dev_speaker.c
@@ -55,10 +55,10 @@ typedef struct _ev3dev_Speaker_obj_t {
     GError *splice_error;
 } ev3dev_Speaker_obj_t;
 
-STATIC ev3dev_Speaker_obj_t ev3dev_speaker_singleton;
+static ev3dev_Speaker_obj_t ev3dev_speaker_singleton;
 
 
-STATIC mp_obj_t ev3dev_Speaker_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t ev3dev_Speaker_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     ev3dev_Speaker_obj_t *self = &ev3dev_speaker_singleton;
     if (!self->initialized) {
         self->base.type = &pb_type_ev3dev_Speaker;
@@ -109,7 +109,7 @@ void _pb_ev3dev_speaker_beep_off(void) {
     set_beep_frequency(&ev3dev_speaker_singleton, 0);
 }
 
-STATIC mp_obj_t ev3dev_Speaker_beep(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Speaker_beep(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3dev_Speaker_obj_t, self,
         PB_ARG_DEFAULT_INT(frequency, 500),
@@ -139,9 +139,9 @@ STATIC mp_obj_t ev3dev_Speaker_beep(size_t n_args, const mp_obj_t *pos_args, mp_
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Speaker_beep_obj, 1, ev3dev_Speaker_beep);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Speaker_beep_obj, 1, ev3dev_Speaker_beep);
 
-STATIC void ev3dev_Speaker_play_note(ev3dev_Speaker_obj_t *self, mp_obj_t obj, int duration) {
+static void ev3dev_Speaker_play_note(ev3dev_Speaker_obj_t *self, mp_obj_t obj, int duration) {
     const char *note = mp_obj_str_get_str(obj);
     int pos = 0;
     double freq;
@@ -315,7 +315,7 @@ STATIC void ev3dev_Speaker_play_note(ev3dev_Speaker_obj_t *self, mp_obj_t obj, i
     }
 }
 
-STATIC mp_obj_t ev3dev_Speaker_play_notes(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Speaker_play_notes(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3dev_Speaker_obj_t, self,
         PB_ARG_REQUIRED(notes),
@@ -342,9 +342,9 @@ STATIC mp_obj_t ev3dev_Speaker_play_notes(size_t n_args, const mp_obj_t *pos_arg
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Speaker_play_notes_obj, 1, ev3dev_Speaker_play_notes);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Speaker_play_notes_obj, 1, ev3dev_Speaker_play_notes);
 
-STATIC void ev3dev_Speaker_aplay_callback(GObject *source_object, GAsyncResult *res, gpointer user_data) {
+static void ev3dev_Speaker_aplay_callback(GObject *source_object, GAsyncResult *res, gpointer user_data) {
     GSubprocess *subprocess = G_SUBPROCESS(source_object);
     ev3dev_Speaker_obj_t *self = user_data;
     g_clear_error(&self->aplay_error);
@@ -352,7 +352,7 @@ STATIC void ev3dev_Speaker_aplay_callback(GObject *source_object, GAsyncResult *
     self->aplay_busy = FALSE;
 }
 
-STATIC mp_obj_t ev3dev_Speaker_play_file(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Speaker_play_file(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3dev_Speaker_obj_t, self,
         PB_ARG_REQUIRED(file));
@@ -423,9 +423,9 @@ STATIC mp_obj_t ev3dev_Speaker_play_file(size_t n_args, const mp_obj_t *pos_args
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Speaker_play_file_obj, 1, ev3dev_Speaker_play_file);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Speaker_play_file_obj, 1, ev3dev_Speaker_play_file);
 
-STATIC void ev3dev_Speaker_espeak_callback(GObject *source_object, GAsyncResult *res, gpointer user_data) {
+static void ev3dev_Speaker_espeak_callback(GObject *source_object, GAsyncResult *res, gpointer user_data) {
     GSubprocess *subprocess = G_SUBPROCESS(source_object);
     ev3dev_Speaker_obj_t *self = user_data;
     g_clear_error(&self->espeak_error);
@@ -433,7 +433,7 @@ STATIC void ev3dev_Speaker_espeak_callback(GObject *source_object, GAsyncResult 
     self->espeak_busy = FALSE;
 }
 
-STATIC void ev3dev_Speaker_splice_callback(GObject *source_object, GAsyncResult *res, gpointer user_data) {
+static void ev3dev_Speaker_splice_callback(GObject *source_object, GAsyncResult *res, gpointer user_data) {
     GOutputStream *out_stream = G_OUTPUT_STREAM(source_object);
     ev3dev_Speaker_obj_t *self = user_data;
     g_clear_error(&self->splice_error);
@@ -441,7 +441,7 @@ STATIC void ev3dev_Speaker_splice_callback(GObject *source_object, GAsyncResult 
     self->splice_busy = FALSE;
 }
 
-STATIC mp_obj_t ev3dev_Speaker_say(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Speaker_say(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3dev_Speaker_obj_t, self,
         PB_ARG_REQUIRED(text));
@@ -558,9 +558,9 @@ STATIC mp_obj_t ev3dev_Speaker_say(size_t n_args, const mp_obj_t *pos_args, mp_m
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Speaker_say_obj, 1, ev3dev_Speaker_say);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Speaker_say_obj, 1, ev3dev_Speaker_say);
 
-STATIC mp_obj_t ev3dev_Speaker_set_speech_options(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Speaker_set_speech_options(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3dev_Speaker_obj_t, self,
         PB_ARG_DEFAULT_NONE(language),
@@ -585,9 +585,9 @@ STATIC mp_obj_t ev3dev_Speaker_set_speech_options(size_t n_args, const mp_obj_t 
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Speaker_set_speech_options_obj, 1, ev3dev_Speaker_set_speech_options);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Speaker_set_speech_options_obj, 1, ev3dev_Speaker_set_speech_options);
 
-STATIC mp_obj_t ev3dev_Speaker_set_volume(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3dev_Speaker_set_volume(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3dev_Speaker_obj_t, self,
         PB_ARG_REQUIRED(volume),
@@ -645,9 +645,9 @@ STATIC mp_obj_t ev3dev_Speaker_set_volume(size_t n_args, const mp_obj_t *pos_arg
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Speaker_set_volume_obj, 1, ev3dev_Speaker_set_volume);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3dev_Speaker_set_volume_obj, 1, ev3dev_Speaker_set_volume);
 
-STATIC const mp_rom_map_elem_t ev3dev_Speaker_locals_dict_table[] = {
+static const mp_rom_map_elem_t ev3dev_Speaker_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_beep),                MP_ROM_PTR(&ev3dev_Speaker_beep_obj)                },
     { MP_ROM_QSTR(MP_QSTR_play_notes),          MP_ROM_PTR(&ev3dev_Speaker_play_notes_obj)          },
     { MP_ROM_QSTR(MP_QSTR_play_file),           MP_ROM_PTR(&ev3dev_Speaker_play_file_obj)           },
@@ -655,7 +655,7 @@ STATIC const mp_rom_map_elem_t ev3dev_Speaker_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_set_speech_options),  MP_ROM_PTR(&ev3dev_Speaker_set_speech_options_obj)  },
     { MP_ROM_QSTR(MP_QSTR_set_volume),          MP_ROM_PTR(&ev3dev_Speaker_set_volume_obj)          },
 };
-STATIC MP_DEFINE_CONST_DICT(ev3dev_Speaker_locals_dict, ev3dev_Speaker_locals_dict_table);
+static MP_DEFINE_CONST_DICT(ev3dev_Speaker_locals_dict, ev3dev_Speaker_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_ev3dev_Speaker,
     MP_QSTR_Speaker,

--- a/pybricks/common/pb_type_battery.c
+++ b/pybricks/common/pb_type_battery.c
@@ -20,21 +20,21 @@
 // an instance of a Battery type. That would make it consistent with the other
 // C types and the high level Python API.
 
-STATIC mp_obj_t battery_voltage(void) {
+static mp_obj_t battery_voltage(void) {
     return mp_obj_new_int(pbio_battery_get_average_voltage());
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(battery_voltage_obj, battery_voltage);
+static MP_DEFINE_CONST_FUN_OBJ_0(battery_voltage_obj, battery_voltage);
 
-STATIC mp_obj_t battery_current(void) {
+static mp_obj_t battery_current(void) {
     uint16_t cur;
     pb_assert(pbdrv_battery_get_current_now(&cur));
     return mp_obj_new_int(cur);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(battery_current_obj, battery_current);
+static MP_DEFINE_CONST_FUN_OBJ_0(battery_current_obj, battery_current);
 
 #if !PYBRICKS_HUB_MOVEHUB
 
-STATIC mp_obj_t battery_type(void) {
+static mp_obj_t battery_type(void) {
     pbdrv_battery_type_t type;
     pb_assert(pbdrv_battery_get_type(&type));
     switch (type) {
@@ -46,20 +46,20 @@ STATIC mp_obj_t battery_type(void) {
             return MP_OBJ_NEW_QSTR(MP_QSTR_Unknown);
     }
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(battery_type_obj, battery_type);
+static MP_DEFINE_CONST_FUN_OBJ_0(battery_type_obj, battery_type);
 
-STATIC mp_obj_t battery_temperature(void) {
+static mp_obj_t battery_temperature(void) {
     uint32_t temperature;
     pb_assert(pbdrv_battery_get_temperature(&temperature));
     return mp_obj_new_int(temperature);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(battery_temperature_obj, battery_temperature);
+static MP_DEFINE_CONST_FUN_OBJ_0(battery_temperature_obj, battery_temperature);
 
 #endif // !PYBRICKS_HUB_MOVEHUB
 
 /* battery module tables */
 
-STATIC const mp_rom_map_elem_t battery_globals_table[] = {
+static const mp_rom_map_elem_t battery_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),    MP_ROM_QSTR(MP_QSTR_battery)        },
     { MP_ROM_QSTR(MP_QSTR_voltage),     MP_ROM_PTR(&battery_voltage_obj)    },
     { MP_ROM_QSTR(MP_QSTR_current),     MP_ROM_PTR(&battery_current_obj)    },
@@ -68,7 +68,7 @@ STATIC const mp_rom_map_elem_t battery_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_temperature), MP_ROM_PTR(&battery_temperature_obj) },
     #endif // !PYBRICKS_HUB_MOVEHUB
 };
-STATIC MP_DEFINE_CONST_DICT(pb_module_battery_globals, battery_globals_table);
+static MP_DEFINE_CONST_DICT(pb_module_battery_globals, battery_globals_table);
 
 const mp_obj_module_t pb_module_battery = {
     .base = { &mp_type_module },

--- a/pybricks/common/pb_type_ble.c
+++ b/pybricks/common/pb_type_ble.c
@@ -90,7 +90,7 @@ typedef enum {
  * @returns                 A pointer to the channel or @c NULL if the channel
  *                          is not allocated in the table.
  */
-STATIC observed_data_t *lookup_observed_data(uint8_t channel) {
+static observed_data_t *lookup_observed_data(uint8_t channel) {
     for (size_t i = 0; i < num_observed_data; i++) {
         observed_data_t *data = &observed_data[i];
 
@@ -113,7 +113,7 @@ STATIC observed_data_t *lookup_observed_data(uint8_t channel) {
  * @param [in]  length          The length of @p data in bytes.
  * @param [in]  rssi            The RSSI of the event in dBm.
  */
-STATIC void handle_observe_event(pbdrv_bluetooth_ad_type_t event_type, const uint8_t *data, uint8_t length, int8_t rssi) {
+static void handle_observe_event(pbdrv_bluetooth_ad_type_t event_type, const uint8_t *data, uint8_t length, int8_t rssi) {
     // NB: ideally we would also be checking `event_type == PBDRV_BLUETOOTH_AD_TYPE_ADV_NONCONN_IND`
     // here but due to a Bluetooth firmware bug on city hub, we have to allow other
     // advertisement types. This would filter out broadcasts from the experimental
@@ -155,7 +155,7 @@ STATIC void handle_observe_event(pbdrv_bluetooth_ad_type_t event_type, const uin
  * @returns             The next free index in @p dst after adding the new data.
  * @throws ValueError   If data exceeds available space remaining in @p dst.
  */
-STATIC size_t pb_module_ble_append(uint8_t *dst, size_t index, const void *src, size_t size, pb_ble_broadcast_data_type_t type) {
+static size_t pb_module_ble_append(uint8_t *dst, size_t index, const void *src, size_t size, pb_ble_broadcast_data_type_t type) {
     size_t next_index = index + size + 1;
 
     if (next_index > OBSERVED_DATA_MAX_SIZE) {
@@ -182,7 +182,7 @@ STATIC size_t pb_module_ble_append(uint8_t *dst, size_t index, const void *src, 
  * @throws ValueError   If data exceeds available space remaining in @p dst.
  * @throws TypeError    If @p arg is not one of the supported types.
  */
-STATIC size_t pb_module_ble_encode(void *dst, size_t index, mp_obj_t arg) {
+static size_t pb_module_ble_encode(void *dst, size_t index, mp_obj_t arg) {
 
     if (arg == mp_const_true) {
         return pb_module_ble_append(dst, index, NULL, 0, PB_BLE_BROADCAST_DATA_TYPE_TRUE);
@@ -255,7 +255,7 @@ STATIC size_t pb_module_ble_encode(void *dst, size_t index, mp_obj_t arg) {
  *                       exceed the available space.
  * @throws TypeError     If any of the arguments are of a type that can't be encoded.
  */
-STATIC mp_obj_t pb_module_ble_broadcast(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_module_ble_broadcast(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_obj_BLE_t, self,
         PB_ARG_REQUIRED(data));
@@ -314,7 +314,7 @@ STATIC mp_obj_t pb_module_ble_broadcast(size_t n_args, const mp_obj_t *pos_args,
     pbdrv_bluetooth_start_broadcasting(self->broadcast_task, &value.v);
     return pb_module_tools_pbio_task_wait_or_await(self->broadcast_task);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_module_ble_broadcast_obj, 1, pb_module_ble_broadcast);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_module_ble_broadcast_obj, 1, pb_module_ble_broadcast);
 
 /**
  * Decodes data that was received by the Bluetooth radio.
@@ -325,7 +325,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_module_ble_broadcast_obj, 1, pb_module_ble_
  * @returns                 The decoded value as a Python object.
  * @throws RuntimeError     If the data was invalid and could not be decoded.
  */
-STATIC mp_obj_t pb_module_ble_decode(const observed_data_t *data, size_t *index) {
+static mp_obj_t pb_module_ble_decode(const observed_data_t *data, size_t *index) {
     uint8_t size = data->data[*index] & 0x1F;
     pb_ble_broadcast_data_type_t data_type = data->data[*index] >> 5;
 
@@ -405,7 +405,7 @@ STATIC mp_obj_t pb_module_ble_decode(const observed_data_t *data, size_t *index)
  * @throws ValueError       If the channel is out of range.
  * @throws RuntimeError     If the last received data was invalid.
  */
-STATIC const observed_data_t *pb_module_ble_get_channel_data(mp_obj_t channel_in) {
+static const observed_data_t *pb_module_ble_get_channel_data(mp_obj_t channel_in) {
     mp_int_t channel = mp_obj_get_int(channel_in);
 
     observed_data_t *ch_data = lookup_observed_data(channel);
@@ -434,7 +434,7 @@ STATIC const observed_data_t *pb_module_ble_get_channel_data(mp_obj_t channel_in
  * @throws ValueError       If the channel is out of range.
  * @throws RuntimeError     If the last received data was invalid.
  */
-STATIC mp_obj_t pb_module_ble_observe(mp_obj_t self_in, mp_obj_t channel_in) {
+static mp_obj_t pb_module_ble_observe(mp_obj_t self_in, mp_obj_t channel_in) {
 
     // BEWARE OF DRAGONS: The data returned by pb_module_ble_get_channel_data()
     // is only valid until the next PBIO event is processed, which can happen
@@ -470,7 +470,7 @@ STATIC mp_obj_t pb_module_ble_observe(mp_obj_t self_in, mp_obj_t channel_in) {
 
     return mp_obj_new_tuple(i, items);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(pb_module_ble_observe_obj, pb_module_ble_observe);
+static MP_DEFINE_CONST_FUN_OBJ_2(pb_module_ble_observe_obj, pb_module_ble_observe);
 
 /**
  * Retrieves the filtered RSSI signal strength of the given channel.
@@ -480,11 +480,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(pb_module_ble_observe_obj, pb_module_ble_observ
  * @returns                 Python object containing the filtered RSSI.
  * @throws ValueError       If the channel is out of range.
  */
-STATIC mp_obj_t pb_module_ble_signal_strength(mp_obj_t self_in, mp_obj_t channel_in) {
+static mp_obj_t pb_module_ble_signal_strength(mp_obj_t self_in, mp_obj_t channel_in) {
     const observed_data_t *ch_data = pb_module_ble_get_channel_data(channel_in);
     return mp_obj_new_int(ch_data->rssi);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(pb_module_ble_signal_strength_obj, pb_module_ble_signal_strength);
+static MP_DEFINE_CONST_FUN_OBJ_2(pb_module_ble_signal_strength_obj, pb_module_ble_signal_strength);
 
 /**
  * Gets the Bluetooth chip frimware version.
@@ -492,21 +492,21 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(pb_module_ble_signal_strength_obj, pb_module_bl
  * @returns                 MicroPython object containing the firmware version
  *                          as a str.
  */
-STATIC mp_obj_t pb_module_ble_version(mp_obj_t self_in) {
+static mp_obj_t pb_module_ble_version(mp_obj_t self_in) {
     const char *version = pbdrv_bluetooth_get_fw_version();
     return mp_obj_new_str(version, strlen(version));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_module_ble_version_obj, pb_module_ble_version);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_module_ble_version_obj, pb_module_ble_version);
 
-STATIC const mp_rom_map_elem_t common_BLE_locals_dict_table[] = {
+static const mp_rom_map_elem_t common_BLE_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_broadcast), MP_ROM_PTR(&pb_module_ble_broadcast_obj) },
     { MP_ROM_QSTR(MP_QSTR_observe), MP_ROM_PTR(&pb_module_ble_observe_obj) },
     { MP_ROM_QSTR(MP_QSTR_signal_strength), MP_ROM_PTR(&pb_module_ble_signal_strength_obj) },
     { MP_ROM_QSTR(MP_QSTR_version), MP_ROM_PTR(&pb_module_ble_version_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(common_BLE_locals_dict, common_BLE_locals_dict_table);
+static MP_DEFINE_CONST_DICT(common_BLE_locals_dict, common_BLE_locals_dict_table);
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(pb_type_BLE,
+static MP_DEFINE_CONST_OBJ_TYPE(pb_type_BLE,
     MP_QSTR_BLE,
     MP_TYPE_FLAG_NONE,
     locals_dict, &common_BLE_locals_dict);

--- a/pybricks/common/pb_type_charger.c
+++ b/pybricks/common/pb_type_charger.c
@@ -19,29 +19,29 @@ typedef struct {
     mp_obj_base_t base;
 } pb_obj_Charger_t;
 
-STATIC mp_obj_t Charger_current(mp_obj_t self_in) {
+static mp_obj_t Charger_current(mp_obj_t self_in) {
     uint16_t current;
     pb_assert(pbdrv_charger_get_current_now(&current));
     return mp_obj_new_int(current);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(Charger_current_obj, Charger_current);
+static MP_DEFINE_CONST_FUN_OBJ_1(Charger_current_obj, Charger_current);
 
-STATIC mp_obj_t Charger_status(mp_obj_t self_in) {
+static mp_obj_t Charger_status(mp_obj_t self_in) {
     return MP_OBJ_NEW_SMALL_INT(pbdrv_charger_get_status());
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(Charger_status_obj, Charger_status);
+static MP_DEFINE_CONST_FUN_OBJ_1(Charger_status_obj, Charger_status);
 
-STATIC mp_obj_t Charger_connected(mp_obj_t self_in) {
+static mp_obj_t Charger_connected(mp_obj_t self_in) {
     return mp_obj_new_bool(pbdrv_usb_get_bcd() != PBDRV_USB_BCD_NONE);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(Charger_connected_obj, Charger_connected);
+static MP_DEFINE_CONST_FUN_OBJ_1(Charger_connected_obj, Charger_connected);
 
-STATIC const mp_rom_map_elem_t Charger_locals_dict_table[] = {
+static const mp_rom_map_elem_t Charger_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_connected), MP_ROM_PTR(&Charger_connected_obj) },
     { MP_ROM_QSTR(MP_QSTR_current), MP_ROM_PTR(&Charger_current_obj) },
     { MP_ROM_QSTR(MP_QSTR_status), MP_ROM_PTR(&Charger_status_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(Charger_locals_dict, Charger_locals_dict_table);
+static MP_DEFINE_CONST_DICT(Charger_locals_dict, Charger_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_Charger,
     MP_QSTR_Charger,

--- a/pybricks/common/pb_type_colorlight_external.c
+++ b/pybricks/common/pb_type_colorlight_external.c
@@ -26,7 +26,7 @@ typedef struct {
 } common_ColorLight_external_obj_t;
 
 // pybricks._common.ColorLight.on
-STATIC mp_obj_t common_ColorLight_external_on(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t common_ColorLight_external_on(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     // Parse arguments
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         common_ColorLight_external_obj_t, self,
@@ -34,24 +34,24 @@ STATIC mp_obj_t common_ColorLight_external_on(size_t n_args, const mp_obj_t *pos
 
     return self->on(self->context, pb_type_Color_get_hsv(color_in));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(common_ColorLight_external_on_obj, 1, common_ColorLight_external_on);
+static MP_DEFINE_CONST_FUN_OBJ_KW(common_ColorLight_external_on_obj, 1, common_ColorLight_external_on);
 
 // pybricks._common.ColorLight.off
-STATIC mp_obj_t common_ColorLight_external_off(mp_obj_t self_in) {
+static mp_obj_t common_ColorLight_external_off(mp_obj_t self_in) {
     common_ColorLight_external_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return self->on(self->context, &pb_Color_NONE_obj.hsv);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(common_ColorLight_external_off_obj, common_ColorLight_external_off);
+static MP_DEFINE_CONST_FUN_OBJ_1(common_ColorLight_external_off_obj, common_ColorLight_external_off);
 
 // dir(pybricks.builtins.ColorLight)
-STATIC const mp_rom_map_elem_t common_ColorLight_external_locals_dict_table[] = {
+static const mp_rom_map_elem_t common_ColorLight_external_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_on), MP_ROM_PTR(&common_ColorLight_external_on_obj) },
     { MP_ROM_QSTR(MP_QSTR_off), MP_ROM_PTR(&common_ColorLight_external_off_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(common_ColorLight_external_locals_dict, common_ColorLight_external_locals_dict_table);
+static MP_DEFINE_CONST_DICT(common_ColorLight_external_locals_dict, common_ColorLight_external_locals_dict_table);
 
 // type(pybricks.builtins.ColorLight)
-STATIC MP_DEFINE_CONST_OBJ_TYPE(pb_type_ColorLight_external,
+static MP_DEFINE_CONST_OBJ_TYPE(pb_type_ColorLight_external,
     MP_QSTR_ColorLight,
     MP_TYPE_FLAG_NONE,
     locals_dict, &common_ColorLight_external_locals_dict);

--- a/pybricks/common/pb_type_colorlight_internal.c
+++ b/pybricks/common/pb_type_colorlight_internal.c
@@ -32,7 +32,7 @@ typedef struct _common_ColorLight_internal_obj_t {
 } common_ColorLight_internal_obj_t;
 
 // pybricks._common.ColorLight.on
-STATIC mp_obj_t common_ColorLight_internal_on(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t common_ColorLight_internal_on(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     // Parse arguments
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         common_ColorLight_internal_obj_t, self,
@@ -42,20 +42,20 @@ STATIC mp_obj_t common_ColorLight_internal_on(size_t n_args, const mp_obj_t *pos
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(common_ColorLight_internal_on_obj, 1, common_ColorLight_internal_on);
+static MP_DEFINE_CONST_FUN_OBJ_KW(common_ColorLight_internal_on_obj, 1, common_ColorLight_internal_on);
 
 // pybricks._common.ColorLight.off
-STATIC mp_obj_t common_ColorLight_internal_off(mp_obj_t self_in) {
+static mp_obj_t common_ColorLight_internal_off(mp_obj_t self_in) {
     common_ColorLight_internal_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     pb_assert(pbio_color_light_off(self->light));
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(common_ColorLight_internal_off_obj, common_ColorLight_internal_off);
+static MP_DEFINE_CONST_FUN_OBJ_1(common_ColorLight_internal_off_obj, common_ColorLight_internal_off);
 
 // pybricks._common.ColorLight.blink
-STATIC mp_obj_t common_ColorLight_internal_blink(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t common_ColorLight_internal_blink(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         common_ColorLight_internal_obj_t, self,
         PB_ARG_REQUIRED(color),
@@ -89,10 +89,10 @@ STATIC mp_obj_t common_ColorLight_internal_blink(size_t n_args, const mp_obj_t *
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(common_ColorLight_internal_blink_obj, 1, common_ColorLight_internal_blink);
+static MP_DEFINE_CONST_FUN_OBJ_KW(common_ColorLight_internal_blink_obj, 1, common_ColorLight_internal_blink);
 
 // pybricks._common.ColorLight.animate
-STATIC mp_obj_t common_ColorLight_internal_animate(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t common_ColorLight_internal_animate(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         common_ColorLight_internal_obj_t, self,
         PB_ARG_REQUIRED(colors),
@@ -124,19 +124,19 @@ STATIC mp_obj_t common_ColorLight_internal_animate(size_t n_args, const mp_obj_t
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(common_ColorLight_internal_animate_obj, 1, common_ColorLight_internal_animate);
+static MP_DEFINE_CONST_FUN_OBJ_KW(common_ColorLight_internal_animate_obj, 1, common_ColorLight_internal_animate);
 
 // dir(pybricks.builtins.ColorLight)
-STATIC const mp_rom_map_elem_t common_ColorLight_internal_locals_dict_table[] = {
+static const mp_rom_map_elem_t common_ColorLight_internal_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_on), MP_ROM_PTR(&common_ColorLight_internal_on_obj) },
     { MP_ROM_QSTR(MP_QSTR_off), MP_ROM_PTR(&common_ColorLight_internal_off_obj) },
     { MP_ROM_QSTR(MP_QSTR_blink), MP_ROM_PTR(&common_ColorLight_internal_blink_obj) },
     { MP_ROM_QSTR(MP_QSTR_animate), MP_ROM_PTR(&common_ColorLight_internal_animate_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(common_ColorLight_internal_locals_dict, common_ColorLight_internal_locals_dict_table);
+static MP_DEFINE_CONST_DICT(common_ColorLight_internal_locals_dict, common_ColorLight_internal_locals_dict_table);
 
 // type(pybricks.builtins.ColorLight)
-STATIC MP_DEFINE_CONST_OBJ_TYPE(pb_type_ColorLight_internal,
+static MP_DEFINE_CONST_OBJ_TYPE(pb_type_ColorLight_internal,
     MP_QSTRnull,
     MP_TYPE_FLAG_NONE,
     locals_dict, &common_ColorLight_internal_locals_dict);

--- a/pybricks/common/pb_type_control.c
+++ b/pybricks/common/pb_type_control.c
@@ -81,7 +81,7 @@ mp_obj_t pb_type_Control_obj_make_new(pbio_control_t *control) {
 }
 
 // pybricks._common.Control.limits
-STATIC mp_obj_t pb_type_Control_limits(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Control_limits(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Control_obj_t, self,
@@ -115,10 +115,10 @@ STATIC mp_obj_t pb_type_Control_limits(size_t n_args, const mp_obj_t *pos_args, 
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Control_limits_obj, 1, pb_type_Control_limits);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Control_limits_obj, 1, pb_type_Control_limits);
 
 // pybricks._common.Control.pid
-STATIC mp_obj_t pb_type_Control_pid(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Control_pid(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Control_obj_t, self,
@@ -156,10 +156,10 @@ STATIC mp_obj_t pb_type_Control_pid(size_t n_args, const mp_obj_t *pos_args, mp_
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Control_pid_obj, 1, pb_type_Control_pid);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Control_pid_obj, 1, pb_type_Control_pid);
 
 // pybricks._common.Control.target_tolerances
-STATIC mp_obj_t pb_type_Control_target_tolerances(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Control_target_tolerances(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Control_obj_t, self,
@@ -186,10 +186,10 @@ STATIC mp_obj_t pb_type_Control_target_tolerances(size_t n_args, const mp_obj_t 
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Control_target_tolerances_obj, 1, pb_type_Control_target_tolerances);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Control_target_tolerances_obj, 1, pb_type_Control_target_tolerances);
 
 // pybricks._common.Control.stall_tolerances
-STATIC mp_obj_t pb_type_Control_stall_tolerances(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Control_stall_tolerances(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Control_obj_t, self,
@@ -217,10 +217,10 @@ STATIC mp_obj_t pb_type_Control_stall_tolerances(size_t n_args, const mp_obj_t *
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Control_stall_tolerances_obj, 1, pb_type_Control_stall_tolerances);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Control_stall_tolerances_obj, 1, pb_type_Control_stall_tolerances);
 
 // pybricks._common.Control.trajectory
-STATIC mp_obj_t pb_type_Control_trajectory(mp_obj_t self_in) {
+static mp_obj_t pb_type_Control_trajectory(mp_obj_t self_in) {
     pb_type_Control_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pbio_trajectory_t *trj = &self->control->trajectory;
 
@@ -249,7 +249,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Control_trajectory_obj, pb_type_Control_trajec
 // DELETEME: This method should not be used in V3.2 or later. It may be removed
 // in a future version
 // pybricks._common.Control.done
-STATIC mp_obj_t pb_type_Control_done(mp_obj_t self_in) {
+static mp_obj_t pb_type_Control_done(mp_obj_t self_in) {
     pb_type_Control_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(pbio_control_is_done(self->control));
 }
@@ -258,7 +258,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Control_done_obj, pb_type_Control_done);
 // DELETEME: This method should not be used in V3.2 or later. It may be removed
 // in a future version
 // pybricks._common.Control.load
-STATIC mp_obj_t pb_type_Control_load(mp_obj_t self_in) {
+static mp_obj_t pb_type_Control_load(mp_obj_t self_in) {
     pb_type_Control_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     if (!pbio_control_is_active(self->control)) {
@@ -273,14 +273,14 @@ MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Control_load_obj, pb_type_Control_load);
 // DELETEME: This method should not be used in V3.2 or later. It may be removed
 // in a future version
 // pybricks._common.Control.stalled
-STATIC mp_obj_t pb_type_Control_stalled(mp_obj_t self_in) {
+static mp_obj_t pb_type_Control_stalled(mp_obj_t self_in) {
     pb_type_Control_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint32_t stall_duration;
     return mp_obj_new_bool(pbio_control_is_stalled(self->control, &stall_duration));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Control_stalled_obj, pb_type_Control_stalled);
 
-STATIC const pb_attr_dict_entry_t pb_type_Control_attr_dict[] = {
+static const pb_attr_dict_entry_t pb_type_Control_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_scale, pb_type_Control_obj_t, scale),
     #if PYBRICKS_PY_COMMON_LOGGER
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_log, pb_type_Control_obj_t, logger),
@@ -289,7 +289,7 @@ STATIC const pb_attr_dict_entry_t pb_type_Control_attr_dict[] = {
 };
 
 // dir(pybricks.common.Control)
-STATIC const mp_rom_map_elem_t pb_type_Control_locals_dict_table[] = {
+static const mp_rom_map_elem_t pb_type_Control_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_limits), MP_ROM_PTR(&pb_type_Control_limits_obj) },
     { MP_ROM_QSTR(MP_QSTR_pid), MP_ROM_PTR(&pb_type_Control_pid_obj) },
     { MP_ROM_QSTR(MP_QSTR_target_tolerances), MP_ROM_PTR(&pb_type_Control_target_tolerances_obj) },
@@ -299,7 +299,7 @@ STATIC const mp_rom_map_elem_t pb_type_Control_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_load), MP_ROM_PTR(&pb_type_Control_load_obj) },
     { MP_ROM_QSTR(MP_QSTR_stalled), MP_ROM_PTR(&pb_type_Control_stalled_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_type_Control_locals_dict, pb_type_Control_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pb_type_Control_locals_dict, pb_type_Control_locals_dict_table);
 
 // type(pybricks.common.Control)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_Control,

--- a/pybricks/common/pb_type_device.c
+++ b/pybricks/common/pb_type_device.c
@@ -69,7 +69,7 @@ void *pb_type_device_get_data_blocking(mp_obj_t self_in, uint8_t mode) {
  * @return                  True if operation is complete (device ready),
  *                          false otherwise.
  */
-STATIC bool pb_pup_device_test_completion(mp_obj_t self_in, uint32_t end_time) {
+static bool pb_pup_device_test_completion(mp_obj_t self_in, uint32_t end_time) {
     pb_type_device_obj_base_t *sensor = MP_OBJ_TO_PTR(self_in);
     pbio_error_t err = pbdrv_legodev_is_ready(sensor->legodev);
     if (err == PBIO_ERROR_AGAIN) {

--- a/pybricks/common/pb_type_imu.c
+++ b/pybricks/common/pb_type_imu.c
@@ -30,7 +30,7 @@ typedef struct _pb_type_imu_obj_t {
 } pb_type_imu_obj_t;
 
 // pybricks._common.IMU.up
-STATIC mp_obj_t pb_type_imu_up(mp_obj_t self_in) {
+static mp_obj_t pb_type_imu_up(mp_obj_t self_in) {
     switch (pbio_imu_get_up_side()) {
         default:
         case PBIO_GEOMETRY_SIDE_FRONT:
@@ -50,7 +50,7 @@ STATIC mp_obj_t pb_type_imu_up(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_imu_up_obj, pb_type_imu_up);
 
 // pybricks._common.IMU.tilt
-STATIC mp_obj_t pb_type_imu_tilt(mp_obj_t self_in) {
+static mp_obj_t pb_type_imu_tilt(mp_obj_t self_in) {
 
     // Read acceleration in the user frame.
     pbio_geometry_xyz_t accl;
@@ -68,7 +68,7 @@ STATIC mp_obj_t pb_type_imu_tilt(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_imu_tilt_obj, pb_type_imu_tilt);
 
-STATIC void pb_type_imu_extract_axis(mp_obj_t obj_in, pbio_geometry_xyz_t *vector) {
+static void pb_type_imu_extract_axis(mp_obj_t obj_in, pbio_geometry_xyz_t *vector) {
     if (!mp_obj_is_type(obj_in, &pb_type_Matrix)) {
         mp_raise_TypeError(MP_ERROR_TEXT("Axis must be Matrix."));
     }
@@ -82,7 +82,7 @@ STATIC void pb_type_imu_extract_axis(mp_obj_t obj_in, pbio_geometry_xyz_t *vecto
 }
 
 // pybricks._common.IMU.acceleration
-STATIC mp_obj_t pb_type_imu_acceleration(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_imu_acceleration(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_imu_obj_t, self,
         PB_ARG_DEFAULT_NONE(axis));
@@ -104,10 +104,10 @@ STATIC mp_obj_t pb_type_imu_acceleration(size_t n_args, const mp_obj_t *pos_args
     pb_assert(pbio_geometry_vector_project(&axis, &acceleration, &projection));
     return mp_obj_new_float_from_f(projection);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_imu_acceleration_obj, 1, pb_type_imu_acceleration);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_imu_acceleration_obj, 1, pb_type_imu_acceleration);
 
 // pybricks._common.IMU.angular_velocity
-STATIC mp_obj_t pb_type_imu_angular_velocity(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_imu_angular_velocity(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_imu_obj_t, self,
         PB_ARG_DEFAULT_NONE(axis));
@@ -129,10 +129,10 @@ STATIC mp_obj_t pb_type_imu_angular_velocity(size_t n_args, const mp_obj_t *pos_
     pb_assert(pbio_geometry_vector_project(&axis, &angular_velocity, &projection));
     return mp_obj_new_float_from_f(projection);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_imu_angular_velocity_obj, 1, pb_type_imu_angular_velocity);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_imu_angular_velocity_obj, 1, pb_type_imu_angular_velocity);
 
 // pybricks._common.IMU.rotation
-STATIC mp_obj_t pb_type_imu_rotation(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_imu_rotation(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_imu_obj_t, self,
         PB_ARG_DEFAULT_NONE(axis));
@@ -147,22 +147,22 @@ STATIC mp_obj_t pb_type_imu_rotation(size_t n_args, const mp_obj_t *pos_args, mp
     pb_assert(pbio_imu_get_single_axis_rotation(&axis, &rotation_angle));
     return mp_obj_new_float_from_f(rotation_angle);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_imu_rotation_obj, 1, pb_type_imu_rotation);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_imu_rotation_obj, 1, pb_type_imu_rotation);
 
 // pybricks._common.IMU.ready
-STATIC mp_obj_t pb_type_imu_ready(mp_obj_t self_in) {
+static mp_obj_t pb_type_imu_ready(mp_obj_t self_in) {
     return mp_obj_new_bool(pbio_imu_is_ready());
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_imu_ready_obj, pb_type_imu_ready);
 
 // pybricks._common.IMU.stationary
-STATIC mp_obj_t pb_type_imu_stationary(mp_obj_t self_in) {
+static mp_obj_t pb_type_imu_stationary(mp_obj_t self_in) {
     return mp_obj_new_bool(pbio_imu_is_stationary());
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_imu_stationary_obj, pb_type_imu_stationary);
 
 // pybricks._common.IMU.settings
-STATIC mp_obj_t pb_type_imu_settings(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_imu_settings(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_imu_obj_t, self,
         PB_ARG_DEFAULT_NONE(angular_velocity_threshold),
@@ -198,17 +198,17 @@ STATIC mp_obj_t pb_type_imu_settings(size_t n_args, const mp_obj_t *pos_args, mp
     pbsys_storage_settings_save_imu_settings();
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_imu_settings_obj, 1, pb_type_imu_settings);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_imu_settings_obj, 1, pb_type_imu_settings);
 
 // pybricks._common.IMU.heading
-STATIC mp_obj_t pb_type_imu_heading(mp_obj_t self_in) {
+static mp_obj_t pb_type_imu_heading(mp_obj_t self_in) {
     (void)self_in;
     return mp_obj_new_float(pbio_imu_get_heading());
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_imu_heading_obj, pb_type_imu_heading);
 
 // pybricks._common.IMU.reset_heading
-STATIC mp_obj_t pb_type_imu_reset_heading(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_imu_reset_heading(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_imu_obj_t, self,
         PB_ARG_REQUIRED(angle));
@@ -218,10 +218,10 @@ STATIC mp_obj_t pb_type_imu_reset_heading(size_t n_args, const mp_obj_t *pos_arg
     pbio_imu_set_heading(mp_obj_get_float(angle_in));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_imu_reset_heading_obj, 1, pb_type_imu_reset_heading);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_imu_reset_heading_obj, 1, pb_type_imu_reset_heading);
 
 // pybricks._common.IMU.update_heading_correction
-STATIC mp_obj_t pb_type_imu_update_heading_correction(mp_obj_t self_in) {
+static mp_obj_t pb_type_imu_update_heading_correction(mp_obj_t self_in) {
     pb_type_imu_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pb_module_tools_assert_blocking();
 
@@ -243,7 +243,7 @@ STATIC mp_obj_t pb_type_imu_update_heading_correction(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_imu_update_heading_correction_obj, pb_type_imu_update_heading_correction);
 
 // dir(pybricks.common.IMU)
-STATIC const mp_rom_map_elem_t pb_type_imu_locals_dict_table[] = {
+static const mp_rom_map_elem_t pb_type_imu_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_acceleration),     MP_ROM_PTR(&pb_type_imu_acceleration_obj)    },
     { MP_ROM_QSTR(MP_QSTR_angular_velocity), MP_ROM_PTR(&pb_type_imu_angular_velocity_obj)},
     { MP_ROM_QSTR(MP_QSTR_heading),          MP_ROM_PTR(&pb_type_imu_heading_obj)         },
@@ -256,15 +256,15 @@ STATIC const mp_rom_map_elem_t pb_type_imu_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_up),               MP_ROM_PTR(&pb_type_imu_up_obj)              },
     { MP_ROM_QSTR(MP_QSTR_update_heading_correction), MP_ROM_PTR(&pb_type_imu_update_heading_correction_obj)},
 };
-STATIC MP_DEFINE_CONST_DICT(pb_type_imu_locals_dict, pb_type_imu_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pb_type_imu_locals_dict, pb_type_imu_locals_dict_table);
 
 // type(pybricks.common.IMU)
-STATIC MP_DEFINE_CONST_OBJ_TYPE(pb_type_IMU,
+static MP_DEFINE_CONST_OBJ_TYPE(pb_type_IMU,
     MP_QSTR_IMU,
     MP_TYPE_FLAG_NONE,
     locals_dict, &pb_type_imu_locals_dict);
 
-STATIC pb_type_imu_obj_t singleton_imu_obj = {
+static pb_type_imu_obj_t singleton_imu_obj = {
     .base.type = &pb_type_IMU,
 };
 

--- a/pybricks/common/pb_type_keypad.c
+++ b/pybricks/common/pb_type_keypad.c
@@ -21,20 +21,20 @@ typedef struct _common_Keypad_obj_t {
 } common_Keypad_obj_t;
 
 // pybricks._common.Keypad.pressed
-STATIC mp_obj_t common_Keypad_pressed(mp_obj_t self_in) {
+static mp_obj_t common_Keypad_pressed(mp_obj_t self_in) {
     common_Keypad_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return self->get_pressed();
 }
 MP_DEFINE_CONST_FUN_OBJ_1(common_Keypad_pressed_obj, common_Keypad_pressed);
 
 // dir(pybricks.common.Keypad)
-STATIC const mp_rom_map_elem_t common_Keypad_locals_dict_table[] = {
+static const mp_rom_map_elem_t common_Keypad_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_pressed),     MP_ROM_PTR(&common_Keypad_pressed_obj)     },
 };
-STATIC MP_DEFINE_CONST_DICT(common_Keypad_locals_dict, common_Keypad_locals_dict_table);
+static MP_DEFINE_CONST_DICT(common_Keypad_locals_dict, common_Keypad_locals_dict_table);
 
 // type(pybricks.common.Keypad)
-STATIC MP_DEFINE_CONST_OBJ_TYPE(pb_type_Keypad,
+static MP_DEFINE_CONST_OBJ_TYPE(pb_type_Keypad,
     MP_QSTRnull,
     MP_TYPE_FLAG_NONE,
     locals_dict, &common_Keypad_locals_dict);

--- a/pybricks/common/pb_type_lightarray.c
+++ b/pybricks/common/pb_type_lightarray.c
@@ -26,7 +26,7 @@ typedef struct _common_LightArray_obj_t {
 } common_LightArray_obj_t;
 
 // pybricks._common.LightArray.on
-STATIC mp_obj_t common_LightArray_on(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t common_LightArray_on(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         common_LightArray_obj_t, self,
         PB_ARG_DEFAULT_INT(brightness, 100));
@@ -37,25 +37,25 @@ STATIC mp_obj_t common_LightArray_on(size_t n_args, const mp_obj_t *pos_args, mp
     // Set the brightness values and wait or await it.
     return pb_type_device_set_data(self->sensor, self->light_mode, brightness_values, self->number_of_lights);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(common_LightArray_on_obj, 1, common_LightArray_on);
+static MP_DEFINE_CONST_FUN_OBJ_KW(common_LightArray_on_obj, 1, common_LightArray_on);
 
 // pybricks._common.LightArray.off
-STATIC mp_obj_t common_LightArray_off(mp_obj_t self_in) {
+static mp_obj_t common_LightArray_off(mp_obj_t self_in) {
     common_LightArray_obj_t *self = MP_OBJ_TO_PTR(self_in);
     int8_t brightness_values[4] = { };
     return pb_type_device_set_data(self->sensor, self->light_mode, brightness_values, self->number_of_lights);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(common_LightArray_off_obj, common_LightArray_off);
+static MP_DEFINE_CONST_FUN_OBJ_1(common_LightArray_off_obj, common_LightArray_off);
 
 // dir(pybricks.builtins.LightArray)
-STATIC const mp_rom_map_elem_t common_LightArray_locals_dict_table[] = {
+static const mp_rom_map_elem_t common_LightArray_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_on), MP_ROM_PTR(&common_LightArray_on_obj) },
     { MP_ROM_QSTR(MP_QSTR_off), MP_ROM_PTR(&common_LightArray_off_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(common_LightArray_locals_dict, common_LightArray_locals_dict_table);
+static MP_DEFINE_CONST_DICT(common_LightArray_locals_dict, common_LightArray_locals_dict_table);
 
 // type(pybricks.builtins.LightArray)
-STATIC MP_DEFINE_CONST_OBJ_TYPE(pb_type_LightArray,
+static MP_DEFINE_CONST_OBJ_TYPE(pb_type_LightArray,
     MP_QSTRnull,
     MP_TYPE_FLAG_NONE,
     locals_dict, &common_LightArray_locals_dict);

--- a/pybricks/common/pb_type_lightmatrix.c
+++ b/pybricks/common/pb_type_lightmatrix.c
@@ -32,7 +32,7 @@ typedef struct _common_LightMatrix_obj_t {
 } common_LightMatrix_obj_t;
 
 // Renews memory for a given number of frames
-STATIC void common_LightMatrix__renew(common_LightMatrix_obj_t *self, uint8_t frames) {
+static void common_LightMatrix__renew(common_LightMatrix_obj_t *self, uint8_t frames) {
     // Matrix with/height
     size_t size = pbio_light_matrix_get_size(self->light_matrix);
 
@@ -44,7 +44,7 @@ STATIC void common_LightMatrix__renew(common_LightMatrix_obj_t *self, uint8_t fr
 }
 
 // pybricks._common.LightMatrix.orientation
-STATIC mp_obj_t common_LightMatrix_orientation(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t common_LightMatrix_orientation(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         common_LightMatrix_obj_t, self,
         PB_ARG_REQUIRED(up));
@@ -53,7 +53,7 @@ STATIC mp_obj_t common_LightMatrix_orientation(size_t n_args, const mp_obj_t *po
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_orientation_obj, 1, common_LightMatrix_orientation);
+static MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_orientation_obj, 1, common_LightMatrix_orientation);
 
 void pb_type_LightMatrix_display_char(pbio_light_matrix_t *light_matrix, mp_obj_t char_in) {
     // Argument must be a qstr or string
@@ -72,7 +72,7 @@ void pb_type_LightMatrix_display_char(pbio_light_matrix_t *light_matrix, mp_obj_
 }
 
 // pybricks._common.LightMatrix.char
-STATIC mp_obj_t common_LightMatrix_char(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t common_LightMatrix_char(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         common_LightMatrix_obj_t, self,
         PB_ARG_REQUIRED(char));
@@ -81,7 +81,7 @@ STATIC mp_obj_t common_LightMatrix_char(size_t n_args, const mp_obj_t *pos_args,
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_char_obj, 1, common_LightMatrix_char);
+static MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_char_obj, 1, common_LightMatrix_char);
 
 static void common_LightMatrix_icon__extract(mp_obj_t icon_in, size_t size, uint8_t *data) {
 
@@ -122,7 +122,7 @@ static void common_LightMatrix_icon__extract(mp_obj_t icon_in, size_t size, uint
 }
 
 // pybricks._common.LightMatrix.icon
-STATIC mp_obj_t common_LightMatrix_icon(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t common_LightMatrix_icon(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         common_LightMatrix_obj_t, self,
         PB_ARG_REQUIRED(icon));
@@ -137,10 +137,10 @@ STATIC mp_obj_t common_LightMatrix_icon(size_t n_args, const mp_obj_t *pos_args,
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_icon_obj, 1, common_LightMatrix_icon);
+static MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_icon_obj, 1, common_LightMatrix_icon);
 
 // pybricks._common.LightMatrix.on
-STATIC mp_obj_t common_LightMatrix_on(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t common_LightMatrix_on(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         common_LightMatrix_obj_t, self,
         PB_ARG_DEFAULT_INT(brightness, 100));
@@ -157,17 +157,17 @@ STATIC mp_obj_t common_LightMatrix_on(size_t n_args, const mp_obj_t *pos_args, m
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_on_obj, 1, common_LightMatrix_on);
+static MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_on_obj, 1, common_LightMatrix_on);
 
 // pybricks._common.LightMatrix.off
-STATIC mp_obj_t common_LightMatrix_off(mp_obj_t self_in) {
+static mp_obj_t common_LightMatrix_off(mp_obj_t self_in) {
     common_LightMatrix_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     pb_assert(pbio_light_matrix_clear(self->light_matrix));
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(common_LightMatrix_off_obj, common_LightMatrix_off);
+static MP_DEFINE_CONST_FUN_OBJ_1(common_LightMatrix_off_obj, common_LightMatrix_off);
 
 void pb_type_LightMatrix_display_number(pbio_light_matrix_t *light_matrix, mp_obj_t number_in) {
 
@@ -214,7 +214,7 @@ void pb_type_LightMatrix_display_number(pbio_light_matrix_t *light_matrix, mp_ob
 }
 
 // pybricks._common.LightMatrix.number
-STATIC mp_obj_t common_LightMatrix_number(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t common_LightMatrix_number(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         common_LightMatrix_obj_t, self,
         PB_ARG_REQUIRED(number));
@@ -223,10 +223,10 @@ STATIC mp_obj_t common_LightMatrix_number(size_t n_args, const mp_obj_t *pos_arg
     pb_type_LightMatrix_display_number(self->light_matrix, number_in);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_number_obj, 1, common_LightMatrix_number);
+static MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_number_obj, 1, common_LightMatrix_number);
 
 // pybricks._common.LightMatrix.animate
-STATIC mp_obj_t common_LightMatrix_animate(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t common_LightMatrix_animate(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         common_LightMatrix_obj_t, self,
         PB_ARG_REQUIRED(icons),
@@ -256,10 +256,10 @@ STATIC mp_obj_t common_LightMatrix_animate(size_t n_args, const mp_obj_t *pos_ar
     pbio_light_matrix_start_animation(self->light_matrix, self->data, self->frames, interval);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_animate_obj, 1, common_LightMatrix_animate);
+static MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_animate_obj, 1, common_LightMatrix_animate);
 
 // pybricks._common.LightMatrix.pixel
-STATIC mp_obj_t common_LightMatrix_pixel(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t common_LightMatrix_pixel(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         common_LightMatrix_obj_t, self,
         PB_ARG_REQUIRED(row),
@@ -271,10 +271,10 @@ STATIC mp_obj_t common_LightMatrix_pixel(size_t n_args, const mp_obj_t *pos_args
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_pixel_obj, 1, common_LightMatrix_pixel);
+static MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_pixel_obj, 1, common_LightMatrix_pixel);
 
 // pybricks._common.LightMatrix.text
-STATIC mp_obj_t common_LightMatrix_text(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t common_LightMatrix_text(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         common_LightMatrix_obj_t, self,
         PB_ARG_REQUIRED(text),
@@ -321,10 +321,10 @@ STATIC mp_obj_t common_LightMatrix_text(size_t n_args, const mp_obj_t *pos_args,
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_text_obj, 1, common_LightMatrix_text);
+static MP_DEFINE_CONST_FUN_OBJ_KW(common_LightMatrix_text_obj, 1, common_LightMatrix_text);
 
 // dir(pybricks.builtins.LightMatrix)
-STATIC const mp_rom_map_elem_t common_LightMatrix_locals_dict_table[] = {
+static const mp_rom_map_elem_t common_LightMatrix_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_char),            MP_ROM_PTR(&common_LightMatrix_char_obj)            },
     { MP_ROM_QSTR(MP_QSTR_icon),            MP_ROM_PTR(&common_LightMatrix_icon_obj)            },
     { MP_ROM_QSTR(MP_QSTR_number),          MP_ROM_PTR(&common_LightMatrix_number_obj)          },
@@ -335,10 +335,10 @@ STATIC const mp_rom_map_elem_t common_LightMatrix_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_orientation),     MP_ROM_PTR(&common_LightMatrix_orientation_obj)     },
     { MP_ROM_QSTR(MP_QSTR_text),            MP_ROM_PTR(&common_LightMatrix_text_obj)            },
 };
-STATIC MP_DEFINE_CONST_DICT(common_LightMatrix_locals_dict, common_LightMatrix_locals_dict_table);
+static MP_DEFINE_CONST_DICT(common_LightMatrix_locals_dict, common_LightMatrix_locals_dict_table);
 
 // type(pybricks.builtins.LightMatrix)
-STATIC MP_DEFINE_CONST_OBJ_TYPE(pb_type_LightMatrix,
+static MP_DEFINE_CONST_OBJ_TYPE(pb_type_LightMatrix,
     MP_QSTR_LightMatrix,
     MP_TYPE_FLAG_NONE,
     locals_dict, &common_LightMatrix_locals_dict);

--- a/pybricks/common/pb_type_logger.c
+++ b/pybricks/common/pb_type_logger.c
@@ -46,7 +46,7 @@ typedef struct _tools_Logger_obj_t {
     uint32_t last_size;
 } tools_Logger_obj_t;
 
-STATIC mp_obj_t tools_Logger_start(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t tools_Logger_start(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         tools_Logger_obj_t, self,
         PB_ARG_REQUIRED(duration),
@@ -66,9 +66,9 @@ STATIC mp_obj_t tools_Logger_start(size_t n_args, const mp_obj_t *pos_args, mp_m
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(tools_Logger_start_obj, 1, tools_Logger_start);
+static MP_DEFINE_CONST_FUN_OBJ_KW(tools_Logger_start_obj, 1, tools_Logger_start);
 
-STATIC mp_obj_t tools_Logger_stop(mp_obj_t self_in) {
+static mp_obj_t tools_Logger_stop(mp_obj_t self_in) {
     tools_Logger_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     // Indicates that background control loops log write more data.
@@ -76,9 +76,9 @@ STATIC mp_obj_t tools_Logger_stop(mp_obj_t self_in) {
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(tools_Logger_stop_obj, tools_Logger_stop);
+static MP_DEFINE_CONST_FUN_OBJ_1(tools_Logger_stop_obj, tools_Logger_stop);
 
-STATIC mp_obj_t tools_Logger_save(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t tools_Logger_save(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         tools_Logger_obj_t, self,
@@ -141,18 +141,18 @@ STATIC mp_obj_t tools_Logger_save(size_t n_args, const mp_obj_t *pos_args, mp_ma
     pb_assert(err);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(tools_Logger_save_obj, 1, tools_Logger_save);
+static MP_DEFINE_CONST_FUN_OBJ_KW(tools_Logger_save_obj, 1, tools_Logger_save);
 
 // dir(pybricks.tools.Logger)
-STATIC const mp_rom_map_elem_t tools_Logger_locals_dict_table[] = {
+static const mp_rom_map_elem_t tools_Logger_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_start), MP_ROM_PTR(&tools_Logger_start_obj) },
     { MP_ROM_QSTR(MP_QSTR_stop), MP_ROM_PTR(&tools_Logger_stop_obj) },
     { MP_ROM_QSTR(MP_QSTR_save), MP_ROM_PTR(&tools_Logger_save_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(tools_Logger_locals_dict, tools_Logger_locals_dict_table);
+static MP_DEFINE_CONST_DICT(tools_Logger_locals_dict, tools_Logger_locals_dict_table);
 
 // type(pybricks.tools.Logger)
-STATIC MP_DEFINE_CONST_OBJ_TYPE(tools_Logger_type,
+static MP_DEFINE_CONST_OBJ_TYPE(tools_Logger_type,
     MP_QSTR_Logger,
     MP_TYPE_FLAG_NONE,
     locals_dict, &tools_Logger_locals_dict);

--- a/pybricks/common/pb_type_motor.c
+++ b/pybricks/common/pb_type_motor.c
@@ -75,7 +75,7 @@ static int32_t get_gear_ratio(mp_obj_t gears_in) {
 }
 
 // pybricks.common.Motor.__init__
-STATIC mp_obj_t pb_type_Motor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pb_type_Motor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port),
         PB_ARG_DEFAULT_OBJ(positive_direction, pb_Direction_CLOCKWISE_obj),
@@ -131,7 +131,7 @@ STATIC mp_obj_t pb_type_Motor_make_new(const mp_obj_type_t *type, size_t n_args,
 }
 
 // pybricks.common.Motor.__repr__
-STATIC void pb_type_Motor_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+static void pb_type_Motor_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pb_type_Motor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_printf(print, "%q(Port.%c, %q.%q)",
         self->device_base.base.type->name, self->port, MP_QSTR_Direction,
@@ -139,7 +139,7 @@ STATIC void pb_type_Motor_print(const mp_print_t *print, mp_obj_t self_in, mp_pr
 }
 
 // pybricks.common.Motor.dc
-STATIC mp_obj_t pb_type_Motor_duty(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Motor_duty(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Motor_obj_t, self,
         PB_ARG_REQUIRED(duty));
@@ -150,26 +150,26 @@ STATIC mp_obj_t pb_type_Motor_duty(size_t n_args, const mp_obj_t *pos_args, mp_m
     pb_assert(pbio_dcmotor_user_command(self->srv->dcmotor, false, voltage));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_duty_obj, 1, pb_type_Motor_duty);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_duty_obj, 1, pb_type_Motor_duty);
 
 // pybricks.common.Motor.stop
-STATIC mp_obj_t pb_type_Motor_stop(mp_obj_t self_in) {
+static mp_obj_t pb_type_Motor_stop(mp_obj_t self_in) {
     pb_type_Motor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pb_assert(pbio_dcmotor_user_command(self->srv->dcmotor, true, 0));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_stop_obj, pb_type_Motor_stop);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_stop_obj, pb_type_Motor_stop);
 
 // pybricks.common.Motor.brake
-STATIC mp_obj_t pb_type_Motor_brake(mp_obj_t self_in) {
+static mp_obj_t pb_type_Motor_brake(mp_obj_t self_in) {
     pb_type_Motor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pb_assert(pbio_dcmotor_user_command(self->srv->dcmotor, false, 0));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_brake_obj, pb_type_Motor_brake);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_brake_obj, pb_type_Motor_brake);
 
 // pybricks.common.Motor.dc
-STATIC mp_obj_t pb_type_Motor_dc_settings(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Motor_dc_settings(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Motor_obj_t, self,
         PB_ARG_DEFAULT_NONE(max_voltage));
@@ -187,27 +187,27 @@ STATIC mp_obj_t pb_type_Motor_dc_settings(size_t n_args, const mp_obj_t *pos_arg
     pb_assert(pbio_dcmotor_set_settings(self->srv->dcmotor, pb_obj_get_int(max_voltage_in)));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_settings_obj, 1, pb_type_Motor_dc_settings);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_settings_obj, 1, pb_type_Motor_dc_settings);
 
 // pybricks.common.Motor.close
-STATIC mp_obj_t pb_type_Motor_close(mp_obj_t self_in) {
+static mp_obj_t pb_type_Motor_close(mp_obj_t self_in) {
     pb_type_Motor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pb_assert(pbio_dcmotor_close(self->srv->dcmotor));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_close_obj, pb_type_Motor_close);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_close_obj, pb_type_Motor_close);
 
 // pybricks.common.Motor.angle
-STATIC mp_obj_t pb_type_Motor_angle(mp_obj_t self_in) {
+static mp_obj_t pb_type_Motor_angle(mp_obj_t self_in) {
     pb_type_Motor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     int32_t angle, speed;
     pb_assert(pbio_servo_get_state_user(self->srv, &angle, &speed));
     return mp_obj_new_int(angle);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_angle_obj, pb_type_Motor_angle);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_angle_obj, pb_type_Motor_angle);
 
 // pybricks.common.Motor.reset_angle
-STATIC mp_obj_t pb_type_Motor_reset_angle(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Motor_reset_angle(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Motor_obj_t, self,
         PB_ARG_DEFAULT_NONE(angle));
@@ -223,10 +223,10 @@ STATIC mp_obj_t pb_type_Motor_reset_angle(size_t n_args, const mp_obj_t *pos_arg
     pb_type_awaitable_update_all(self->device_base.awaitables, PB_TYPE_AWAITABLE_OPT_CANCEL_ALL);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_reset_angle_obj, 1, pb_type_Motor_reset_angle);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_reset_angle_obj, 1, pb_type_Motor_reset_angle);
 
 // pybricks.common.Motor.speed
-STATIC mp_obj_t pb_type_Motor_speed(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Motor_speed(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Motor_obj_t, self,
         PB_ARG_DEFAULT_INT(window, 100));
@@ -235,10 +235,10 @@ STATIC mp_obj_t pb_type_Motor_speed(size_t n_args, const mp_obj_t *pos_args, mp_
     pb_assert(pbio_servo_get_speed_user(self->srv, pb_obj_get_positive_int(window_in), &speed));
     return mp_obj_new_int(speed);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_speed_obj, 1, pb_type_Motor_speed);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_speed_obj, 1, pb_type_Motor_speed);
 
 // pybricks.common.Motor.run
-STATIC mp_obj_t pb_type_Motor_run(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Motor_run(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Motor_obj_t, self,
         PB_ARG_REQUIRED(speed));
@@ -248,18 +248,18 @@ STATIC mp_obj_t pb_type_Motor_run(size_t n_args, const mp_obj_t *pos_args, mp_ma
     pb_type_awaitable_update_all(self->device_base.awaitables, PB_TYPE_AWAITABLE_OPT_CANCEL_ALL);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_run_obj, 1, pb_type_Motor_run);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_run_obj, 1, pb_type_Motor_run);
 
 // pybricks.common.Motor.hold
-STATIC mp_obj_t pb_type_Motor_hold(mp_obj_t self_in) {
+static mp_obj_t pb_type_Motor_hold(mp_obj_t self_in) {
     pb_type_Motor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pb_assert(pbio_servo_stop(self->srv, PBIO_CONTROL_ON_COMPLETION_HOLD));
     pb_type_awaitable_update_all(self->device_base.awaitables, PB_TYPE_AWAITABLE_OPT_CANCEL_ALL);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_hold_obj, pb_type_Motor_hold);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_hold_obj, pb_type_Motor_hold);
 
-STATIC bool pb_type_Motor_test_completion(mp_obj_t self_in, uint32_t end_time) {
+static bool pb_type_Motor_test_completion(mp_obj_t self_in, uint32_t end_time) {
     pb_type_Motor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     // Handle I/O exceptions like port unplugged.
     if (!pbio_servo_update_loop_is_running(self->srv)) {
@@ -270,12 +270,12 @@ STATIC bool pb_type_Motor_test_completion(mp_obj_t self_in, uint32_t end_time) {
     return pbio_control_is_done(&self->srv->control);
 }
 
-STATIC void pb_type_Motor_cancel(mp_obj_t self_in) {
+static void pb_type_Motor_cancel(mp_obj_t self_in) {
     pb_type_Motor_stop(self_in);
 }
 
 // Common awaitable used for most motor methods.
-STATIC mp_obj_t await_or_wait(pb_type_Motor_obj_t *self) {
+static mp_obj_t await_or_wait(pb_type_Motor_obj_t *self) {
     return pb_type_awaitable_await_or_wait(
         MP_OBJ_FROM_PTR(self),
         self->device_base.awaitables,
@@ -287,7 +287,7 @@ STATIC mp_obj_t await_or_wait(pb_type_Motor_obj_t *self) {
 }
 
 // pybricks.common.Motor.run_time
-STATIC mp_obj_t pb_type_Motor_run_time(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Motor_run_time(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Motor_obj_t, self,
         PB_ARG_REQUIRED(speed),
@@ -310,9 +310,9 @@ STATIC mp_obj_t pb_type_Motor_run_time(size_t n_args, const mp_obj_t *pos_args, 
     // Handle completion by awaiting or blocking.
     return await_or_wait(self);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_run_time_obj, 1, pb_type_Motor_run_time);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_run_time_obj, 1, pb_type_Motor_run_time);
 
-STATIC mp_obj_t pb_type_Motor_stall_return_value(mp_obj_t self_in) {
+static mp_obj_t pb_type_Motor_stall_return_value(mp_obj_t self_in) {
 
     pb_type_Motor_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -324,7 +324,7 @@ STATIC mp_obj_t pb_type_Motor_stall_return_value(mp_obj_t self_in) {
 }
 
 // pybricks.common.Motor.run_until_stalled
-STATIC mp_obj_t pb_type_Motor_run_until_stalled(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Motor_run_until_stalled(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Motor_obj_t, self,
         PB_ARG_REQUIRED(speed),
@@ -356,10 +356,10 @@ STATIC mp_obj_t pb_type_Motor_run_until_stalled(size_t n_args, const mp_obj_t *p
         pb_type_Motor_cancel,
         PB_TYPE_AWAITABLE_OPT_CANCEL_ALL);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_run_until_stalled_obj, 1, pb_type_Motor_run_until_stalled);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_run_until_stalled_obj, 1, pb_type_Motor_run_until_stalled);
 
 // pybricks.common.Motor.run_angle
-STATIC mp_obj_t pb_type_Motor_run_angle(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Motor_run_angle(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Motor_obj_t, self,
         PB_ARG_REQUIRED(speed),
@@ -381,10 +381,10 @@ STATIC mp_obj_t pb_type_Motor_run_angle(size_t n_args, const mp_obj_t *pos_args,
     // Handle completion by awaiting or blocking.
     return await_or_wait(self);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_run_angle_obj, 1, pb_type_Motor_run_angle);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_run_angle_obj, 1, pb_type_Motor_run_angle);
 
 // pybricks.common.Motor.run_target
-STATIC mp_obj_t pb_type_Motor_run_target(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Motor_run_target(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Motor_obj_t, self,
         PB_ARG_REQUIRED(speed),
@@ -406,10 +406,10 @@ STATIC mp_obj_t pb_type_Motor_run_target(size_t n_args, const mp_obj_t *pos_args
     // Handle completion by awaiting or blocking.
     return await_or_wait(self);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_run_target_obj, 1, pb_type_Motor_run_target);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_run_target_obj, 1, pb_type_Motor_run_target);
 
 // pybricks.common.Motor.track_target
-STATIC mp_obj_t pb_type_Motor_track_target(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Motor_track_target(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Motor_obj_t, self,
         PB_ARG_REQUIRED(target_angle));
@@ -419,36 +419,36 @@ STATIC mp_obj_t pb_type_Motor_track_target(size_t n_args, const mp_obj_t *pos_ar
     pb_type_awaitable_update_all(self->device_base.awaitables, PB_TYPE_AWAITABLE_OPT_CANCEL_ALL);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_track_target_obj, 1, pb_type_Motor_track_target);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Motor_track_target_obj, 1, pb_type_Motor_track_target);
 
 // pybricks.common.Motor.stalled
-STATIC mp_obj_t pb_type_Motor_stalled(mp_obj_t self_in) {
+static mp_obj_t pb_type_Motor_stalled(mp_obj_t self_in) {
     pb_type_Motor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint32_t stall_duration;
     bool stalled;
     pb_assert(pbio_servo_is_stalled(self->srv, &stalled, &stall_duration));
     return mp_obj_new_bool(stalled);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_stalled_obj, pb_type_Motor_stalled);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_stalled_obj, pb_type_Motor_stalled);
 
 // pybricks.common.Motor.done
-STATIC mp_obj_t pb_type_Motor_done(mp_obj_t self_in) {
+static mp_obj_t pb_type_Motor_done(mp_obj_t self_in) {
     pb_type_Motor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(pbio_control_is_done(&self->srv->control));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_done_obj, pb_type_Motor_done);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_done_obj, pb_type_Motor_done);
 
 // pybricks.common.Motor.load
-STATIC mp_obj_t pb_type_Motor_load(mp_obj_t self_in) {
+static mp_obj_t pb_type_Motor_load(mp_obj_t self_in) {
     pb_type_Motor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     int32_t load;
     pb_assert(pbio_servo_get_load(self->srv, &load));
     return mp_obj_new_int(load);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_load_obj, pb_type_Motor_load);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Motor_load_obj, pb_type_Motor_load);
 
 #if PYBRICKS_PY_COMMON_CONTROL | PYBRICKS_PY_COMMON_LOGGER
-STATIC const pb_attr_dict_entry_t pb_type_Motor_attr_dict[] = {
+static const pb_attr_dict_entry_t pb_type_Motor_attr_dict[] = {
     #if PYBRICKS_PY_COMMON_CONTROL
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_control, pb_type_Motor_obj_t, control),
     #endif
@@ -463,7 +463,7 @@ STATIC const pb_attr_dict_entry_t pb_type_Motor_attr_dict[] = {
 #endif // PYBRICKS_PY_COMMON_CONTROL | PYBRICKS_PY_COMMON_LOGGER
 
 // dir(pybricks.builtins.Motor)
-STATIC const mp_rom_map_elem_t pb_type_Motor_locals_dict_table[] = {
+static const mp_rom_map_elem_t pb_type_Motor_locals_dict_table[] = {
     //
     // Methods common to DC motors and encoded motors
     //
@@ -489,10 +489,10 @@ STATIC const mp_rom_map_elem_t pb_type_Motor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_track_target), MP_ROM_PTR(&pb_type_Motor_track_target_obj) },
     { MP_ROM_QSTR(MP_QSTR_load), MP_ROM_PTR(&pb_type_Motor_load_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_type_Motor_locals_dict, pb_type_Motor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pb_type_Motor_locals_dict, pb_type_Motor_locals_dict_table);
 
 // The DC Motor methods are shared with the DCMotor class, so use the first section of the same table.
-STATIC MP_DEFINE_CONST_DICT_WITH_SIZE(pb_type_DCMotor_locals_dict, pb_type_Motor_locals_dict_table, 5);
+static MP_DEFINE_CONST_DICT_WITH_SIZE(pb_type_DCMotor_locals_dict, pb_type_Motor_locals_dict_table, 5);
 
 // type(pybricks.builtins.DCMotor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_DCMotor,

--- a/pybricks/common/pb_type_motor_model.c
+++ b/pybricks/common/pb_type_motor_model.c
@@ -29,7 +29,7 @@ mp_obj_t pb_type_MotorModel_obj_make_new(pbio_observer_t *observer) {
 }
 
 // pybricks._common.MotorModel.settings
-STATIC mp_obj_t pb_type_MotorModel_settings(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_MotorModel_settings(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_MotorModel_obj_t, self,
@@ -67,10 +67,10 @@ STATIC mp_obj_t pb_type_MotorModel_settings(size_t n_args, const mp_obj_t *pos_a
     self->observer->settings.coulomb_friction_speed_cutoff = mp_obj_get_int(set_values[7]);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_MotorModel_settings_obj, 1, pb_type_MotorModel_settings);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_MotorModel_settings_obj, 1, pb_type_MotorModel_settings);
 
 // pybricks._common.Motor.state
-STATIC mp_obj_t pb_type_MotorModel_state(mp_obj_t self_in) {
+static mp_obj_t pb_type_MotorModel_state(mp_obj_t self_in) {
     pb_type_MotorModel_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     pbio_angle_t zero = {.millidegrees = 0, .rotations = 0};
@@ -87,11 +87,11 @@ STATIC mp_obj_t pb_type_MotorModel_state(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_MotorModel_state_obj, pb_type_MotorModel_state);
 
 // dir(pybricks.common.MotorModel)
-STATIC const mp_rom_map_elem_t pb_type_MotorModel_locals_dict_table[] = {
+static const mp_rom_map_elem_t pb_type_MotorModel_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_state),    MP_ROM_PTR(&pb_type_MotorModel_state_obj) },
     { MP_ROM_QSTR(MP_QSTR_settings), MP_ROM_PTR(&pb_type_MotorModel_settings_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_type_MotorModel_locals_dict, pb_type_MotorModel_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pb_type_MotorModel_locals_dict, pb_type_MotorModel_locals_dict_table);
 
 // type(pybricks.common.MotorModel)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_MotorModel,

--- a/pybricks/common/pb_type_speaker.c
+++ b/pybricks/common/pb_type_speaker.c
@@ -43,9 +43,9 @@ typedef struct {
     uint16_t sample_attenuator;
 } pb_type_Speaker_obj_t;
 
-STATIC uint16_t waveform_data[128];
+static uint16_t waveform_data[128];
 
-STATIC mp_obj_t pb_type_Speaker_volume(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Speaker_volume(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Speaker_obj_t, self,
         PB_ARG_DEFAULT_NONE(volume));
@@ -61,9 +61,9 @@ STATIC mp_obj_t pb_type_Speaker_volume(size_t n_args, const mp_obj_t *pos_args, 
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Speaker_volume_obj, 1, pb_type_Speaker_volume);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Speaker_volume_obj, 1, pb_type_Speaker_volume);
 
-STATIC void pb_type_Speaker_generate_square_wave(uint16_t sample_attenuator) {
+static void pb_type_Speaker_generate_square_wave(uint16_t sample_attenuator) {
     uint16_t lo_amplitude_value = INT16_MAX - sample_attenuator;
     uint16_t hi_amplitude_value = sample_attenuator + INT16_MAX;
 
@@ -77,13 +77,13 @@ STATIC void pb_type_Speaker_generate_square_wave(uint16_t sample_attenuator) {
 }
 
 // For 0 frequencies that are just flat lines.
-STATIC void pb_type_Speaker_generate_line_wave(void) {
+static void pb_type_Speaker_generate_line_wave(void) {
     for (size_t i = 0; i < MP_ARRAY_SIZE(waveform_data); i++) {
         waveform_data[i] = INT16_MAX;
     }
 }
 
-STATIC void pb_type_Speaker_start_beep(uint32_t frequency, uint16_t sample_attenuator) {
+static void pb_type_Speaker_start_beep(uint32_t frequency, uint16_t sample_attenuator) {
     // TODO: allow other wave shapes - sine, triangle, sawtooth
     // TODO: don't recreate waveform if it hasn't changed shape or volume
 
@@ -103,11 +103,11 @@ STATIC void pb_type_Speaker_start_beep(uint32_t frequency, uint16_t sample_atten
     pbdrv_sound_start(&waveform_data[0], MP_ARRAY_SIZE(waveform_data), frequency * MP_ARRAY_SIZE(waveform_data));
 }
 
-STATIC void pb_type_Speaker_stop_beep(void) {
+static void pb_type_Speaker_stop_beep(void) {
     pbdrv_sound_stop();
 }
 
-STATIC mp_obj_t pb_type_Speaker_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pb_type_Speaker_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
 
     pb_type_Speaker_obj_t *self = mp_obj_malloc(pb_type_Speaker_obj_t, type);
 
@@ -123,7 +123,7 @@ STATIC mp_obj_t pb_type_Speaker_make_new(const mp_obj_type_t *type, size_t n_arg
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC bool pb_type_Speaker_beep_test_completion(mp_obj_t self_in, uint32_t end_time) {
+static bool pb_type_Speaker_beep_test_completion(mp_obj_t self_in, uint32_t end_time) {
     pb_type_Speaker_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (mp_hal_ticks_ms() - self->beep_end_time < (uint32_t)INT32_MAX) {
         pb_type_Speaker_stop_beep();
@@ -132,7 +132,7 @@ STATIC bool pb_type_Speaker_beep_test_completion(mp_obj_t self_in, uint32_t end_
     return false;
 }
 
-STATIC void pb_type_Speaker_cancel(mp_obj_t self_in) {
+static void pb_type_Speaker_cancel(mp_obj_t self_in) {
     pb_type_Speaker_stop_beep();
     pb_type_Speaker_obj_t *self = MP_OBJ_TO_PTR(self_in);
     self->beep_end_time = mp_hal_ticks_ms();
@@ -140,7 +140,7 @@ STATIC void pb_type_Speaker_cancel(mp_obj_t self_in) {
     self->notes_generator = MP_OBJ_NULL;
 }
 
-STATIC mp_obj_t pb_type_Speaker_beep(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Speaker_beep(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Speaker_obj_t, self,
         PB_ARG_DEFAULT_INT(frequency, 500),
@@ -168,9 +168,9 @@ STATIC mp_obj_t pb_type_Speaker_beep(size_t n_args, const mp_obj_t *pos_args, mp
         pb_type_Speaker_cancel,
         PB_TYPE_AWAITABLE_OPT_CANCEL_ALL);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Speaker_beep_obj, 1, pb_type_Speaker_beep);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Speaker_beep_obj, 1, pb_type_Speaker_beep);
 
-STATIC void pb_type_Speaker_play_note(pb_type_Speaker_obj_t *self, mp_obj_t obj, int duration) {
+static void pb_type_Speaker_play_note(pb_type_Speaker_obj_t *self, mp_obj_t obj, int duration) {
     const char *note = mp_obj_str_get_str(obj);
     int pos = 0;
     mp_float_t freq;
@@ -337,7 +337,7 @@ STATIC void pb_type_Speaker_play_note(pb_type_Speaker_obj_t *self, mp_obj_t obj,
     self->beep_end_time = release ? time_now + 7 * duration / 8 : time_now + duration;
 }
 
-STATIC bool pb_type_Speaker_notes_test_completion(mp_obj_t self_in, uint32_t end_time) {
+static bool pb_type_Speaker_notes_test_completion(mp_obj_t self_in, uint32_t end_time) {
     pb_type_Speaker_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     bool release_done = mp_hal_ticks_ms() - self->release_end_time < (uint32_t)INT32_MAX;
@@ -365,7 +365,7 @@ STATIC bool pb_type_Speaker_notes_test_completion(mp_obj_t self_in, uint32_t end
     return false;
 }
 
-STATIC mp_obj_t pb_type_Speaker_play_notes(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Speaker_play_notes(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Speaker_obj_t, self,
         PB_ARG_REQUIRED(notes),
@@ -384,14 +384,14 @@ STATIC mp_obj_t pb_type_Speaker_play_notes(size_t n_args, const mp_obj_t *pos_ar
         pb_type_Speaker_cancel,
         PB_TYPE_AWAITABLE_OPT_CANCEL_ALL);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Speaker_play_notes_obj, 1, pb_type_Speaker_play_notes);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Speaker_play_notes_obj, 1, pb_type_Speaker_play_notes);
 
-STATIC const mp_rom_map_elem_t pb_type_Speaker_locals_dict_table[] = {
+static const mp_rom_map_elem_t pb_type_Speaker_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_volume), MP_ROM_PTR(&pb_type_Speaker_volume_obj) },
     { MP_ROM_QSTR(MP_QSTR_beep), MP_ROM_PTR(&pb_type_Speaker_beep_obj) },
     { MP_ROM_QSTR(MP_QSTR_play_notes), MP_ROM_PTR(&pb_type_Speaker_play_notes_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_type_Speaker_locals_dict, pb_type_Speaker_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pb_type_Speaker_locals_dict, pb_type_Speaker_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_Speaker,
     MP_QSTR_Speaker,

--- a/pybricks/common/pb_type_system.c
+++ b/pybricks/common/pb_type_system.c
@@ -19,21 +19,21 @@
 #include <pybricks/util_mp/pb_kwarg_helper.h>
 #include <pybricks/util_mp/pb_obj_helper.h>
 
-STATIC mp_obj_t pb_type_System_name(void) {
+static mp_obj_t pb_type_System_name(void) {
     const char *hub_name = pbdrv_bluetooth_get_hub_name();
     return mp_obj_new_str(hub_name, strlen(hub_name));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(pb_type_System_name_obj, pb_type_System_name);
+static MP_DEFINE_CONST_FUN_OBJ_0(pb_type_System_name_obj, pb_type_System_name);
 
 #if PBDRV_CONFIG_RESET
 
 #include <pbdrv/reset.h>
 
-STATIC mp_obj_t pb_type_System_reset_reason(void) {
+static mp_obj_t pb_type_System_reset_reason(void) {
     pbdrv_reset_reason_t reason = pbdrv_reset_get_reason();
     return MP_OBJ_NEW_SMALL_INT(reason);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(pb_type_System_reset_reason_obj, pb_type_System_reset_reason);
+static MP_DEFINE_CONST_FUN_OBJ_0(pb_type_System_reset_reason_obj, pb_type_System_reset_reason);
 
 #endif // PBDRV_CONFIG_RESET
 
@@ -44,7 +44,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(pb_type_System_reset_reason_obj, pb_type_System
 
 #include <pybricks/parameters.h>
 
-STATIC mp_obj_t pb_type_System_set_stop_button(mp_obj_t buttons_in) {
+static mp_obj_t pb_type_System_set_stop_button(mp_obj_t buttons_in) {
     pbio_button_flags_t buttons = 0;
 
     if (mp_obj_is_true(buttons_in)) {
@@ -75,9 +75,9 @@ STATIC mp_obj_t pb_type_System_set_stop_button(mp_obj_t buttons_in) {
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_System_set_stop_button_obj, pb_type_System_set_stop_button);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_type_System_set_stop_button_obj, pb_type_System_set_stop_button);
 
-STATIC mp_obj_t pb_type_System_shutdown(void) {
+static mp_obj_t pb_type_System_shutdown(void) {
 
     // Start shutdown.
     pbsys_status_set(PBIO_PYBRICKS_STATUS_SHUTDOWN_REQUEST);
@@ -89,9 +89,9 @@ STATIC mp_obj_t pb_type_System_shutdown(void) {
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(pb_type_System_shutdown_obj, pb_type_System_shutdown);
+static MP_DEFINE_CONST_FUN_OBJ_0(pb_type_System_shutdown_obj, pb_type_System_shutdown);
 
-STATIC mp_obj_t pb_type_System_storage(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_System_storage(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_FUNCTION(n_args, pos_args, kw_args,
         PB_ARG_REQUIRED(offset),
         PB_ARG_DEFAULT_NONE(read),
@@ -120,12 +120,12 @@ STATIC mp_obj_t pb_type_System_storage(size_t n_args, const mp_obj_t *pos_args, 
 
     mp_raise_TypeError(MP_ERROR_TEXT("Must set either read (int) or write (bytes)."));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_System_storage_obj, 0, pb_type_System_storage);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_System_storage_obj, 0, pb_type_System_storage);
 
 #endif // PBIO_CONFIG_ENABLE_SYS
 
 // dir(pybricks.common.System)
-STATIC const mp_rom_map_elem_t common_System_locals_dict_table[] = {
+static const mp_rom_map_elem_t common_System_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_name), MP_ROM_PTR(&pb_type_System_name_obj) },
     #if PBDRV_CONFIG_RESET
     { MP_ROM_QSTR(MP_QSTR_reset_reason), MP_ROM_PTR(&pb_type_System_reset_reason_obj) },
@@ -136,7 +136,7 @@ STATIC const mp_rom_map_elem_t common_System_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_storage), MP_ROM_PTR(&pb_type_System_storage_obj) },
     #endif
 };
-STATIC MP_DEFINE_CONST_DICT(common_System_locals_dict, common_System_locals_dict_table);
+static MP_DEFINE_CONST_DICT(common_System_locals_dict, common_System_locals_dict_table);
 
 // type(pybricks.common.System) but implemented as module for reduced build size.
 // REVISIT: Make implementation consistent across modules/singletons: https://github.com/pybricks/support/issues/840

--- a/pybricks/ev3devices/pb_module_ev3devices.c
+++ b/pybricks/ev3devices/pb_module_ev3devices.c
@@ -8,7 +8,7 @@
 #include <pybricks/common.h>
 #include <pybricks/ev3devices.h>
 
-STATIC const mp_rom_map_elem_t ev3devices_globals_table[] = {
+static const mp_rom_map_elem_t ev3devices_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),         MP_ROM_QSTR(MP_QSTR_ev3devices)              },
     #if PYBRICKS_PY_COMMON_MOTORS
     { MP_ROM_QSTR(MP_QSTR_Motor),            MP_ROM_PTR(&pb_type_Motor)                   },
@@ -19,7 +19,7 @@ STATIC const mp_rom_map_elem_t ev3devices_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_UltrasonicSensor), MP_ROM_PTR(&pb_type_ev3devices_UltrasonicSensor)},
     { MP_ROM_QSTR(MP_QSTR_GyroSensor),       MP_ROM_PTR(&pb_type_ev3devices_GyroSensor)      },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_module_ev3devices_globals, ev3devices_globals_table);
+static MP_DEFINE_CONST_DICT(pb_module_ev3devices_globals, ev3devices_globals_table);
 
 const mp_obj_module_t pb_module_ev3devices = {
     .base = { &mp_type_module },

--- a/pybricks/ev3devices/pb_type_ev3devices_colorsensor.c
+++ b/pybricks/ev3devices/pb_type_ev3devices_colorsensor.c
@@ -19,7 +19,7 @@ typedef struct _ev3devices_ColorSensor_obj_t {
 } ev3devices_ColorSensor_obj_t;
 
 // pybricks.ev3devices.ColorSensor.__init__
-STATIC mp_obj_t ev3devices_ColorSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t ev3devices_ColorSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
     ev3devices_ColorSensor_obj_t *self = mp_obj_malloc(ev3devices_ColorSensor_obj_t, type);
@@ -28,7 +28,7 @@ STATIC mp_obj_t ev3devices_ColorSensor_make_new(const mp_obj_type_t *type, size_
 }
 
 // pybricks.ev3devices.ColorSensor.color
-STATIC mp_obj_t get_color(mp_obj_t self_in) {
+static mp_obj_t get_color(mp_obj_t self_in) {
     int8_t *color = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_EV3_COLOR_SENSOR__COLOR);
     switch (color[0]) {
         case 1:
@@ -49,24 +49,24 @@ STATIC mp_obj_t get_color(mp_obj_t self_in) {
             return mp_const_none;
     }
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_color_obj, PBDRV_LEGODEV_MODE_EV3_COLOR_SENSOR__COLOR, get_color);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_color_obj, PBDRV_LEGODEV_MODE_EV3_COLOR_SENSOR__COLOR, get_color);
 
 // pybricks.ev3devices.ColorSensor.ambient
-STATIC mp_obj_t get_ambient(mp_obj_t self_in) {
+static mp_obj_t get_ambient(mp_obj_t self_in) {
     int8_t *ambient = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_EV3_COLOR_SENSOR__AMBIENT);
     return mp_obj_new_int(ambient[0]);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_ambient_obj, PBDRV_LEGODEV_MODE_EV3_COLOR_SENSOR__AMBIENT, get_ambient);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_ambient_obj, PBDRV_LEGODEV_MODE_EV3_COLOR_SENSOR__AMBIENT, get_ambient);
 
 // pybricks.ev3devices.ColorSensor.reflection
-STATIC mp_obj_t get_reflection(mp_obj_t self_in) {
+static mp_obj_t get_reflection(mp_obj_t self_in) {
     int8_t *reflection = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_EV3_COLOR_SENSOR__REFLECT);
     return mp_obj_new_int(reflection[0]);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_reflection_obj, PBDRV_LEGODEV_MODE_EV3_COLOR_SENSOR__REFLECT, get_reflection);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_reflection_obj, PBDRV_LEGODEV_MODE_EV3_COLOR_SENSOR__REFLECT, get_reflection);
 
 // pybricks.ev3devices.ColorSensor.rgb
-STATIC mp_obj_t get_rgb(mp_obj_t self_in) {
+static mp_obj_t get_rgb(mp_obj_t self_in) {
     int16_t *rgb = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_EV3_COLOR_SENSOR__RGB_RAW);
     mp_obj_t tup[3];
 
@@ -81,16 +81,16 @@ STATIC mp_obj_t get_rgb(mp_obj_t self_in) {
     }
     return mp_obj_new_tuple(3, tup);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_rgb_obj, PBDRV_LEGODEV_MODE_EV3_COLOR_SENSOR__RGB_RAW, get_rgb);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_rgb_obj, PBDRV_LEGODEV_MODE_EV3_COLOR_SENSOR__RGB_RAW, get_rgb);
 
 // dir(pybricks.ev3devices.ColorSensor)
-STATIC const mp_rom_map_elem_t ev3devices_ColorSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t ev3devices_ColorSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_reflection), MP_ROM_PTR(&get_reflection_obj) },
     { MP_ROM_QSTR(MP_QSTR_ambient), MP_ROM_PTR(&get_ambient_obj) },
     { MP_ROM_QSTR(MP_QSTR_color), MP_ROM_PTR(&get_color_obj) },
     { MP_ROM_QSTR(MP_QSTR_rgb), MP_ROM_PTR(&get_rgb_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(ev3devices_ColorSensor_locals_dict, ev3devices_ColorSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(ev3devices_ColorSensor_locals_dict, ev3devices_ColorSensor_locals_dict_table);
 
 // type(pybricks.ev3devices.ColorSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_ev3devices_ColorSensor,

--- a/pybricks/ev3devices/pb_type_ev3devices_gyrosensor.c
+++ b/pybricks/ev3devices/pb_type_ev3devices_gyrosensor.c
@@ -21,7 +21,7 @@ typedef struct _ev3devices_GyroSensor_obj_t {
 } ev3devices_GyroSensor_obj_t;
 
 // pybricks.ev3devices.GyroSensor (internal) Get new offset  for new reset angle
-STATIC mp_int_t ev3devices_GyroSensor_get_angle_offset(mp_obj_t self_in, pbio_direction_t direction, mp_int_t new_angle) {
+static mp_int_t ev3devices_GyroSensor_get_angle_offset(mp_obj_t self_in, pbio_direction_t direction, mp_int_t new_angle) {
     // Read raw sensor values
     int32_t raw_angle = *(int16_t *)pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_EV3_GYRO_SENSOR__ANG);
 
@@ -34,7 +34,7 @@ STATIC mp_int_t ev3devices_GyroSensor_get_angle_offset(mp_obj_t self_in, pbio_di
 }
 
 // pybricks.ev3devices.GyroSensor.__init__
-STATIC mp_obj_t ev3devices_GyroSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t ev3devices_GyroSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port),
         PB_ARG_DEFAULT_OBJ(direction, pb_Direction_CLOCKWISE_obj));
@@ -49,7 +49,7 @@ STATIC mp_obj_t ev3devices_GyroSensor_make_new(const mp_obj_type_t *type, size_t
 }
 
 // pybricks.ev3devices.GyroSensor.speed
-STATIC mp_obj_t ev3devices_GyroSensor_speed(mp_obj_t self_in) {
+static mp_obj_t ev3devices_GyroSensor_speed(mp_obj_t self_in) {
     ev3devices_GyroSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     int32_t raw_speed = *(int16_t *)pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_EV3_GYRO_SENSOR__RATE);
 
@@ -62,10 +62,10 @@ STATIC mp_obj_t ev3devices_GyroSensor_speed(mp_obj_t self_in) {
         return mp_obj_new_int(-raw_speed);
     }
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(ev3devices_GyroSensor_speed_obj, ev3devices_GyroSensor_speed);
+static MP_DEFINE_CONST_FUN_OBJ_1(ev3devices_GyroSensor_speed_obj, ev3devices_GyroSensor_speed);
 
 // pybricks.ev3devices.GyroSensor.angle
-STATIC mp_obj_t ev3devices_GyroSensor_angle(mp_obj_t self_in) {
+static mp_obj_t ev3devices_GyroSensor_angle(mp_obj_t self_in) {
     ev3devices_GyroSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     int32_t raw_angle = *(int16_t *)pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_EV3_GYRO_SENSOR__ANG);
 
@@ -75,10 +75,10 @@ STATIC mp_obj_t ev3devices_GyroSensor_angle(mp_obj_t self_in) {
         return mp_obj_new_int(-raw_angle - self->offset);
     }
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(ev3devices_GyroSensor_angle_obj, ev3devices_GyroSensor_angle);
+static MP_DEFINE_CONST_FUN_OBJ_1(ev3devices_GyroSensor_angle_obj, ev3devices_GyroSensor_angle);
 
 // pybricks.ev3devices.GyroSensor.reset_angle
-STATIC mp_obj_t ev3devices_GyroSensor_reset_angle(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3devices_GyroSensor_reset_angle(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3devices_GyroSensor_obj_t, self,
         PB_ARG_REQUIRED(angle));
@@ -86,15 +86,15 @@ STATIC mp_obj_t ev3devices_GyroSensor_reset_angle(size_t n_args, const mp_obj_t 
     self->offset = ev3devices_GyroSensor_get_angle_offset(MP_OBJ_FROM_PTR(self), self->direction, pb_obj_get_int(angle_in));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3devices_GyroSensor_reset_angle_obj, 1, ev3devices_GyroSensor_reset_angle);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3devices_GyroSensor_reset_angle_obj, 1, ev3devices_GyroSensor_reset_angle);
 
 // dir(pybricks.ev3devices.GyroSensor)
-STATIC const mp_rom_map_elem_t ev3devices_GyroSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t ev3devices_GyroSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_angle),       MP_ROM_PTR(&ev3devices_GyroSensor_angle_obj)       },
     { MP_ROM_QSTR(MP_QSTR_speed),       MP_ROM_PTR(&ev3devices_GyroSensor_speed_obj)       },
     { MP_ROM_QSTR(MP_QSTR_reset_angle), MP_ROM_PTR(&ev3devices_GyroSensor_reset_angle_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(ev3devices_GyroSensor_locals_dict, ev3devices_GyroSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(ev3devices_GyroSensor_locals_dict, ev3devices_GyroSensor_locals_dict_table);
 
 // type(pybricks.ev3devices.GyroSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_ev3devices_GyroSensor,

--- a/pybricks/ev3devices/pb_type_ev3devices_infraredsensor.c
+++ b/pybricks/ev3devices/pb_type_ev3devices_infraredsensor.c
@@ -20,7 +20,7 @@ typedef struct _ev3devices_InfraredSensor_obj_t {
 } ev3devices_InfraredSensor_obj_t;
 
 // pybricks.ev3devices.InfraredSensor.__init__
-STATIC mp_obj_t ev3devices_InfraredSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t ev3devices_InfraredSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -30,14 +30,14 @@ STATIC mp_obj_t ev3devices_InfraredSensor_make_new(const mp_obj_type_t *type, si
 }
 
 // pybricks.ev3devices.InfraredSensor.distance
-STATIC mp_obj_t ev3devices_InfraredSensor_distance(mp_obj_t self_in) {
+static mp_obj_t ev3devices_InfraredSensor_distance(mp_obj_t self_in) {
     int8_t *distance = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_EV3_INFRARED_SENSOR__PROX);
     return mp_obj_new_int(distance[0]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(ev3devices_InfraredSensor_distance_obj, ev3devices_InfraredSensor_distance);
+static MP_DEFINE_CONST_FUN_OBJ_1(ev3devices_InfraredSensor_distance_obj, ev3devices_InfraredSensor_distance);
 
 // pybricks.ev3devices.InfraredSensor.beacon
-STATIC mp_obj_t ev3devices_InfraredSensor_beacon(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3devices_InfraredSensor_beacon(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3devices_InfraredSensor_obj_t, self,
@@ -65,10 +65,10 @@ STATIC mp_obj_t ev3devices_InfraredSensor_beacon(size_t n_args, const mp_obj_t *
 
     return mp_obj_new_tuple(2, ret);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3devices_InfraredSensor_beacon_obj, 1, ev3devices_InfraredSensor_beacon);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3devices_InfraredSensor_beacon_obj, 1, ev3devices_InfraredSensor_beacon);
 
 // pybricks.ev3devices.InfraredSensor.buttons
-STATIC mp_obj_t ev3devices_InfraredSensor_buttons(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3devices_InfraredSensor_buttons(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3devices_InfraredSensor_obj_t, self,
@@ -134,10 +134,10 @@ STATIC mp_obj_t ev3devices_InfraredSensor_buttons(size_t n_args, const mp_obj_t 
 
     return mp_obj_new_list(len, pressed);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3devices_InfraredSensor_buttons_obj, 1, ev3devices_InfraredSensor_buttons);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3devices_InfraredSensor_buttons_obj, 1, ev3devices_InfraredSensor_buttons);
 
 // pybricks.ev3devices.InfraredSensor.keypad
-STATIC mp_obj_t ev3devices_InfraredSensor_keypad(mp_obj_t self_in) {
+static mp_obj_t ev3devices_InfraredSensor_keypad(mp_obj_t self_in) {
 
     int16_t keypad_data = *(int16_t *)pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_EV3_INFRARED_SENSOR__REM_A);
 
@@ -163,16 +163,16 @@ STATIC mp_obj_t ev3devices_InfraredSensor_keypad(mp_obj_t self_in) {
 
     return mp_obj_new_list(len, pressed);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(ev3devices_InfraredSensor_keypad_obj, ev3devices_InfraredSensor_keypad);
+static MP_DEFINE_CONST_FUN_OBJ_1(ev3devices_InfraredSensor_keypad_obj, ev3devices_InfraredSensor_keypad);
 
 // dir(pybricks.ev3devices.InfraredSensor)
-STATIC const mp_rom_map_elem_t ev3devices_InfraredSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t ev3devices_InfraredSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_distance), MP_ROM_PTR(&ev3devices_InfraredSensor_distance_obj) },
     { MP_ROM_QSTR(MP_QSTR_beacon),   MP_ROM_PTR(&ev3devices_InfraredSensor_beacon_obj) },
     { MP_ROM_QSTR(MP_QSTR_buttons),  MP_ROM_PTR(&ev3devices_InfraredSensor_buttons_obj) },
     { MP_ROM_QSTR(MP_QSTR_keypad),   MP_ROM_PTR(&ev3devices_InfraredSensor_keypad_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(ev3devices_InfraredSensor_locals_dict, ev3devices_InfraredSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(ev3devices_InfraredSensor_locals_dict, ev3devices_InfraredSensor_locals_dict_table);
 
 // type(pybricks.ev3devices.InfraredSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_ev3devices_InfraredSensor,

--- a/pybricks/ev3devices/pb_type_ev3devices_touchsensor.c
+++ b/pybricks/ev3devices/pb_type_ev3devices_touchsensor.c
@@ -20,7 +20,7 @@ typedef struct _ev3devices_TouchSensor_obj_t {
 } ev3devices_TouchSensor_obj_t;
 
 // pybricks.ev3devices.TouchSensor.__init__
-STATIC mp_obj_t ev3devices_TouchSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t ev3devices_TouchSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -30,18 +30,18 @@ STATIC mp_obj_t ev3devices_TouchSensor_make_new(const mp_obj_type_t *type, size_
 }
 
 // pybricks.ev3devices.TouchSensor.pressed
-STATIC mp_obj_t ev3devices_TouchSensor_pressed(mp_obj_t self_in) {
+static mp_obj_t ev3devices_TouchSensor_pressed(mp_obj_t self_in) {
     int32_t *analog = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_EV3_TOUCH_SENSOR__TOUCH);
     return mp_obj_new_bool(analog[0] > 250);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(ev3devices_TouchSensor_pressed_obj, ev3devices_TouchSensor_pressed);
+static MP_DEFINE_CONST_FUN_OBJ_1(ev3devices_TouchSensor_pressed_obj, ev3devices_TouchSensor_pressed);
 
 
 // dir(pybricks.ev3devices.TouchSensor)
-STATIC const mp_rom_map_elem_t ev3devices_TouchSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t ev3devices_TouchSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_pressed), MP_ROM_PTR(&ev3devices_TouchSensor_pressed_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(ev3devices_TouchSensor_locals_dict, ev3devices_TouchSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(ev3devices_TouchSensor_locals_dict, ev3devices_TouchSensor_locals_dict_table);
 
 // type(pybricks.ev3devices.TouchSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_ev3devices_TouchSensor,

--- a/pybricks/ev3devices/pb_type_ev3devices_ultrasonicsensor.c
+++ b/pybricks/ev3devices/pb_type_ev3devices_ultrasonicsensor.c
@@ -20,7 +20,7 @@ typedef struct _ev3devices_UltrasonicSensor_obj_t {
 
 
 // pybricks.ev3devices.UltrasonicSensor.__init__
-STATIC mp_obj_t ev3devices_UltrasonicSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t ev3devices_UltrasonicSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -30,7 +30,7 @@ STATIC mp_obj_t ev3devices_UltrasonicSensor_make_new(const mp_obj_type_t *type, 
 }
 
 // pybricks.ev3devices.UltrasonicSensor.distance
-STATIC mp_obj_t ev3devices_UltrasonicSensor_distance(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t ev3devices_UltrasonicSensor_distance(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         ev3devices_UltrasonicSensor_obj_t, self,
@@ -40,21 +40,21 @@ STATIC mp_obj_t ev3devices_UltrasonicSensor_distance(size_t n_args, const mp_obj
     int16_t *distance = pb_type_device_get_data_blocking(MP_OBJ_FROM_PTR(self), mode);
     return mp_obj_new_int(distance[0]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ev3devices_UltrasonicSensor_distance_obj, 1, ev3devices_UltrasonicSensor_distance);
+static MP_DEFINE_CONST_FUN_OBJ_KW(ev3devices_UltrasonicSensor_distance_obj, 1, ev3devices_UltrasonicSensor_distance);
 
 // pybricks.ev3devices.UltrasonicSensor.presence
-STATIC mp_obj_t ev3devices_UltrasonicSensor_presence(mp_obj_t self_in) {
+static mp_obj_t ev3devices_UltrasonicSensor_presence(mp_obj_t self_in) {
     int8_t *presence = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_EV3_ULTRASONIC_SENSOR__LISTEN);
     return mp_obj_new_bool(presence[0]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(ev3devices_UltrasonicSensor_presence_obj, ev3devices_UltrasonicSensor_presence);
+static MP_DEFINE_CONST_FUN_OBJ_1(ev3devices_UltrasonicSensor_presence_obj, ev3devices_UltrasonicSensor_presence);
 
 // dir(pybricks.ev3devices.UltrasonicSensor)
-STATIC const mp_rom_map_elem_t ev3devices_UltrasonicSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t ev3devices_UltrasonicSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_distance), MP_ROM_PTR(&ev3devices_UltrasonicSensor_distance_obj) },
     { MP_ROM_QSTR(MP_QSTR_presence), MP_ROM_PTR(&ev3devices_UltrasonicSensor_presence_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(ev3devices_UltrasonicSensor_locals_dict, ev3devices_UltrasonicSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(ev3devices_UltrasonicSensor_locals_dict, ev3devices_UltrasonicSensor_locals_dict_table);
 
 // type(pybricks.ev3devices.UltrasonicSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_ev3devices_UltrasonicSensor,

--- a/pybricks/experimental/pb_module_experimental.c
+++ b/pybricks/experimental/pb_module_experimental.c
@@ -29,11 +29,11 @@
 
 #include "py/mpthread.h"
 
-STATIC void sighandler(int signum) {
+static void sighandler(int signum) {
     // we just want the signal to interrupt system calls
 }
 
-STATIC mp_obj_t mod_experimental___init__(void) {
+static mp_obj_t mod_experimental___init__(void) {
     struct sigaction sa;
     sa.sa_flags = 0;
     sa.sa_handler = sighandler;
@@ -42,20 +42,20 @@ STATIC mp_obj_t mod_experimental___init__(void) {
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_experimental___init___obj, mod_experimental___init__);
+static MP_DEFINE_CONST_FUN_OBJ_0(mod_experimental___init___obj, mod_experimental___init__);
 
-STATIC mp_obj_t mod_experimental_pthread_raise(mp_obj_t thread_id_in, mp_obj_t ex_in) {
+static mp_obj_t mod_experimental_pthread_raise(mp_obj_t thread_id_in, mp_obj_t ex_in) {
     mp_uint_t thread_id = mp_obj_int_get_truncated(thread_id_in);
     if (ex_in != mp_const_none && !mp_obj_is_exception_instance(ex_in)) {
         mp_raise_TypeError(MP_ERROR_TEXT("must be an exception or None"));
     }
     return mp_obj_new_int(mp_thread_schedule_exception(thread_id, ex_in));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_experimental_pthread_raise_obj, mod_experimental_pthread_raise);
+static MP_DEFINE_CONST_FUN_OBJ_2(mod_experimental_pthread_raise_obj, mod_experimental_pthread_raise);
 #endif // PYBRICKS_HUB_EV3BRICK
 
 // pybricks.experimental.hello_world
-STATIC mp_obj_t experimental_hello_world(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t experimental_hello_world(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_FUNCTION(n_args, pos_args, kw_args,
         // Add up to 8 arguments below, all separated by one comma.
         // You can choose from:
@@ -90,9 +90,9 @@ STATIC mp_obj_t experimental_hello_world(size_t n_args, const mp_obj_t *pos_args
     return mp_obj_new_int(foo * foo);
 }
 // See also experimental_globals_table below. This function object is added there to make it importable.
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(experimental_hello_world_obj, 0, experimental_hello_world);
+static MP_DEFINE_CONST_FUN_OBJ_KW(experimental_hello_world_obj, 0, experimental_hello_world);
 
-STATIC const mp_rom_map_elem_t experimental_globals_table[] = {
+static const mp_rom_map_elem_t experimental_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_experimental) },
     #if PYBRICKS_HUB_EV3BRICK
     { MP_ROM_QSTR(MP_QSTR___init__), MP_ROM_PTR(&mod_experimental___init___obj) },
@@ -100,7 +100,7 @@ STATIC const mp_rom_map_elem_t experimental_globals_table[] = {
     #endif // PYBRICKS_HUB_EV3BRICK
     { MP_ROM_QSTR(MP_QSTR_hello_world), MP_ROM_PTR(&experimental_hello_world_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_module_experimental_globals, experimental_globals_table);
+static MP_DEFINE_CONST_DICT(pb_module_experimental_globals, experimental_globals_table);
 
 const mp_obj_module_t pb_module_experimental = {
     .base = { &mp_type_module },

--- a/pybricks/hubs/pb_module_hubs.c
+++ b/pybricks/hubs/pb_module_hubs.c
@@ -11,7 +11,7 @@
 #include <pbdrv/config.h>
 #include <pybricks/hubs.h>
 
-STATIC const mp_rom_map_elem_t hubs_globals_table[] = {
+static const mp_rom_map_elem_t hubs_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),              MP_ROM_QSTR(MP_QSTR_hubs)    },
     { MP_ROM_QSTR(MP_QSTR_ThisHub),               MP_ROM_PTR(&pb_type_ThisHub) },
     { MP_ROM_QSTR(PYBRICKS_HUB_CLASS_NAME),       MP_ROM_PTR(&pb_type_ThisHub) },
@@ -19,7 +19,7 @@ STATIC const mp_rom_map_elem_t hubs_globals_table[] = {
     { MP_ROM_QSTR(PYBRICKS_HUB_CLASS_NAME_ALIAS), MP_ROM_PTR(&pb_type_ThisHub) },
     #endif
 };
-STATIC MP_DEFINE_CONST_DICT(pb_module_hubs_globals, hubs_globals_table);
+static MP_DEFINE_CONST_DICT(pb_module_hubs_globals, hubs_globals_table);
 
 const mp_obj_module_t pb_module_hubs = {
     .base = { &mp_type_module },

--- a/pybricks/hubs/pb_type_cityhub.c
+++ b/pybricks/hubs/pb_type_cityhub.c
@@ -25,7 +25,7 @@ typedef struct _hubs_CityHub_obj_t {
     mp_obj_t system;
 } hubs_CityHub_obj_t;
 
-STATIC mp_obj_t hubs_CityHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t hubs_CityHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     #if PYBRICKS_PY_COMMON_BLE
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_DEFAULT_INT(broadcast_channel, 0),
@@ -43,7 +43,7 @@ STATIC mp_obj_t hubs_CityHub_make_new(const mp_obj_type_t *type, size_t n_args, 
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC const pb_attr_dict_entry_t hubs_CityHub_attr_dict[] = {
+static const pb_attr_dict_entry_t hubs_CityHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_CityHub_obj_t, battery),
     #if PYBRICKS_PY_COMMON_BLE
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_ble, hubs_CityHub_obj_t, ble),

--- a/pybricks/hubs/pb_type_essentialhub.c
+++ b/pybricks/hubs/pb_type_essentialhub.c
@@ -37,7 +37,7 @@ typedef struct _hubs_EssentialHub_obj_t {
     mp_obj_t system;
 } hubs_EssentialHub_obj_t;
 
-STATIC mp_obj_t hubs_EssentialHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t hubs_EssentialHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_DEFAULT_OBJ(top_side, pb_type_Axis_Z_obj),
         PB_ARG_DEFAULT_OBJ(front_side, pb_type_Axis_X_obj)
@@ -60,7 +60,7 @@ STATIC mp_obj_t hubs_EssentialHub_make_new(const mp_obj_type_t *type, size_t n_a
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC const pb_attr_dict_entry_t hubs_EssentialHub_attr_dict[] = {
+static const pb_attr_dict_entry_t hubs_EssentialHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_EssentialHub_obj_t, battery),
     #if PYBRICKS_PY_COMMON_BLE
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_ble, hubs_EssentialHub_obj_t, ble),

--- a/pybricks/hubs/pb_type_ev3brick.c
+++ b/pybricks/hubs/pb_type_ev3brick.c
@@ -28,7 +28,7 @@ typedef struct _hubs_EV3Brick_obj_t {
     mp_obj_t system;
 } hubs_EV3Brick_obj_t;
 
-STATIC mp_obj_t pb_type_ev3brick_button_pressed(void) {
+static mp_obj_t pb_type_ev3brick_button_pressed(void) {
     pbio_button_flags_t flags;
     pb_assert(pbio_button_is_pressed(&flags));
     mp_obj_t pressed[5];
@@ -51,7 +51,7 @@ STATIC mp_obj_t pb_type_ev3brick_button_pressed(void) {
     return mp_obj_new_set(num, pressed);
 }
 
-STATIC mp_obj_t hubs_EV3Brick_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t hubs_EV3Brick_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     hubs_EV3Brick_obj_t *self = mp_obj_malloc(hubs_EV3Brick_obj_t, type);
 
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
@@ -67,7 +67,7 @@ STATIC mp_obj_t hubs_EV3Brick_make_new(const mp_obj_type_t *type, size_t n_args,
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC const pb_attr_dict_entry_t hubs_EV3Brick_attr_dict[] = {
+static const pb_attr_dict_entry_t hubs_EV3Brick_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_EV3Brick_obj_t, battery),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_buttons, hubs_EV3Brick_obj_t, buttons),
     #if PYBRICKS_RUNS_ON_EV3DEV

--- a/pybricks/hubs/pb_type_movehub.c
+++ b/pybricks/hubs/pb_type_movehub.c
@@ -151,7 +151,7 @@ typedef struct {
 } hubs_MoveHub_IMU_obj_t;
 
 // This is an integer version of pybricks._common.IMU.up
-STATIC mp_obj_t hubs_MoveHub_IMU_up(mp_obj_t self_in) {
+static mp_obj_t hubs_MoveHub_IMU_up(mp_obj_t self_in) {
 
     int8_t values[3];
     motion_get_acceleration_raw(values);
@@ -193,7 +193,7 @@ STATIC mp_obj_t hubs_MoveHub_IMU_up(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(hubs_MoveHub_IMU_up_obj, hubs_MoveHub_IMU_up);
 
-STATIC mp_obj_t hubs_MoveHub_IMU_acceleration(mp_obj_t self_in) {
+static mp_obj_t hubs_MoveHub_IMU_acceleration(mp_obj_t self_in) {
 
     hubs_MoveHub_IMU_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -208,10 +208,10 @@ STATIC mp_obj_t hubs_MoveHub_IMU_acceleration(mp_obj_t self_in) {
     }
     return mp_obj_new_tuple(3, values);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(hubs_MoveHub_IMU_acceleration_obj, hubs_MoveHub_IMU_acceleration);
+static MP_DEFINE_CONST_FUN_OBJ_1(hubs_MoveHub_IMU_acceleration_obj, hubs_MoveHub_IMU_acceleration);
 
 // pybricks._common.SimpleAccelerometer.tilt
-STATIC mp_obj_t hubs_MoveHub_IMU_tilt(mp_obj_t self_in) {
+static mp_obj_t hubs_MoveHub_IMU_tilt(mp_obj_t self_in) {
 
     hubs_MoveHub_IMU_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -233,19 +233,19 @@ STATIC mp_obj_t hubs_MoveHub_IMU_tilt(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(hubs_MoveHub_IMU_tilt_obj, hubs_MoveHub_IMU_tilt);
 
-STATIC const mp_rom_map_elem_t hubs_MoveHub_IMU_locals_dict_table[] = {
+static const mp_rom_map_elem_t hubs_MoveHub_IMU_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_acceleration), MP_ROM_PTR(&hubs_MoveHub_IMU_acceleration_obj) },
     { MP_ROM_QSTR(MP_QSTR_up),           MP_ROM_PTR(&hubs_MoveHub_IMU_up_obj)           },
     { MP_ROM_QSTR(MP_QSTR_tilt),         MP_ROM_PTR(&hubs_MoveHub_IMU_tilt_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(hubs_MoveHub_IMU_locals_dict, hubs_MoveHub_IMU_locals_dict_table);
+static MP_DEFINE_CONST_DICT(hubs_MoveHub_IMU_locals_dict, hubs_MoveHub_IMU_locals_dict_table);
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(hubs_MoveHub_IMU_type,
+static MP_DEFINE_CONST_OBJ_TYPE(hubs_MoveHub_IMU_type,
     MP_QSTRnull,
     MP_TYPE_FLAG_NONE,
     locals_dict, &hubs_MoveHub_IMU_locals_dict);
 
-STATIC mp_obj_t hubs_MoveHub_IMU_make_new(mp_obj_t top_side_in, mp_obj_t front_side_in) {
+static mp_obj_t hubs_MoveHub_IMU_make_new(mp_obj_t top_side_in, mp_obj_t front_side_in) {
     hubs_MoveHub_IMU_obj_t *self = mp_obj_malloc(hubs_MoveHub_IMU_obj_t, &hubs_MoveHub_IMU_type);
 
     // Save base orientation.
@@ -314,7 +314,7 @@ typedef struct _hubs_MoveHub_obj_t {
 } hubs_MoveHub_obj_t;
 
 
-STATIC mp_obj_t hubs_MoveHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t hubs_MoveHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_DEFAULT_INT(top_side, pb_type_Axis_Z_int_enum),
         PB_ARG_DEFAULT_INT(front_side, pb_type_Axis_X_int_enum)
@@ -336,7 +336,7 @@ STATIC mp_obj_t hubs_MoveHub_make_new(const mp_obj_type_t *type, size_t n_args, 
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC const pb_attr_dict_entry_t hubs_MoveHub_attr_dict[] = {
+static const pb_attr_dict_entry_t hubs_MoveHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_MoveHub_obj_t, battery),
     #if PYBRICKS_PY_COMMON_BLE
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_ble, hubs_MoveHub_obj_t, ble),

--- a/pybricks/hubs/pb_type_nxtbrick.c
+++ b/pybricks/hubs/pb_type_nxtbrick.c
@@ -25,7 +25,7 @@ typedef struct _hubs_NXTBrick_obj_t {
     mp_obj_t system;
 } hubs_NXTBrick_obj_t;
 
-STATIC mp_obj_t pb_type_nxtbrick_button_pressed(void) {
+static mp_obj_t pb_type_nxtbrick_button_pressed(void) {
     pbio_button_flags_t flags;
     pb_assert(pbio_button_is_pressed(&flags));
     mp_obj_t pressed[4];
@@ -45,7 +45,7 @@ STATIC mp_obj_t pb_type_nxtbrick_button_pressed(void) {
     return mp_obj_new_set(num, pressed);
 }
 
-STATIC mp_obj_t hubs_NXTBrick_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t hubs_NXTBrick_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     hubs_NXTBrick_obj_t *self = mp_obj_malloc(hubs_NXTBrick_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
     self->buttons = pb_type_Keypad_obj_new(pb_type_nxtbrick_button_pressed);
@@ -54,7 +54,7 @@ STATIC mp_obj_t hubs_NXTBrick_make_new(const mp_obj_type_t *type, size_t n_args,
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC const pb_attr_dict_entry_t hubs_NXTBrick_attr_dict[] = {
+static const pb_attr_dict_entry_t hubs_NXTBrick_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_NXTBrick_obj_t, battery),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_buttons, hubs_NXTBrick_obj_t, buttons),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_speaker, hubs_NXTBrick_obj_t, speaker),

--- a/pybricks/hubs/pb_type_primehub.c
+++ b/pybricks/hubs/pb_type_primehub.c
@@ -41,7 +41,7 @@ typedef struct _hubs_PrimeHub_obj_t {
     mp_obj_t system;
 } hubs_PrimeHub_obj_t;
 
-STATIC mp_obj_t pb_type_primehub_button_pressed(void) {
+static mp_obj_t pb_type_primehub_button_pressed(void) {
     pbio_button_flags_t flags;
     pb_assert(pbio_button_is_pressed(&flags));
     mp_obj_t pressed[4];
@@ -61,7 +61,7 @@ STATIC mp_obj_t pb_type_primehub_button_pressed(void) {
     return mp_obj_new_set(num, pressed);
 }
 
-STATIC mp_obj_t hubs_PrimeHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t hubs_PrimeHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_DEFAULT_OBJ(top_side, pb_type_Axis_Z_obj),
         PB_ARG_DEFAULT_OBJ(front_side, pb_type_Axis_X_obj)
@@ -86,7 +86,7 @@ STATIC mp_obj_t hubs_PrimeHub_make_new(const mp_obj_type_t *type, size_t n_args,
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC const pb_attr_dict_entry_t hubs_PrimeHub_attr_dict[] = {
+static const pb_attr_dict_entry_t hubs_PrimeHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_PrimeHub_obj_t, battery),
     #if PYBRICKS_PY_COMMON_BLE
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_ble, hubs_PrimeHub_obj_t, ble),

--- a/pybricks/hubs/pb_type_technichub.c
+++ b/pybricks/hubs/pb_type_technichub.c
@@ -27,7 +27,7 @@ typedef struct _hubs_TechnicHub_obj_t {
     mp_obj_t system;
 } hubs_TechnicHub_obj_t;
 
-STATIC mp_obj_t hubs_TechnicHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t hubs_TechnicHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_DEFAULT_OBJ(top_side, pb_type_Axis_Z_obj),
         PB_ARG_DEFAULT_OBJ(front_side, pb_type_Axis_X_obj)
@@ -49,7 +49,7 @@ STATIC mp_obj_t hubs_TechnicHub_make_new(const mp_obj_type_t *type, size_t n_arg
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC const pb_attr_dict_entry_t hubs_TechnicHub_attr_dict[] = {
+static const pb_attr_dict_entry_t hubs_TechnicHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_TechnicHub_obj_t, battery),
     #if PYBRICKS_PY_COMMON_BLE
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_ble, hubs_TechnicHub_obj_t, ble),

--- a/pybricks/hubs/pb_type_virtualhub.c
+++ b/pybricks/hubs/pb_type_virtualhub.c
@@ -26,7 +26,7 @@ typedef struct _hubs_VirtualHub_obj_t {
     mp_obj_t system;
 } hubs_VirtualHub_obj_t;
 
-STATIC mp_obj_t hubs_VirtualHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t hubs_VirtualHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     hubs_VirtualHub_obj_t *self = mp_obj_malloc(hubs_VirtualHub_obj_t, type);
     self->battery = MP_OBJ_FROM_PTR(&pb_module_battery);
     self->buttons = pb_type_Keypad_obj_new(pb_type_button_pressed_hub_single_button);
@@ -36,7 +36,7 @@ STATIC mp_obj_t hubs_VirtualHub_make_new(const mp_obj_type_t *type, size_t n_arg
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC const pb_attr_dict_entry_t hubs_VirtualHub_attr_dict[] = {
+static const pb_attr_dict_entry_t hubs_VirtualHub_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_battery, hubs_VirtualHub_obj_t, battery),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_buttons, hubs_VirtualHub_obj_t, buttons),
     // PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, hubs_VirtualHub_obj_t, light),

--- a/pybricks/iodevices/pb_module_iodevices.c
+++ b/pybricks/iodevices/pb_module_iodevices.c
@@ -8,7 +8,7 @@
 #include <pybricks/common.h>
 #include <pybricks/iodevices.h>
 
-STATIC const mp_rom_map_elem_t iodevices_globals_table[] = {
+static const mp_rom_map_elem_t iodevices_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),         MP_ROM_QSTR(MP_QSTR_iodevices)                },
     #if PYBRICKS_PY_PUPDEVICES
     { MP_ROM_QSTR(MP_QSTR_PUPDevice),        MP_ROM_PTR(&pb_type_iodevices_PUPDevice)      },
@@ -30,7 +30,7 @@ STATIC const mp_rom_map_elem_t iodevices_globals_table[] = {
     #endif
     #endif // PYBRICKS_PY_EV3DEVICES
 };
-STATIC MP_DEFINE_CONST_DICT(pb_module_iodevices_globals, iodevices_globals_table);
+static MP_DEFINE_CONST_DICT(pb_module_iodevices_globals, iodevices_globals_table);
 
 const mp_obj_module_t pb_module_iodevices = {
     .base = { &mp_type_module },

--- a/pybricks/iodevices/pb_type_iodevices_analogsensor.c
+++ b/pybricks/iodevices/pb_type_iodevices_analogsensor.c
@@ -25,7 +25,7 @@ typedef struct _iodevices_AnalogSensor_obj_t {
 } iodevices_AnalogSensor_obj_t;
 
 // pybricks.iodevices.AnalogSensor.__init__
-STATIC mp_obj_t iodevices_AnalogSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t iodevices_AnalogSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -39,16 +39,16 @@ STATIC mp_obj_t iodevices_AnalogSensor_make_new(const mp_obj_type_t *type, size_
 }
 
 // pybricks.iodevices.AnalogSensor.voltage
-STATIC mp_obj_t iodevices_AnalogSensor_voltage(mp_obj_t self_in) {
+static mp_obj_t iodevices_AnalogSensor_voltage(mp_obj_t self_in) {
     iodevices_AnalogSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint8_t mode = self->active ? PBDRV_LEGODEV_MODE_NXT_ANALOG__ACTIVE : PBDRV_LEGODEV_MODE_NXT_ANALOG__PASSIVE;
     int32_t *voltage = pb_type_device_get_data_blocking(self_in, mode);
     return mp_obj_new_int(voltage[0]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(iodevices_AnalogSensor_voltage_obj, iodevices_AnalogSensor_voltage);
+static MP_DEFINE_CONST_FUN_OBJ_1(iodevices_AnalogSensor_voltage_obj, iodevices_AnalogSensor_voltage);
 
 // pybricks.iodevices.AnalogSensor.resistance
-STATIC mp_obj_t iodevices_AnalogSensor_resistance(mp_obj_t self_in) {
+static mp_obj_t iodevices_AnalogSensor_resistance(mp_obj_t self_in) {
     iodevices_AnalogSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint8_t mode = self->active ? PBDRV_LEGODEV_MODE_NXT_ANALOG__ACTIVE : PBDRV_LEGODEV_MODE_NXT_ANALOG__PASSIVE;
     int32_t voltage = *(int32_t *)pb_type_device_get_data_blocking(self_in, mode);
@@ -61,34 +61,34 @@ STATIC mp_obj_t iodevices_AnalogSensor_resistance(mp_obj_t self_in) {
     // Return as if a pure voltage divider between load and 10K internal resistor
     return mp_obj_new_int((10000 * voltage) / (vmax - voltage));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(iodevices_AnalogSensor_resistance_obj, iodevices_AnalogSensor_resistance);
+static MP_DEFINE_CONST_FUN_OBJ_1(iodevices_AnalogSensor_resistance_obj, iodevices_AnalogSensor_resistance);
 
 // pybricks.iodevices.AnalogSensor.active
-STATIC mp_obj_t iodevices_AnalogSensor_active(mp_obj_t self_in) {
+static mp_obj_t iodevices_AnalogSensor_active(mp_obj_t self_in) {
     iodevices_AnalogSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_ANALOG__ACTIVE);
     self->active = true;
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(iodevices_AnalogSensor_active_obj, iodevices_AnalogSensor_active);
+static MP_DEFINE_CONST_FUN_OBJ_1(iodevices_AnalogSensor_active_obj, iodevices_AnalogSensor_active);
 
 // pybricks.iodevices.AnalogSensor.passive
-STATIC mp_obj_t iodevices_AnalogSensor_passive(mp_obj_t self_in) {
+static mp_obj_t iodevices_AnalogSensor_passive(mp_obj_t self_in) {
     iodevices_AnalogSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_ANALOG__PASSIVE);
     self->active = false;
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(iodevices_AnalogSensor_passive_obj, iodevices_AnalogSensor_passive);
+static MP_DEFINE_CONST_FUN_OBJ_1(iodevices_AnalogSensor_passive_obj, iodevices_AnalogSensor_passive);
 
 // dir(pybricks.iodevices.AnalogSensor)
-STATIC const mp_rom_map_elem_t iodevices_AnalogSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t iodevices_AnalogSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_voltage),    MP_ROM_PTR(&iodevices_AnalogSensor_voltage_obj)    },
     { MP_ROM_QSTR(MP_QSTR_resistance), MP_ROM_PTR(&iodevices_AnalogSensor_resistance_obj) },
     { MP_ROM_QSTR(MP_QSTR_active),     MP_ROM_PTR(&iodevices_AnalogSensor_active_obj)    },
     { MP_ROM_QSTR(MP_QSTR_passive),    MP_ROM_PTR(&iodevices_AnalogSensor_passive_obj)    },
 };
-STATIC MP_DEFINE_CONST_DICT(iodevices_AnalogSensor_locals_dict, iodevices_AnalogSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(iodevices_AnalogSensor_locals_dict, iodevices_AnalogSensor_locals_dict_table);
 
 // type(pybricks.iodevices.AnalogSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_iodevices_AnalogSensor,

--- a/pybricks/iodevices/pb_type_iodevices_ev3devsensor.c
+++ b/pybricks/iodevices/pb_type_iodevices_ev3devsensor.c
@@ -27,7 +27,7 @@ typedef struct _iodevices_Ev3devSensor_obj_t {
 } iodevices_Ev3devSensor_obj_t;
 
 // pybricks.iodevices.Ev3devSensor.__init__
-STATIC mp_obj_t iodevices_Ev3devSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t iodevices_Ev3devSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -47,7 +47,7 @@ STATIC mp_obj_t iodevices_Ev3devSensor_make_new(const mp_obj_type_t *type, size_
 }
 
 // pybricks.iodevices.Ev3devSensor.read
-STATIC mp_obj_t iodevices_Ev3devSensor_read(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t iodevices_Ev3devSensor_read(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         iodevices_Ev3devSensor_obj_t, self,
         PB_ARG_REQUIRED(mode));
@@ -92,17 +92,17 @@ STATIC mp_obj_t iodevices_Ev3devSensor_read(size_t n_args, const mp_obj_t *pos_a
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_Ev3devSensor_read_obj, 1, iodevices_Ev3devSensor_read);
 
-STATIC const pb_attr_dict_entry_t iodevices_Ev3devSensor_attr_dict[] = {
+static const pb_attr_dict_entry_t iodevices_Ev3devSensor_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_sensor_index, iodevices_Ev3devSensor_obj_t, sensor_index),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_port_index, iodevices_Ev3devSensor_obj_t, port_index),
     PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.iodevices.Ev3devSensor)
-STATIC const mp_rom_map_elem_t iodevices_Ev3devSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t iodevices_Ev3devSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_read),         MP_ROM_PTR(&iodevices_Ev3devSensor_read_obj)                        },
 };
-STATIC MP_DEFINE_CONST_DICT(iodevices_Ev3devSensor_locals_dict, iodevices_Ev3devSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(iodevices_Ev3devSensor_locals_dict, iodevices_Ev3devSensor_locals_dict_table);
 
 // type(pybricks.iodevices.Ev3devSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_iodevices_Ev3devSensor,

--- a/pybricks/iodevices/pb_type_iodevices_i2cdevice.c
+++ b/pybricks/iodevices/pb_type_iodevices_i2cdevice.c
@@ -27,7 +27,7 @@ typedef struct _iodevices_I2CDevice_obj_t {
 } iodevices_I2CDevice_obj_t;
 
 // pybricks.iodevices.I2CDevice.__init__
-STATIC mp_obj_t iodevices_I2CDevice_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t iodevices_I2CDevice_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port),
         PB_ARG_REQUIRED(address));
@@ -51,7 +51,7 @@ STATIC mp_obj_t iodevices_I2CDevice_make_new(const mp_obj_type_t *type, size_t n
 }
 
 // pybricks.iodevices.I2CDevice.read
-STATIC mp_obj_t iodevices_I2CDevice_read(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t iodevices_I2CDevice_read(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         iodevices_I2CDevice_obj_t, self,
@@ -95,10 +95,10 @@ STATIC mp_obj_t iodevices_I2CDevice_read(size_t n_args, const mp_obj_t *pos_args
 
     return mp_obj_new_bytes(buf, length);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_I2CDevice_read_obj, 1, iodevices_I2CDevice_read);
+static MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_I2CDevice_read_obj, 1, iodevices_I2CDevice_read);
 
 // pybricks.iodevices.I2CDevice.write
-STATIC mp_obj_t iodevices_I2CDevice_write(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t iodevices_I2CDevice_write(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         iodevices_I2CDevice_obj_t, self,
@@ -146,14 +146,14 @@ STATIC mp_obj_t iodevices_I2CDevice_write(size_t n_args, const mp_obj_t *pos_arg
     pb_assert(pb_smbus_write_bytes(self->bus, self->address, reg, data_len, data));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_I2CDevice_write_obj, 1, iodevices_I2CDevice_write);
+static MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_I2CDevice_write_obj, 1, iodevices_I2CDevice_write);
 
 // dir(pybricks.iodevices.I2CDevice)
-STATIC const mp_rom_map_elem_t iodevices_I2CDevice_locals_dict_table[] = {
+static const mp_rom_map_elem_t iodevices_I2CDevice_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_read),    MP_ROM_PTR(&iodevices_I2CDevice_read_obj)    },
     { MP_ROM_QSTR(MP_QSTR_write),   MP_ROM_PTR(&iodevices_I2CDevice_write_obj)    },
 };
-STATIC MP_DEFINE_CONST_DICT(iodevices_I2CDevice_locals_dict, iodevices_I2CDevice_locals_dict_table);
+static MP_DEFINE_CONST_DICT(iodevices_I2CDevice_locals_dict, iodevices_I2CDevice_locals_dict_table);
 
 // type(pybricks.iodevices.I2CDevice)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_iodevices_I2CDevice,

--- a/pybricks/iodevices/pb_type_iodevices_lwp3device.c
+++ b/pybricks/iodevices/pb_type_iodevices_lwp3device.c
@@ -101,10 +101,10 @@ typedef struct {
     char name[LWP3_MAX_HUB_PROPERTY_NAME_SIZE + 1];
 } pb_lwp3device_t;
 
-STATIC pb_lwp3device_t pb_lwp3device_singleton;
+static pb_lwp3device_t pb_lwp3device_singleton;
 
 // Handles LEGO Wireless protocol messages from the LWP3 Device.
-STATIC pbio_pybricks_error_t handle_notification(pbdrv_bluetooth_connection_t connection, const uint8_t *value, uint32_t size) {
+static pbio_pybricks_error_t handle_notification(pbdrv_bluetooth_connection_t connection, const uint8_t *value, uint32_t size) {
     pb_lwp3device_t *lwp3device = &pb_lwp3device_singleton;
 
     #if PYBRICKS_PY_IODEVICES
@@ -136,7 +136,7 @@ STATIC pbio_pybricks_error_t handle_notification(pbdrv_bluetooth_connection_t co
     return PBIO_PYBRICKS_ERROR_OK;
 }
 
-STATIC pbdrv_bluetooth_ad_match_result_flags_t lwp3_advertisement_matches(uint8_t event_type, const uint8_t *data, const char *name, const uint8_t *addr, const uint8_t *match_addr) {
+static pbdrv_bluetooth_ad_match_result_flags_t lwp3_advertisement_matches(uint8_t event_type, const uint8_t *data, const char *name, const uint8_t *addr, const uint8_t *match_addr) {
     pbdrv_bluetooth_ad_match_result_flags_t flags = PBDRV_BLUETOOTH_AD_MATCH_NONE;
 
     // Whether this looks like a LWP3 advertisement of the correct hub kind.
@@ -156,7 +156,7 @@ STATIC pbdrv_bluetooth_ad_match_result_flags_t lwp3_advertisement_matches(uint8_
     return flags;
 }
 
-STATIC pbdrv_bluetooth_ad_match_result_flags_t lwp3_advertisement_response_matches(uint8_t event_type, const uint8_t *data, const char *name, const uint8_t *addr, const uint8_t *match_addr) {
+static pbdrv_bluetooth_ad_match_result_flags_t lwp3_advertisement_response_matches(uint8_t event_type, const uint8_t *data, const char *name, const uint8_t *addr, const uint8_t *match_addr) {
 
     pb_lwp3device_t *lwp3device = &pb_lwp3device_singleton;
 
@@ -180,13 +180,13 @@ STATIC pbdrv_bluetooth_ad_match_result_flags_t lwp3_advertisement_response_match
     return flags;
 }
 
-STATIC void pb_lwp3device_assert_connected(void) {
+static void pb_lwp3device_assert_connected(void) {
     if (!pbdrv_bluetooth_is_connected(PBDRV_BLUETOOTH_CONNECTION_PERIPHERAL)) {
         mp_raise_OSError(MP_ENODEV);
     }
 }
 
-STATIC void pb_lwp3device_connect(const char *name, mp_int_t timeout, lwp3_hub_kind_t hub_kind) {
+static void pb_lwp3device_connect(const char *name, mp_int_t timeout, lwp3_hub_kind_t hub_kind) {
     pb_lwp3device_t *lwp3device = &pb_lwp3device_singleton;
 
     // REVISIT: for now, we only allow a single connection to a LWP3 device.
@@ -224,7 +224,7 @@ STATIC void pb_lwp3device_connect(const char *name, mp_int_t timeout, lwp3_hub_k
     pb_module_tools_pbio_task_do_blocking(&lwp3device->task, timeout);
 }
 
-STATIC mp_obj_t pb_type_pupdevices_Remote_light_on(void *context, const pbio_color_hsv_t *hsv) {
+static mp_obj_t pb_type_pupdevices_Remote_light_on(void *context, const pbio_color_hsv_t *hsv) {
     pb_lwp3device_t *lwp3device = &pb_lwp3device_singleton;
 
     pb_lwp3device_assert_connected();
@@ -263,7 +263,7 @@ STATIC mp_obj_t pb_type_pupdevices_Remote_light_on(void *context, const pbio_col
     return pb_module_tools_pbio_task_wait_or_await(&lwp3device->task);
 }
 
-STATIC void pb_lwp3device_configure_remote(void) {
+static void pb_lwp3device_configure_remote(void) {
 
     pb_lwp3device_t *remote = &pb_lwp3device_singleton;
 
@@ -375,7 +375,7 @@ typedef struct _pb_type_pupdevices_Remote_obj_t {
     mp_obj_t light;
 } pb_type_pupdevices_Remote_obj_t;
 
-STATIC mp_obj_t pb_type_pupdevices_Remote_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pb_type_pupdevices_Remote_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_DEFAULT_NONE(name),
         PB_ARG_DEFAULT_INT(timeout, 10000));
@@ -398,7 +398,7 @@ STATIC mp_obj_t pb_type_pupdevices_Remote_make_new(const mp_obj_type_t *type, si
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC mp_obj_t pb_lwp3device_name(size_t n_args, const mp_obj_t *args) {
+static mp_obj_t pb_lwp3device_name(size_t n_args, const mp_obj_t *args) {
     pb_lwp3device_t *lwp3device = &pb_lwp3device_singleton;
 
     pb_lwp3device_assert_connected();
@@ -442,27 +442,27 @@ STATIC mp_obj_t pb_lwp3device_name(size_t n_args, const mp_obj_t *args) {
 
     return mp_obj_new_str(lwp3device->name, strlen(lwp3device->name));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pb_lwp3device_name_obj, 1, 2, pb_lwp3device_name);
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pb_lwp3device_name_obj, 1, 2, pb_lwp3device_name);
 
-STATIC mp_obj_t pb_lwp3device_disconnect(mp_obj_t self_in) {
+static mp_obj_t pb_lwp3device_disconnect(mp_obj_t self_in) {
     pb_lwp3device_t *lwp3device = &pb_lwp3device_singleton;
     pb_lwp3device_assert_connected();
     pbdrv_bluetooth_peripheral_disconnect(&lwp3device->task);
     return pb_module_tools_pbio_task_wait_or_await(&lwp3device->task);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_lwp3device_disconnect_obj, pb_lwp3device_disconnect);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_lwp3device_disconnect_obj, pb_lwp3device_disconnect);
 
-STATIC const pb_attr_dict_entry_t pb_type_pupdevices_Remote_attr_dict[] = {
+static const pb_attr_dict_entry_t pb_type_pupdevices_Remote_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_buttons, pb_type_pupdevices_Remote_obj_t, buttons),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, pb_type_pupdevices_Remote_obj_t, light),
     PB_ATTR_DICT_SENTINEL
 };
 
-STATIC const mp_rom_map_elem_t pb_type_pupdevices_Remote_locals_dict_table[] = {
+static const mp_rom_map_elem_t pb_type_pupdevices_Remote_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_disconnect), MP_ROM_PTR(&pb_lwp3device_disconnect_obj) },
     { MP_ROM_QSTR(MP_QSTR_name), MP_ROM_PTR(&pb_lwp3device_name_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_type_pupdevices_Remote_locals_dict, pb_type_pupdevices_Remote_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pb_type_pupdevices_Remote_locals_dict, pb_type_pupdevices_Remote_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_pupdevices_Remote,
     MP_QSTR_Remote,
@@ -474,7 +474,7 @@ MP_DEFINE_CONST_OBJ_TYPE(pb_type_pupdevices_Remote,
 
 #if PYBRICKS_PY_IODEVICES
 
-STATIC mp_obj_t pb_type_iodevices_LWP3Device_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pb_type_iodevices_LWP3Device_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(hub_kind),
         PB_ARG_DEFAULT_NONE(name),
@@ -490,7 +490,7 @@ STATIC mp_obj_t pb_type_iodevices_LWP3Device_make_new(const mp_obj_type_t *type,
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC mp_obj_t lwp3device_write(mp_obj_t self_in, mp_obj_t buf_in) {
+static mp_obj_t lwp3device_write(mp_obj_t self_in, mp_obj_t buf_in) {
     pb_lwp3device_t *lwp3device = &pb_lwp3device_singleton;
 
     pb_lwp3device_assert_connected();
@@ -517,9 +517,9 @@ STATIC mp_obj_t lwp3device_write(mp_obj_t self_in, mp_obj_t buf_in) {
     pbdrv_bluetooth_peripheral_write(&lwp3device->task, &msg.value);
     return pb_module_tools_pbio_task_wait_or_await(&lwp3device->task);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(lwp3device_write_obj, lwp3device_write);
+static MP_DEFINE_CONST_FUN_OBJ_2(lwp3device_write_obj, lwp3device_write);
 
-STATIC mp_obj_t lwp3device_read(mp_obj_t self_in) {
+static mp_obj_t lwp3device_read(mp_obj_t self_in) {
     pb_lwp3device_t *lwp3device = &pb_lwp3device_singleton;
 
     // wait until a notification is received
@@ -542,15 +542,15 @@ STATIC mp_obj_t lwp3device_read(mp_obj_t self_in) {
 
     return mp_obj_new_bytes(lwp3device->buffer, len);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(lwp3device_read_obj, lwp3device_read);
+static MP_DEFINE_CONST_FUN_OBJ_1(lwp3device_read_obj, lwp3device_read);
 
-STATIC const mp_rom_map_elem_t pb_type_iodevices_LWP3Device_locals_dict_table[] = {
+static const mp_rom_map_elem_t pb_type_iodevices_LWP3Device_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_disconnect), MP_ROM_PTR(&pb_lwp3device_disconnect_obj) },
     { MP_ROM_QSTR(MP_QSTR_name), MP_ROM_PTR(&pb_lwp3device_name_obj) },
     { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&lwp3device_write_obj) },
     { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&lwp3device_read_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_type_iodevices_LWP3Device_locals_dict, pb_type_iodevices_LWP3Device_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pb_type_iodevices_LWP3Device_locals_dict, pb_type_iodevices_LWP3Device_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_iodevices_LWP3Device,
     MP_QSTR_LWP3Device,

--- a/pybricks/iodevices/pb_type_iodevices_pupdevice.c
+++ b/pybricks/iodevices/pb_type_iodevices_pupdevice.c
@@ -40,7 +40,7 @@ typedef struct _iodevices_PUPDevice_obj_t {
  * @param [in]  port_in     The port.
  * @return                  True if passive device, false otherwise.
  */
-STATIC bool init_passive_pup_device(iodevices_PUPDevice_obj_t *self, mp_obj_t port_in) {
+static bool init_passive_pup_device(iodevices_PUPDevice_obj_t *self, mp_obj_t port_in) {
     pb_module_tools_assert_blocking();
     pbio_port_id_t port = pb_type_enum_get_value(port_in, &pb_enum_type_Port);
     pbdrv_legodev_type_id_t candidates[] = {
@@ -57,7 +57,7 @@ STATIC bool init_passive_pup_device(iodevices_PUPDevice_obj_t *self, mp_obj_t po
 }
 
 // pybricks.iodevices.PUPDevice.__init__
-STATIC mp_obj_t iodevices_PUPDevice_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t iodevices_PUPDevice_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -75,7 +75,7 @@ STATIC mp_obj_t iodevices_PUPDevice_make_new(const mp_obj_type_t *type, size_t n
 }
 
 // pybricks.iodevices.PUPDevice.info
-STATIC mp_obj_t iodevices_PUPDevice_info(mp_obj_t self_in) {
+static mp_obj_t iodevices_PUPDevice_info(mp_obj_t self_in) {
     iodevices_PUPDevice_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     // Passive devices only have an ID.
@@ -109,7 +109,7 @@ STATIC mp_obj_t iodevices_PUPDevice_info(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(iodevices_PUPDevice_info_obj, iodevices_PUPDevice_info);
 
-STATIC mp_obj_t get_pup_data_tuple(mp_obj_t self_in) {
+static mp_obj_t get_pup_data_tuple(mp_obj_t self_in) {
     iodevices_PUPDevice_obj_t *self = MP_OBJ_TO_PTR(self_in);
     void *data = pb_type_device_get_data(self_in, self->last_mode);
 
@@ -143,7 +143,7 @@ STATIC mp_obj_t get_pup_data_tuple(mp_obj_t self_in) {
 }
 
 // pybricks.iodevices.PUPDevice.read
-STATIC mp_obj_t iodevices_PUPDevice_read(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t iodevices_PUPDevice_read(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         iodevices_PUPDevice_obj_t, self,
         PB_ARG_REQUIRED(mode));
@@ -170,7 +170,7 @@ STATIC mp_obj_t iodevices_PUPDevice_read(size_t n_args, const mp_obj_t *pos_args
 MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_PUPDevice_read_obj, 1, iodevices_PUPDevice_read);
 
 // pybricks.iodevices.PUPDevice.write
-STATIC mp_obj_t iodevices_PUPDevice_write(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t iodevices_PUPDevice_write(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         iodevices_PUPDevice_obj_t, self,
         PB_ARG_REQUIRED(mode),
@@ -252,12 +252,12 @@ STATIC mp_obj_t iodevices_PUPDevice_write(size_t n_args, const mp_obj_t *pos_arg
 MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_PUPDevice_write_obj, 1, iodevices_PUPDevice_write);
 
 // dir(pybricks.iodevices.PUPDevice)
-STATIC const mp_rom_map_elem_t iodevices_PUPDevice_locals_dict_table[] = {
+static const mp_rom_map_elem_t iodevices_PUPDevice_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_read),       MP_ROM_PTR(&iodevices_PUPDevice_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_write),      MP_ROM_PTR(&iodevices_PUPDevice_write_obj)},
     { MP_ROM_QSTR(MP_QSTR_info),       MP_ROM_PTR(&iodevices_PUPDevice_info_obj)},
 };
-STATIC MP_DEFINE_CONST_DICT(iodevices_PUPDevice_locals_dict, iodevices_PUPDevice_locals_dict_table);
+static MP_DEFINE_CONST_DICT(iodevices_PUPDevice_locals_dict, iodevices_PUPDevice_locals_dict_table);
 
 // type(pybricks.iodevices.PUPDevice)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_iodevices_PUPDevice,

--- a/pybricks/iodevices/pb_type_iodevices_uartdevice.c
+++ b/pybricks/iodevices/pb_type_iodevices_uartdevice.c
@@ -30,7 +30,7 @@ typedef struct _iodevices_UARTDevice_obj_t {
 } iodevices_UARTDevice_obj_t;
 
 // pybricks.iodevices.UARTDevice.__init__
-STATIC mp_obj_t iodevices_UARTDevice_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t iodevices_UARTDevice_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port),
         PB_ARG_REQUIRED(baudrate),
@@ -50,7 +50,7 @@ STATIC mp_obj_t iodevices_UARTDevice_make_new(const mp_obj_type_t *type, size_t 
 }
 
 // pybricks.iodevices.UARTDevice.write
-STATIC mp_obj_t iodevices_UARTDevice_write(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t iodevices_UARTDevice_write(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         iodevices_UARTDevice_obj_t, self,
@@ -69,19 +69,19 @@ STATIC mp_obj_t iodevices_UARTDevice_write(size_t n_args, const mp_obj_t *pos_ar
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_UARTDevice_write_obj, 1, iodevices_UARTDevice_write);
+static MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_UARTDevice_write_obj, 1, iodevices_UARTDevice_write);
 
 // pybricks.iodevices.UARTDevice.waiting
-STATIC mp_obj_t iodevices_UARTDevice_waiting(mp_obj_t self_in) {
+static mp_obj_t iodevices_UARTDevice_waiting(mp_obj_t self_in) {
     iodevices_UARTDevice_obj_t *self = MP_OBJ_TO_PTR(self_in);
     size_t waiting;
     pb_assert(pb_serial_in_waiting(self->serial, &waiting));
     return mp_obj_new_int(waiting);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(iodevices_UARTDevice_waiting_obj, iodevices_UARTDevice_waiting);
+static MP_DEFINE_CONST_FUN_OBJ_1(iodevices_UARTDevice_waiting_obj, iodevices_UARTDevice_waiting);
 
 // pybricks.iodevices.UARTDevice._read_internal
-STATIC mp_obj_t iodevices_UARTDevice_read_internal(iodevices_UARTDevice_obj_t *self, size_t len) {
+static mp_obj_t iodevices_UARTDevice_read_internal(iodevices_UARTDevice_obj_t *self, size_t len) {
 
     if (len > UART_MAX_LEN) {
         pb_assert(PBIO_ERROR_INVALID_ARG);
@@ -136,7 +136,7 @@ STATIC mp_obj_t iodevices_UARTDevice_read_internal(iodevices_UARTDevice_obj_t *s
 }
 
 // pybricks.iodevices.UARTDevice.read
-STATIC mp_obj_t iodevices_UARTDevice_read(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t iodevices_UARTDevice_read(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         iodevices_UARTDevice_obj_t, self,
@@ -145,10 +145,10 @@ STATIC mp_obj_t iodevices_UARTDevice_read(size_t n_args, const mp_obj_t *pos_arg
     size_t length = mp_obj_get_int(length_in);
     return iodevices_UARTDevice_read_internal(self, length);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_UARTDevice_read_obj, 1, iodevices_UARTDevice_read);
+static MP_DEFINE_CONST_FUN_OBJ_KW(iodevices_UARTDevice_read_obj, 1, iodevices_UARTDevice_read);
 
 // pybricks.iodevices.UARTDevice.read_all
-STATIC mp_obj_t iodevices_UARTDevice_read_all(mp_obj_t self_in) {
+static mp_obj_t iodevices_UARTDevice_read_all(mp_obj_t self_in) {
 
     iodevices_UARTDevice_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -157,25 +157,25 @@ STATIC mp_obj_t iodevices_UARTDevice_read_all(mp_obj_t self_in) {
 
     return iodevices_UARTDevice_read_internal(self, len);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(iodevices_UARTDevice_read_all_obj, iodevices_UARTDevice_read_all);
+static MP_DEFINE_CONST_FUN_OBJ_1(iodevices_UARTDevice_read_all_obj, iodevices_UARTDevice_read_all);
 
 // pybricks.iodevices.UARTDevice.clear
-STATIC mp_obj_t iodevices_UARTDevice_clear(mp_obj_t self_in) {
+static mp_obj_t iodevices_UARTDevice_clear(mp_obj_t self_in) {
     iodevices_UARTDevice_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pb_assert(pb_serial_clear(self->serial));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(iodevices_UARTDevice_clear_obj, iodevices_UARTDevice_clear);
+static MP_DEFINE_CONST_FUN_OBJ_1(iodevices_UARTDevice_clear_obj, iodevices_UARTDevice_clear);
 
 // dir(pybricks.iodevices.UARTDevice)
-STATIC const mp_rom_map_elem_t iodevices_UARTDevice_locals_dict_table[] = {
+static const mp_rom_map_elem_t iodevices_UARTDevice_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_read),  MP_ROM_PTR(&iodevices_UARTDevice_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_read_all),  MP_ROM_PTR(&iodevices_UARTDevice_read_all_obj) },
     { MP_ROM_QSTR(MP_QSTR_write),  MP_ROM_PTR(&iodevices_UARTDevice_write_obj) },
     { MP_ROM_QSTR(MP_QSTR_waiting), MP_ROM_PTR(&iodevices_UARTDevice_waiting_obj) },
     { MP_ROM_QSTR(MP_QSTR_clear), MP_ROM_PTR(&iodevices_UARTDevice_clear_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(iodevices_UARTDevice_locals_dict, iodevices_UARTDevice_locals_dict_table);
+static MP_DEFINE_CONST_DICT(iodevices_UARTDevice_locals_dict, iodevices_UARTDevice_locals_dict_table);
 
 // type(pybricks.iodevices.UARTDevice)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_iodevices_UARTDevice,

--- a/pybricks/iodevices/pb_type_iodevices_xbox_controller.c
+++ b/pybricks/iodevices/pb_type_iodevices_xbox_controller.c
@@ -82,10 +82,10 @@ typedef struct {
     xbox_input_map_t state;
 } pb_xbox_t;
 
-STATIC pb_xbox_t pb_xbox_singleton;
+static pb_xbox_t pb_xbox_singleton;
 
 // Handles LEGO Wireless protocol messages from the XBOX Device.
-STATIC pbio_pybricks_error_t handle_notification(pbdrv_bluetooth_connection_t connection, const uint8_t *value, uint32_t size) {
+static pbio_pybricks_error_t handle_notification(pbdrv_bluetooth_connection_t connection, const uint8_t *value, uint32_t size) {
     pb_xbox_t *xbox = &pb_xbox_singleton;
     if (size <= sizeof(xbox_input_map_t)) {
         memcpy(&xbox->state, &value[0], size);
@@ -95,7 +95,7 @@ STATIC pbio_pybricks_error_t handle_notification(pbdrv_bluetooth_connection_t co
 
 #define _16BIT_AS_LE(x) ((x) & 0xff), (((x) >> 8) & 0xff)
 
-STATIC pbdrv_bluetooth_ad_match_result_flags_t xbox_advertisement_matches(uint8_t event_type, const uint8_t *data, const char *name, const uint8_t *addr, const uint8_t *match_addr) {
+static pbdrv_bluetooth_ad_match_result_flags_t xbox_advertisement_matches(uint8_t event_type, const uint8_t *data, const char *name, const uint8_t *addr, const uint8_t *match_addr) {
 
     // The controller seems to advertise three different packets, so allow all.
 
@@ -146,7 +146,7 @@ STATIC pbdrv_bluetooth_ad_match_result_flags_t xbox_advertisement_matches(uint8_
     return flags;
 }
 
-STATIC pbdrv_bluetooth_ad_match_result_flags_t xbox_advertisement_response_matches(uint8_t event_type, const uint8_t *data, const char *name, const uint8_t *addr, const uint8_t *match_addr) {
+static pbdrv_bluetooth_ad_match_result_flags_t xbox_advertisement_response_matches(uint8_t event_type, const uint8_t *data, const char *name, const uint8_t *addr, const uint8_t *match_addr) {
 
     pbdrv_bluetooth_ad_match_result_flags_t flags = PBDRV_BLUETOOTH_AD_MATCH_NONE;
 
@@ -163,7 +163,7 @@ STATIC pbdrv_bluetooth_ad_match_result_flags_t xbox_advertisement_response_match
     return flags;
 }
 
-STATIC void pb_xbox_assert_connected(void) {
+static void pb_xbox_assert_connected(void) {
     if (!pbdrv_bluetooth_is_connected(PBDRV_BLUETOOTH_CONNECTION_PERIPHERAL)) {
         mp_raise_OSError(MP_ENODEV);
     }
@@ -187,13 +187,13 @@ static void pb_xbox_discover_and_read(pbdrv_bluetooth_peripheral_char_t *char_in
     pb_module_tools_pbio_task_do_blocking(&xbox->task, -1);
 }
 
-STATIC xbox_input_map_t *pb_xbox_get_buttons(void) {
+static xbox_input_map_t *pb_xbox_get_buttons(void) {
     xbox_input_map_t *buttons = &pb_xbox_singleton.state;
     pb_xbox_assert_connected();
     return buttons;
 }
 
-STATIC mp_obj_t pb_xbox_button_pressed(void) {
+static mp_obj_t pb_xbox_button_pressed(void) {
     xbox_input_map_t *buttons = pb_xbox_get_buttons();
 
     // At most 16 simultaneous button presses, plus up to two dpad directions.
@@ -276,7 +276,7 @@ STATIC mp_obj_t pb_xbox_button_pressed(void) {
     return mp_obj_new_set(count, items);
 }
 
-STATIC mp_obj_t pb_type_xbox_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pb_type_xbox_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
 
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_DEFAULT_INT(joystick_deadzone, 10)
@@ -383,14 +383,14 @@ STATIC mp_obj_t pb_type_xbox_make_new(const mp_obj_type_t *type, size_t n_args, 
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC mp_obj_t pb_xbox_name(size_t n_args, const mp_obj_t *args) {
+static mp_obj_t pb_xbox_name(size_t n_args, const mp_obj_t *args) {
     pb_xbox_assert_connected();
     const char *name = pbdrv_bluetooth_peripheral_get_name();
     return mp_obj_new_str(name, strlen(name));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pb_xbox_name_obj, 1, 2, pb_xbox_name);
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pb_xbox_name_obj, 1, 2, pb_xbox_name);
 
-STATIC mp_obj_t pb_xbox_state(mp_obj_t self_in) {
+static mp_obj_t pb_xbox_state(mp_obj_t self_in) {
 
     xbox_input_map_t *buttons = pb_xbox_get_buttons();
 
@@ -410,21 +410,21 @@ STATIC mp_obj_t pb_xbox_state(mp_obj_t self_in) {
     };
     return mp_obj_new_tuple(MP_ARRAY_SIZE(state), state);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_xbox_state_obj, pb_xbox_state);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_xbox_state_obj, pb_xbox_state);
 
-STATIC mp_obj_t pb_xbox_dpad(mp_obj_t self_in) {
+static mp_obj_t pb_xbox_dpad(mp_obj_t self_in) {
     xbox_input_map_t *buttons = pb_xbox_get_buttons();
     return mp_obj_new_int(buttons->dpad);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_xbox_dpad_obj, pb_xbox_dpad);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_xbox_dpad_obj, pb_xbox_dpad);
 
-STATIC mp_obj_t pb_xbox_profile(mp_obj_t self_in) {
+static mp_obj_t pb_xbox_profile(mp_obj_t self_in) {
     xbox_input_map_t *buttons = pb_xbox_get_buttons();
     return mp_obj_new_int(buttons->profile);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_xbox_profile_obj, pb_xbox_profile);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_xbox_profile_obj, pb_xbox_profile);
 
-STATIC mp_obj_t pb_xbox_joystick(mp_obj_t self_in, uint16_t x_raw, uint16_t y_raw) {
+static mp_obj_t pb_xbox_joystick(mp_obj_t self_in, uint16_t x_raw, uint16_t y_raw) {
     pb_type_xbox_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     mp_int_t x = (x_raw - INT16_MAX) * 100 / INT16_MAX;
@@ -444,19 +444,19 @@ STATIC mp_obj_t pb_xbox_joystick(mp_obj_t self_in, uint16_t x_raw, uint16_t y_ra
     return mp_obj_new_tuple(MP_ARRAY_SIZE(directions), directions);
 }
 
-STATIC mp_obj_t pb_xbox_joystick_left(mp_obj_t self_in) {
+static mp_obj_t pb_xbox_joystick_left(mp_obj_t self_in) {
     xbox_input_map_t *buttons = pb_xbox_get_buttons();
     return pb_xbox_joystick(self_in, buttons->x, buttons->y);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_xbox_joystick_left_obj, pb_xbox_joystick_left);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_xbox_joystick_left_obj, pb_xbox_joystick_left);
 
-STATIC mp_obj_t pb_xbox_joystick_right(mp_obj_t self_in) {
+static mp_obj_t pb_xbox_joystick_right(mp_obj_t self_in) {
     xbox_input_map_t *buttons = pb_xbox_get_buttons();
     return pb_xbox_joystick(self_in, buttons->z, buttons->rz);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_xbox_joystick_right_obj, pb_xbox_joystick_right);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_xbox_joystick_right_obj, pb_xbox_joystick_right);
 
-STATIC mp_obj_t pb_xbox_triggers(mp_obj_t self_in) {
+static mp_obj_t pb_xbox_triggers(mp_obj_t self_in) {
     xbox_input_map_t *buttons = pb_xbox_get_buttons();
     mp_obj_t tiggers[] = {
         mp_obj_new_int(buttons->left_trigger * 100 / 1023),
@@ -464,7 +464,7 @@ STATIC mp_obj_t pb_xbox_triggers(mp_obj_t self_in) {
     };
     return mp_obj_new_tuple(MP_ARRAY_SIZE(tiggers), tiggers);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_xbox_triggers_obj, pb_xbox_triggers);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_xbox_triggers_obj, pb_xbox_triggers);
 
 typedef struct {
     uint8_t activation_flags;
@@ -477,7 +477,7 @@ typedef struct {
     uint8_t repetitions;
 } __attribute__((packed)) xbox_rumble_command_t;
 
-STATIC mp_obj_t pb_xbox_rumble(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_xbox_rumble(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_xbox_obj_t, self,
         PB_ARG_DEFAULT_INT(power, 100),
@@ -555,9 +555,9 @@ STATIC mp_obj_t pb_xbox_rumble(size_t n_args, const mp_obj_t *pos_args, mp_map_t
     pbdrv_bluetooth_peripheral_write(&xbox->task, &msg.value);
     return pb_module_tools_pbio_task_wait_or_await(&xbox->task);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_xbox_rumble_obj, 1, pb_xbox_rumble);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_xbox_rumble_obj, 1, pb_xbox_rumble);
 
-STATIC const mp_rom_map_elem_t pb_type_xbox_locals_dict_table[] = {
+static const mp_rom_map_elem_t pb_type_xbox_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_name), MP_ROM_PTR(&pb_xbox_name_obj)  },
     { MP_ROM_QSTR(MP_QSTR_state), MP_ROM_PTR(&pb_xbox_state_obj) },
     { MP_ROM_QSTR(MP_QSTR_dpad), MP_ROM_PTR(&pb_xbox_dpad_obj) },
@@ -567,9 +567,9 @@ STATIC const mp_rom_map_elem_t pb_type_xbox_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_triggers), MP_ROM_PTR(&pb_xbox_triggers_obj) },
     { MP_ROM_QSTR(MP_QSTR_rumble), MP_ROM_PTR(&pb_xbox_rumble_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_type_xbox_locals_dict, pb_type_xbox_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pb_type_xbox_locals_dict, pb_type_xbox_locals_dict_table);
 
-STATIC const pb_attr_dict_entry_t pb_type_xbox_attr_dict[] = {
+static const pb_attr_dict_entry_t pb_type_xbox_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_buttons, pb_type_xbox_obj_t, buttons),
     PB_ATTR_DICT_SENTINEL
 };

--- a/pybricks/media/pb_module_media.c
+++ b/pybricks/media/pb_module_media.c
@@ -10,10 +10,10 @@
 
 #include <pybricks/util_pb/pb_error.h>
 
-STATIC const mp_rom_map_elem_t media_globals_table[] = {
+static const mp_rom_map_elem_t media_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),    MP_ROM_QSTR(MP_QSTR_media)      },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_module_media_globals, media_globals_table);
+static MP_DEFINE_CONST_DICT(pb_module_media_globals, media_globals_table);
 
 const mp_obj_module_t pb_module_media = {
     .base = { &mp_type_module },

--- a/pybricks/nxtdevices/pb_module_nxtdevices.c
+++ b/pybricks/nxtdevices/pb_module_nxtdevices.c
@@ -8,7 +8,7 @@
 #include <pybricks/common.h>
 #include <pybricks/nxtdevices.h>
 
-STATIC const mp_rom_map_elem_t nxtdevices_globals_table[] = {
+static const mp_rom_map_elem_t nxtdevices_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),          MP_ROM_QSTR(MP_QSTR_nxtdevices)                  },
     #if PYBRICKS_PY_COMMON_MOTORS && !PYBRICKS_PY_EV3DEVICES
     { MP_ROM_QSTR(MP_QSTR_Motor),             MP_ROM_PTR(&pb_type_Motor)                       },
@@ -23,7 +23,7 @@ STATIC const mp_rom_map_elem_t nxtdevices_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_UltrasonicSensor),  MP_ROM_PTR(&pb_type_nxtdevices_UltrasonicSensor) },
     #endif
 };
-STATIC MP_DEFINE_CONST_DICT(pb_module_nxtdevices_globals, nxtdevices_globals_table);
+static MP_DEFINE_CONST_DICT(pb_module_nxtdevices_globals, nxtdevices_globals_table);
 
 const mp_obj_module_t pb_module_nxtdevices = {
     .base = { &mp_type_module },

--- a/pybricks/nxtdevices/pb_type_nxtdevices_colorsensor.c
+++ b/pybricks/nxtdevices/pb_type_nxtdevices_colorsensor.c
@@ -21,7 +21,7 @@ typedef struct _nxtdevices_ColorSensor_obj_t {
     mp_obj_t light;
 } nxtdevices_ColorSensor_obj_t;
 
-STATIC mp_obj_t nxtdevices_ColorSensor_light_on(void *context, const pbio_color_hsv_t *hsv) {
+static mp_obj_t nxtdevices_ColorSensor_light_on(void *context, const pbio_color_hsv_t *hsv) {
     pb_type_device_obj_base_t *sensor = context;
     uint8_t mode;
 
@@ -39,7 +39,7 @@ STATIC mp_obj_t nxtdevices_ColorSensor_light_on(void *context, const pbio_color_
 }
 
 // pybricks.nxtdevices.ColorSensor.__init__
-STATIC mp_obj_t nxtdevices_ColorSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t nxtdevices_ColorSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -59,7 +59,7 @@ STATIC mp_obj_t nxtdevices_ColorSensor_make_new(const mp_obj_type_t *type, size_
 }
 
 // pybricks.nxtdevices.ColorSensor.rgb
-STATIC mp_obj_t nxtdevices_ColorSensor_rgb(mp_obj_t self_in) {
+static mp_obj_t nxtdevices_ColorSensor_rgb(mp_obj_t self_in) {
     int32_t *all = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_COLOR_SENSOR__MEASURE);
     mp_obj_t ret[3];
     for (uint8_t i = 0; i < 3; i++) {
@@ -68,26 +68,26 @@ STATIC mp_obj_t nxtdevices_ColorSensor_rgb(mp_obj_t self_in) {
     }
     return mp_obj_new_tuple(3, ret);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_ColorSensor_rgb_obj, nxtdevices_ColorSensor_rgb);
+static MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_ColorSensor_rgb_obj, nxtdevices_ColorSensor_rgb);
 
 // pybricks.nxtdevices.ColorSensor.reflection
-STATIC mp_obj_t nxtdevices_ColorSensor_reflection(mp_obj_t self_in) {
+static mp_obj_t nxtdevices_ColorSensor_reflection(mp_obj_t self_in) {
     int32_t *all = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_COLOR_SENSOR__MEASURE);
     // Return the average of red, green, and blue reflection
     return mp_obj_new_int((all[0] + all[1] + all[2]) * 101 / (3 * 256));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_ColorSensor_reflection_obj, nxtdevices_ColorSensor_reflection);
+static MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_ColorSensor_reflection_obj, nxtdevices_ColorSensor_reflection);
 
 // pybricks.nxtdevices.ColorSensor.ambient
-STATIC mp_obj_t nxtdevices_ColorSensor_ambient(mp_obj_t self_in) {
+static mp_obj_t nxtdevices_ColorSensor_ambient(mp_obj_t self_in) {
     int32_t *all = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_COLOR_SENSOR__MEASURE);
     // Return the ambient light
     return mp_obj_new_int(all[3]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_ColorSensor_ambient_obj, nxtdevices_ColorSensor_ambient);
+static MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_ColorSensor_ambient_obj, nxtdevices_ColorSensor_ambient);
 
 // pybricks.nxtdevices.ColorSensor.hsv
-STATIC mp_obj_t nxtdevices_ColorSensor_hsv(mp_obj_t self_in) {
+static mp_obj_t nxtdevices_ColorSensor_hsv(mp_obj_t self_in) {
     // Read sensor data
     int32_t *all = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_COLOR_SENSOR__MEASURE);
     pbio_color_rgb_t rgb = {
@@ -108,7 +108,7 @@ STATIC mp_obj_t nxtdevices_ColorSensor_hsv(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_ColorSensor_hsv_obj, nxtdevices_ColorSensor_hsv);
 
 // pybricks.nxtdevices.ColorSensor.color
-STATIC mp_obj_t nxtdevices_ColorSensor_color(mp_obj_t self_in) {
+static mp_obj_t nxtdevices_ColorSensor_color(mp_obj_t self_in) {
     nxtdevices_ColorSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     int32_t *all = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_COLOR_SENSOR__MEASURE);
@@ -124,15 +124,15 @@ STATIC mp_obj_t nxtdevices_ColorSensor_color(mp_obj_t self_in) {
     // Get and return discretized color based on HSV
     return pb_color_map_get_color(&self->color_map, &hsv);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_ColorSensor_color_obj, nxtdevices_ColorSensor_color);
+static MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_ColorSensor_color_obj, nxtdevices_ColorSensor_color);
 
-STATIC const pb_attr_dict_entry_t nxtdevices_ColorSensor_attr_dict[] = {
+static const pb_attr_dict_entry_t nxtdevices_ColorSensor_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, nxtdevices_ColorSensor_obj_t, light),
     PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.nxtdevices.ColorSensor)
-STATIC const mp_rom_map_elem_t nxtdevices_ColorSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t nxtdevices_ColorSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_hsv),        MP_ROM_PTR(&nxtdevices_ColorSensor_hsv_obj)                  },
     { MP_ROM_QSTR(MP_QSTR_rgb),        MP_ROM_PTR(&nxtdevices_ColorSensor_rgb_obj)                  },
     { MP_ROM_QSTR(MP_QSTR_ambient),    MP_ROM_PTR(&nxtdevices_ColorSensor_ambient_obj)              },
@@ -140,7 +140,7 @@ STATIC const mp_rom_map_elem_t nxtdevices_ColorSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_color),      MP_ROM_PTR(&nxtdevices_ColorSensor_color_obj)                },
     { MP_ROM_QSTR(MP_QSTR_detectable_colors),  MP_ROM_PTR(&pb_ColorSensor_detectable_colors_obj)                    },
 };
-STATIC MP_DEFINE_CONST_DICT(nxtdevices_ColorSensor_locals_dict, nxtdevices_ColorSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(nxtdevices_ColorSensor_locals_dict, nxtdevices_ColorSensor_locals_dict_table);
 
 // type(pybricks.nxtdevices.ColorSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_nxtdevices_ColorSensor,

--- a/pybricks/nxtdevices/pb_type_nxtdevices_energymeter.c
+++ b/pybricks/nxtdevices/pb_type_nxtdevices_energymeter.c
@@ -18,7 +18,7 @@ typedef struct _nxtdevices_EnergyMeter_obj_t {
 } nxtdevices_EnergyMeter_obj_t;
 
 // pybricks.nxtdevices.EnergyMeter.__init__
-STATIC mp_obj_t nxtdevices_EnergyMeter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t nxtdevices_EnergyMeter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -32,14 +32,14 @@ STATIC mp_obj_t nxtdevices_EnergyMeter_make_new(const mp_obj_type_t *type, size_
 }
 
 // pybricks.nxtdevices.EnergyMeter.storage
-STATIC mp_obj_t nxtdevices_EnergyMeter_storage(mp_obj_t self_in) {
+static mp_obj_t nxtdevices_EnergyMeter_storage(mp_obj_t self_in) {
     int32_t *all = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_ENERGY_METER_ALL);
     return mp_obj_new_int(all[4]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_EnergyMeter_storage_obj, nxtdevices_EnergyMeter_storage);
+static MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_EnergyMeter_storage_obj, nxtdevices_EnergyMeter_storage);
 
 // pybricks.nxtdevices.EnergyMeter.input
-STATIC mp_obj_t nxtdevices_EnergyMeter_input(mp_obj_t self_in) {
+static mp_obj_t nxtdevices_EnergyMeter_input(mp_obj_t self_in) {
     int32_t *all = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_ENERGY_METER_ALL);
     mp_obj_t dat[3];
     dat[0] = mp_obj_new_int(all[0]);
@@ -47,10 +47,10 @@ STATIC mp_obj_t nxtdevices_EnergyMeter_input(mp_obj_t self_in) {
     dat[2] = mp_obj_new_int(all[5]);
     return mp_obj_new_tuple(3, dat);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_EnergyMeter_input_obj, nxtdevices_EnergyMeter_input);
+static MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_EnergyMeter_input_obj, nxtdevices_EnergyMeter_input);
 
 // pybricks.nxtdevices.EnergyMeter.output
-STATIC mp_obj_t nxtdevices_EnergyMeter_output(mp_obj_t self_in) {
+static mp_obj_t nxtdevices_EnergyMeter_output(mp_obj_t self_in) {
     int32_t *all = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_ENERGY_METER_ALL);
     mp_obj_t dat[3];
     dat[0] = mp_obj_new_int(all[2]);
@@ -58,15 +58,15 @@ STATIC mp_obj_t nxtdevices_EnergyMeter_output(mp_obj_t self_in) {
     dat[2] = mp_obj_new_int(all[6]);
     return mp_obj_new_tuple(3, dat);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_EnergyMeter_output_obj, nxtdevices_EnergyMeter_output);
+static MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_EnergyMeter_output_obj, nxtdevices_EnergyMeter_output);
 
 // dir(pybricks.ev3devices.EnergyMeter)
-STATIC const mp_rom_map_elem_t nxtdevices_EnergyMeter_locals_dict_table[] = {
+static const mp_rom_map_elem_t nxtdevices_EnergyMeter_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_input),      MP_ROM_PTR(&nxtdevices_EnergyMeter_input_obj) },
     { MP_ROM_QSTR(MP_QSTR_output),     MP_ROM_PTR(&nxtdevices_EnergyMeter_output_obj) },
     { MP_ROM_QSTR(MP_QSTR_storage),    MP_ROM_PTR(&nxtdevices_EnergyMeter_storage_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(nxtdevices_EnergyMeter_locals_dict, nxtdevices_EnergyMeter_locals_dict_table);
+static MP_DEFINE_CONST_DICT(nxtdevices_EnergyMeter_locals_dict, nxtdevices_EnergyMeter_locals_dict_table);
 
 // type(pybricks.nxtdevices.EnergyMeter)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_nxtdevices_EnergyMeter,

--- a/pybricks/nxtdevices/pb_type_nxtdevices_lightsensor.c
+++ b/pybricks/nxtdevices/pb_type_nxtdevices_lightsensor.c
@@ -30,21 +30,21 @@ typedef struct _nxtdevices_LightSensor_obj_t {
 } nxtdevices_LightSensor_obj_t;
 
 // pybricks.nxtdevices.LightSensor.ambient
-STATIC mp_obj_t nxtdevices_LightSensor_ambient(mp_obj_t self_in) {
+static mp_obj_t nxtdevices_LightSensor_ambient(mp_obj_t self_in) {
     int32_t *analog = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_LIGHT_SENSOR__AMBIENT);
     return mp_obj_new_int(analog_scale(analog[0], 1906, 4164, true));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_LightSensor_ambient_obj, nxtdevices_LightSensor_ambient);
+static MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_LightSensor_ambient_obj, nxtdevices_LightSensor_ambient);
 
 // pybricks.nxtdevices.LightSensor.reflection
-STATIC mp_obj_t nxtdevices_LightSensor_reflection(mp_obj_t self_in) {
+static mp_obj_t nxtdevices_LightSensor_reflection(mp_obj_t self_in) {
     int32_t *analog = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_LIGHT_SENSOR__REFLECT);
     return mp_obj_new_int(analog_scale(analog[0], 1906, 3000, true));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_LightSensor_reflection_obj, nxtdevices_LightSensor_reflection);
+static MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_LightSensor_reflection_obj, nxtdevices_LightSensor_reflection);
 
 // pybricks.nxtdevices.LightSensor.__init__
-STATIC mp_obj_t nxtdevices_LightSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t nxtdevices_LightSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -58,11 +58,11 @@ STATIC mp_obj_t nxtdevices_LightSensor_make_new(const mp_obj_type_t *type, size_
 }
 
 // dir(pybricks.ev3devices.LightSensor)
-STATIC const mp_rom_map_elem_t nxtdevices_LightSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t nxtdevices_LightSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ambient),  MP_ROM_PTR(&nxtdevices_LightSensor_ambient_obj) },
     { MP_ROM_QSTR(MP_QSTR_reflection), MP_ROM_PTR(&nxtdevices_LightSensor_reflection_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(nxtdevices_LightSensor_locals_dict, nxtdevices_LightSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(nxtdevices_LightSensor_locals_dict, nxtdevices_LightSensor_locals_dict_table);
 
 // type(pybricks.ev3devices.LightSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_nxtdevices_LightSensor,

--- a/pybricks/nxtdevices/pb_type_nxtdevices_soundsensor.c
+++ b/pybricks/nxtdevices/pb_type_nxtdevices_soundsensor.c
@@ -19,7 +19,7 @@ typedef struct _nxtdevices_SoundSensor_obj_t {
 } nxtdevices_SoundSensor_obj_t;
 
 // pybricks.nxtdevices.SoundSensor.intensity
-STATIC mp_obj_t nxtdevices_SoundSensor_intensity(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t nxtdevices_SoundSensor_intensity(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         nxtdevices_SoundSensor_obj_t, self,
@@ -30,10 +30,10 @@ STATIC mp_obj_t nxtdevices_SoundSensor_intensity(size_t n_args, const mp_obj_t *
 
     return mp_obj_new_int(analog_scale(analog[0], 650, 4860, true));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(nxtdevices_SoundSensor_intensity_obj, 1, nxtdevices_SoundSensor_intensity);
+static MP_DEFINE_CONST_FUN_OBJ_KW(nxtdevices_SoundSensor_intensity_obj, 1, nxtdevices_SoundSensor_intensity);
 
 // pybricks.nxtdevices.SoundSensor.__init__
-STATIC mp_obj_t nxtdevices_SoundSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t nxtdevices_SoundSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -50,10 +50,10 @@ STATIC mp_obj_t nxtdevices_SoundSensor_make_new(const mp_obj_type_t *type, size_
 }
 
 // dir(pybricks.ev3devices.SoundSensor)
-STATIC const mp_rom_map_elem_t nxtdevices_SoundSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t nxtdevices_SoundSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_intensity),  MP_ROM_PTR(&nxtdevices_SoundSensor_intensity_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(nxtdevices_SoundSensor_locals_dict, nxtdevices_SoundSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(nxtdevices_SoundSensor_locals_dict, nxtdevices_SoundSensor_locals_dict_table);
 
 // type(pybricks.ev3devices.SoundSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_nxtdevices_SoundSensor,

--- a/pybricks/nxtdevices/pb_type_nxtdevices_temperaturesensor.c
+++ b/pybricks/nxtdevices/pb_type_nxtdevices_temperaturesensor.c
@@ -19,7 +19,7 @@ typedef struct _nxtdevices_TemperatureSensor_obj_t {
 } nxtdevices_TemperatureSensor_obj_t;
 
 // pybricks.nxtdevices.TemperatureSensor.__init__
-STATIC mp_obj_t nxtdevices_TemperatureSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t nxtdevices_TemperatureSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -29,18 +29,18 @@ STATIC mp_obj_t nxtdevices_TemperatureSensor_make_new(const mp_obj_type_t *type,
 }
 
 // pybricks.nxtdevices.TemperatureSensor.temperature
-STATIC mp_obj_t nxtdevices_TemperatureSensor_temperature(mp_obj_t self_in) {
+static mp_obj_t nxtdevices_TemperatureSensor_temperature(mp_obj_t self_in) {
     int16_t *temperature_scaled = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_TEMPERATURE_SENSOR_CELSIUS);
     // FIXME: ENDIANNESS
     return mp_obj_new_float((temperature_scaled[0] >> 4) / 16.0);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_TemperatureSensor_temperature_obj, nxtdevices_TemperatureSensor_temperature);
+static MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_TemperatureSensor_temperature_obj, nxtdevices_TemperatureSensor_temperature);
 
 // dir(pybricks.ev3devices.TemperatureSensor)
-STATIC const mp_rom_map_elem_t nxtdevices_TemperatureSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t nxtdevices_TemperatureSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_temperature),    MP_ROM_PTR(&nxtdevices_TemperatureSensor_temperature_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(nxtdevices_TemperatureSensor_locals_dict, nxtdevices_TemperatureSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(nxtdevices_TemperatureSensor_locals_dict, nxtdevices_TemperatureSensor_locals_dict_table);
 
 // type(pybricks.nxtdevices.TemperatureSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_nxtdevices_TemperatureSensor,

--- a/pybricks/nxtdevices/pb_type_nxtdevices_touchsensor.c
+++ b/pybricks/nxtdevices/pb_type_nxtdevices_touchsensor.c
@@ -19,7 +19,7 @@ typedef struct _nxtdevices_TouchSensor_obj_t {
 } nxtdevices_TouchSensor_obj_t;
 
 // pybricks.nxtdevices.TouchSensor.__init__
-STATIC mp_obj_t nxtdevices_TouchSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t nxtdevices_TouchSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -29,17 +29,17 @@ STATIC mp_obj_t nxtdevices_TouchSensor_make_new(const mp_obj_type_t *type, size_
 }
 
 // pybricks.nxtdevices.TouchSensor.pressed
-STATIC mp_obj_t nxtdevices_TouchSensor_pressed(mp_obj_t self_in) {
+static mp_obj_t nxtdevices_TouchSensor_pressed(mp_obj_t self_in) {
     int32_t *analog = pb_type_device_get_data_blocking(self_in, 0);
     return mp_obj_new_bool(analog[0] < 2500);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_TouchSensor_pressed_obj, nxtdevices_TouchSensor_pressed);
+static MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_TouchSensor_pressed_obj, nxtdevices_TouchSensor_pressed);
 
 // dir(pybricks.ev3devices.TouchSensor)
-STATIC const mp_rom_map_elem_t nxtdevices_TouchSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t nxtdevices_TouchSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_pressed), MP_ROM_PTR(&nxtdevices_TouchSensor_pressed_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(nxtdevices_TouchSensor_locals_dict, nxtdevices_TouchSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(nxtdevices_TouchSensor_locals_dict, nxtdevices_TouchSensor_locals_dict_table);
 
 // type(pybricks.ev3devices.TouchSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_nxtdevices_TouchSensor,

--- a/pybricks/nxtdevices/pb_type_nxtdevices_ultrasonicsensor.c
+++ b/pybricks/nxtdevices/pb_type_nxtdevices_ultrasonicsensor.c
@@ -19,7 +19,7 @@ typedef struct _nxtdevices_UltrasonicSensor_obj_t {
 } nxtdevices_UltrasonicSensor_obj_t;
 
 // pybricks.nxtdevices.UltrasonicSensor.__init__
-STATIC mp_obj_t nxtdevices_UltrasonicSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t nxtdevices_UltrasonicSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -29,17 +29,17 @@ STATIC mp_obj_t nxtdevices_UltrasonicSensor_make_new(const mp_obj_type_t *type, 
 }
 
 // pybricks.nxtdevices.UltrasonicSensor.distance
-STATIC mp_obj_t nxtdevices_UltrasonicSensor_distance(mp_obj_t self_in) {
+static mp_obj_t nxtdevices_UltrasonicSensor_distance(mp_obj_t self_in) {
     int8_t *distance = pb_type_device_get_data_blocking(self_in, PBDRV_LEGODEV_MODE_NXT_ULTRASONIC_SENSOR__DIST_CM);
     return mp_obj_new_int(distance[0] * 10);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_UltrasonicSensor_distance_obj, nxtdevices_UltrasonicSensor_distance);
+static MP_DEFINE_CONST_FUN_OBJ_1(nxtdevices_UltrasonicSensor_distance_obj, nxtdevices_UltrasonicSensor_distance);
 
 // dir(pybricks.nxtdevices.UltrasonicSensor)
-STATIC const mp_rom_map_elem_t nxtdevices_UltrasonicSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t nxtdevices_UltrasonicSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_distance), MP_ROM_PTR(&nxtdevices_UltrasonicSensor_distance_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(nxtdevices_UltrasonicSensor_locals_dict, nxtdevices_UltrasonicSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(nxtdevices_UltrasonicSensor_locals_dict, nxtdevices_UltrasonicSensor_locals_dict_table);
 
 // type(pybricks.nxtdevices.UltrasonicSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_nxtdevices_UltrasonicSensor,

--- a/pybricks/parameters/pb_module_parameters.c
+++ b/pybricks/parameters/pb_module_parameters.c
@@ -8,7 +8,7 @@
 #include <pybricks/parameters.h>
 #include <pybricks/parameters/pb_type_button.h>
 
-STATIC const mp_rom_map_elem_t parameters_globals_table[] = {
+static const mp_rom_map_elem_t parameters_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),    MP_ROM_QSTR(MP_QSTR_parameters)     },
     { MP_ROM_QSTR(MP_QSTR_Axis),        MP_ROM_PTR(&pb_enum_type_Axis)      },
     #if PYBRICKS_PY_PARAMETERS_BUTTON
@@ -23,7 +23,7 @@ STATIC const mp_rom_map_elem_t parameters_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_Side),        MP_ROM_PTR(&pb_enum_type_Side)      },
     { MP_ROM_QSTR(MP_QSTR_Stop),        MP_ROM_PTR(&pb_enum_type_Stop)      },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_module_parameters_globals, parameters_globals_table);
+static MP_DEFINE_CONST_DICT(pb_module_parameters_globals, parameters_globals_table);
 
 const mp_obj_module_t pb_module_parameters = {
     .base = { &mp_type_module },

--- a/pybricks/parameters/pb_type_axis.c
+++ b/pybricks/parameters/pb_type_axis.c
@@ -14,7 +14,7 @@
 
 #if MICROPY_PY_BUILTINS_FLOAT
 
-STATIC const float pb_type_Axis_X_data[] = {1.0f, 0.0f, 0.0f};
+static const float pb_type_Axis_X_data[] = {1.0f, 0.0f, 0.0f};
 
 const pb_type_Matrix_obj_t pb_type_Axis_X_obj = {
     {&pb_type_Matrix},
@@ -24,7 +24,7 @@ const pb_type_Matrix_obj_t pb_type_Axis_X_obj = {
     .n = 1,
 };
 
-STATIC const float pb_type_Axis_Y_data[] = {0.0f, 1.0f, 0.0f};
+static const float pb_type_Axis_Y_data[] = {0.0f, 1.0f, 0.0f};
 
 const pb_type_Matrix_obj_t pb_type_Axis_Y_obj = {
     {&pb_type_Matrix},
@@ -34,7 +34,7 @@ const pb_type_Matrix_obj_t pb_type_Axis_Y_obj = {
     .n = 1,
 };
 
-STATIC const float pb_type_Axis_Z_data[] = {0.0f, 0.0f, 1.0f};
+static const float pb_type_Axis_Z_data[] = {0.0f, 0.0f, 1.0f};
 
 const pb_type_Matrix_obj_t pb_type_Axis_Z_obj = {
     {&pb_type_Matrix},
@@ -45,7 +45,7 @@ const pb_type_Matrix_obj_t pb_type_Axis_Z_obj = {
 };
 #endif // MICROPY_PY_BUILTINS_FLOAT
 
-STATIC const mp_rom_map_elem_t pb_type_Axis_table[] = {
+static const mp_rom_map_elem_t pb_type_Axis_table[] = {
     #if MICROPY_PY_BUILTINS_FLOAT
     { MP_ROM_QSTR(MP_QSTR_X),     MP_ROM_PTR(&pb_type_Axis_X_obj)},
     { MP_ROM_QSTR(MP_QSTR_Y),     MP_ROM_PTR(&pb_type_Axis_Y_obj)},
@@ -56,7 +56,7 @@ STATIC const mp_rom_map_elem_t pb_type_Axis_table[] = {
     { MP_ROM_QSTR(MP_QSTR_Z),     MP_ROM_INT(pb_type_Axis_Z_int_enum)},
     #endif // MICROPY_PY_BUILTINS_FLOAT
 };
-STATIC MP_DEFINE_CONST_DICT(pb_type_Axis_locals_dict, pb_type_Axis_table);
+static MP_DEFINE_CONST_DICT(pb_type_Axis_locals_dict, pb_type_Axis_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_enum_type_Axis,
     MP_QSTR_Axis,

--- a/pybricks/parameters/pb_type_button.c
+++ b/pybricks/parameters/pb_type_button.c
@@ -19,7 +19,7 @@
 
 #include <pybricks/util_pb/pb_error.h>
 
-STATIC const qstr buttons[] = {
+static const qstr buttons[] = {
     MP_QSTR_LEFT,
     MP_QSTR_RIGHT,
     MP_QSTR_CENTER,
@@ -57,7 +57,7 @@ STATIC const qstr buttons[] = {
 
 extern const mp_obj_type_t pb_type_button_;
 
-STATIC void pb_type_button_print(const mp_print_t *print,  mp_obj_t self_in, mp_print_kind_t kind) {
+static void pb_type_button_print(const mp_print_t *print,  mp_obj_t self_in, mp_print_kind_t kind) {
     pb_obj_button_t *self = MP_OBJ_TO_PTR(self_in);
     mp_printf(print, self->name == pb_type_button.name ? "%q" : "%q.%q", MP_QSTR_Button, self->name);
 }
@@ -68,7 +68,7 @@ mp_obj_t pb_type_button_new(qstr name) {
     return MP_OBJ_FROM_PTR(result);
 }
 
-STATIC void pb_type_button_attribute_handler(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+static void pb_type_button_attribute_handler(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 
     // Write and delete not supported. Re-reading from an instance also not supported.
     if (dest[0] != MP_OBJ_NULL || MP_OBJ_TO_PTR(self_in) != &pb_type_button) {
@@ -84,7 +84,7 @@ STATIC void pb_type_button_attribute_handler(mp_obj_t self_in, qstr attr, mp_obj
     }
 }
 
-STATIC mp_obj_t pb_type_button_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
+static mp_obj_t pb_type_button_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
 
     // Only equality comparison is supported.
     if (op != MP_BINARY_OP_EQUAL) {

--- a/pybricks/parameters/pb_type_color.c
+++ b/pybricks/parameters/pb_type_color.c
@@ -163,7 +163,7 @@ void pb_type_Color_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kin
     mp_printf(print, "Color(h=%u, s=%u, v=%d)", self->hsv.h, self->hsv.s, self->hsv.v);
 }
 
-STATIC mp_obj_t pb_type_Color_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
+static mp_obj_t pb_type_Color_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
 
     // If we're a Color instance, there is no subscr
     if (MP_OBJ_TO_PTR(self_in) != &pb_type_Color_obj) {
@@ -179,7 +179,7 @@ STATIC mp_obj_t pb_type_Color_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t 
     return MP_OBJ_TYPE_GET_SLOT(&mp_type_dict, subscr)(MP_OBJ_FROM_PTR(MP_STATE_VM(pb_type_Color_dict)), index, value);
 }
 
-STATIC mp_obj_t pb_type_Color_getiter(mp_obj_t self_in, mp_obj_iter_buf_t *iter_buf) {
+static mp_obj_t pb_type_Color_getiter(mp_obj_t self_in, mp_obj_iter_buf_t *iter_buf) {
 
     // If we're a Color instance, there is no getiter
     if (MP_OBJ_TO_PTR(self_in) != &pb_type_Color_obj) {
@@ -190,7 +190,7 @@ STATIC mp_obj_t pb_type_Color_getiter(mp_obj_t self_in, mp_obj_iter_buf_t *iter_
     return ((mp_getiter_fun_t)MP_OBJ_TYPE_GET_SLOT(&mp_type_dict, iter))(MP_OBJ_FROM_PTR(MP_STATE_VM(pb_type_Color_dict)), iter_buf);
 }
 
-STATIC void pb_type_Color_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+static void pb_type_Color_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 
     // If we're a Color instance, just check h, s, v attributes
     if (MP_OBJ_TO_PTR(self_in) != &pb_type_Color_obj) {
@@ -232,7 +232,7 @@ STATIC void pb_type_Color_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     }
 }
 
-STATIC mp_obj_t pb_type_Color_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
+static mp_obj_t pb_type_Color_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
 
     pb_type_Color_obj_t *self = MP_OBJ_TO_PTR(lhs_in);
 
@@ -297,7 +297,7 @@ STATIC mp_obj_t pb_type_Color_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_o
 }
 
 // pybricks.parameters.Color
-STATIC mp_obj_t pb_type_Color_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pb_type_Color_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
 
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(h),

--- a/pybricks/parameters/pb_type_direction.c
+++ b/pybricks/parameters/pb_type_direction.c
@@ -23,11 +23,11 @@ const pb_obj_enum_member_t pb_Direction_COUNTERCLOCKWISE_obj = {
     .value = PBIO_DIRECTION_COUNTERCLOCKWISE
 };
 
-STATIC const mp_rom_map_elem_t pb_enum_Direction_table[] = {
+static const mp_rom_map_elem_t pb_enum_Direction_table[] = {
     { MP_ROM_QSTR(MP_QSTR_CLOCKWISE),         MP_ROM_PTR(&pb_Direction_CLOCKWISE_obj)        },
     { MP_ROM_QSTR(MP_QSTR_COUNTERCLOCKWISE),  MP_ROM_PTR(&pb_Direction_COUNTERCLOCKWISE_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_enum_type_Direction_locals_dict, pb_enum_Direction_table);
+static MP_DEFINE_CONST_DICT(pb_enum_type_Direction_locals_dict, pb_enum_Direction_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_enum_type_Direction,
     MP_QSTR_Direction,

--- a/pybricks/parameters/pb_type_icon.c
+++ b/pybricks/parameters/pb_type_icon.c
@@ -243,7 +243,7 @@ static uint32_t get_bitmap(qstr attr) {
 // pybricks.parameters.Icon.ARROW_UP
 // pybricks.parameters.Icon.ARROW_LEFT
 // etc.
-STATIC void pb_type_Icon_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+static void pb_type_Icon_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     if (dest[0] == MP_OBJ_NULL) {
         uint32_t bitmap = get_bitmap(attr);
         if (bitmap != UINT32_MAX) {
@@ -253,14 +253,14 @@ STATIC void pb_type_Icon_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 }
 
 // pybricks.parameters.Icon(x)
-STATIC mp_obj_t pb_type_Icon_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pb_type_Icon_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     if (n_args != 1) {
         pb_assert(PBIO_ERROR_INVALID_ARG);
     }
     return pb_type_Matrix_make_bitmap(5, 5, 100, mp_obj_get_int(args[0]));
 }
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(pb_type_Icon,
+static MP_DEFINE_CONST_OBJ_TYPE(pb_type_Icon,
     MP_QSTR_Icon,
     MP_TYPE_FLAG_NONE,
     call, pb_type_Icon_call,

--- a/pybricks/parameters/pb_type_port.c
+++ b/pybricks/parameters/pb_type_port.c
@@ -93,7 +93,7 @@ const pb_obj_enum_member_t pb_Port_4_obj = {
 };
 #endif
 
-STATIC const mp_rom_map_elem_t pb_enum_Port_table[] = {
+static const mp_rom_map_elem_t pb_enum_Port_table[] = {
     #if PBDRV_CONFIG_HAS_PORT_A
     { MP_ROM_QSTR(MP_QSTR_A),  MP_ROM_PTR(&pb_Port_A_obj)},
     #endif
@@ -125,7 +125,7 @@ STATIC const mp_rom_map_elem_t pb_enum_Port_table[] = {
     { MP_ROM_QSTR(MP_QSTR_S4),  MP_ROM_PTR(&pb_Port_4_obj)},
     #endif
 };
-STATIC MP_DEFINE_CONST_DICT(pb_enum_type_Port_locals_dict, pb_enum_Port_table);
+static MP_DEFINE_CONST_DICT(pb_enum_type_Port_locals_dict, pb_enum_Port_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_enum_type_Port,
     MP_QSTR_Port,

--- a/pybricks/parameters/pb_type_side.c
+++ b/pybricks/parameters/pb_type_side.c
@@ -47,7 +47,7 @@ const pb_obj_enum_member_t pb_Side_TOP_obj = {
     .value = PBIO_GEOMETRY_SIDE_TOP
 };
 
-STATIC const mp_rom_map_elem_t pb_enum_Side_table[] = {
+static const mp_rom_map_elem_t pb_enum_Side_table[] = {
     { MP_ROM_QSTR(MP_QSTR_BACK),   MP_ROM_PTR(&pb_Side_BACK_obj)  },
     { MP_ROM_QSTR(MP_QSTR_BOTTOM), MP_ROM_PTR(&pb_Side_BOTTOM_obj)},
     { MP_ROM_QSTR(MP_QSTR_FRONT),  MP_ROM_PTR(&pb_Side_FRONT_obj) },
@@ -55,7 +55,7 @@ STATIC const mp_rom_map_elem_t pb_enum_Side_table[] = {
     { MP_ROM_QSTR(MP_QSTR_RIGHT),  MP_ROM_PTR(&pb_Side_RIGHT_obj) },
     { MP_ROM_QSTR(MP_QSTR_TOP),    MP_ROM_PTR(&pb_Side_TOP_obj)   },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_enum_type_Side_locals_dict, pb_enum_Side_table);
+static MP_DEFINE_CONST_DICT(pb_enum_type_Side_locals_dict, pb_enum_Side_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_enum_type_Side,
     MP_QSTR_Side,

--- a/pybricks/parameters/pb_type_stop.c
+++ b/pybricks/parameters/pb_type_stop.c
@@ -47,7 +47,7 @@ const pb_obj_enum_member_t pb_Stop_NONE_obj = {
     .value = PBIO_CONTROL_ON_COMPLETION_CONTINUE
 };
 
-STATIC const mp_rom_map_elem_t pb_enum_Stop_table[] = {
+static const mp_rom_map_elem_t pb_enum_Stop_table[] = {
     { MP_ROM_QSTR(MP_QSTR_COAST),       MP_ROM_PTR(&pb_Stop_COAST_obj) },
     { MP_ROM_QSTR(MP_QSTR_COAST_SMART), MP_ROM_PTR(&pb_Stop_COAST_SMART_obj) },
     { MP_ROM_QSTR(MP_QSTR_BRAKE),       MP_ROM_PTR(&pb_Stop_BRAKE_obj) },
@@ -55,7 +55,7 @@ STATIC const mp_rom_map_elem_t pb_enum_Stop_table[] = {
     { MP_ROM_QSTR(MP_QSTR_HOLD),        MP_ROM_PTR(&pb_Stop_HOLD_obj)  },
     { MP_ROM_QSTR(MP_QSTR_NONE),        MP_ROM_PTR(&pb_Stop_NONE_obj)},
 };
-STATIC MP_DEFINE_CONST_DICT(pb_enum_type_Stop_locals_dict, pb_enum_Stop_table);
+static MP_DEFINE_CONST_DICT(pb_enum_type_Stop_locals_dict, pb_enum_Stop_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_enum_type_Stop,
     MP_QSTR_Stop,

--- a/pybricks/pupdevices/pb_module_pupdevices.c
+++ b/pybricks/pupdevices/pb_module_pupdevices.c
@@ -11,7 +11,7 @@
 #include <pybricks/common.h>
 #include <pybricks/pupdevices.h>
 
-STATIC const mp_rom_map_elem_t pupdevices_globals_table[] = {
+static const mp_rom_map_elem_t pupdevices_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),            MP_ROM_QSTR(MP_QSTR_pupdevices)                    },
     #if PYBRICKS_PY_COMMON_MOTORS
     { MP_ROM_QSTR(MP_QSTR_Motor),               MP_ROM_PTR(&pb_type_Motor)                         },
@@ -30,7 +30,7 @@ STATIC const mp_rom_map_elem_t pupdevices_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_TiltSensor),          MP_ROM_PTR(&pb_type_pupdevices_TiltSensor)         },
     { MP_ROM_QSTR(MP_QSTR_UltrasonicSensor),    MP_ROM_PTR(&pb_type_pupdevices_UltrasonicSensor)   },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_module_pupdevices_globals, pupdevices_globals_table);
+static MP_DEFINE_CONST_DICT(pb_module_pupdevices_globals, pupdevices_globals_table);
 
 const mp_obj_module_t pb_module_pupdevices = {
     .base = { &mp_type_module },

--- a/pybricks/pupdevices/pb_type_pupdevices_colordistancesensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_colordistancesensor.c
@@ -42,7 +42,7 @@ pb_type_device_obj_base_t *pupdevices_ColorDistanceSensor__get_device(mp_obj_t o
  * @param [in] context    Sensor base object.
  * @param [in] hsv        Requested color, will be rounded to nearest color.
  */
-STATIC mp_obj_t pupdevices_ColorDistanceSensor_light_on(void *context, const pbio_color_hsv_t *hsv) {
+static mp_obj_t pupdevices_ColorDistanceSensor_light_on(void *context, const pbio_color_hsv_t *hsv) {
     pb_type_device_obj_base_t *sensor = context;
 
     // Even though the mode takes a 0-10 value for color, only red, green and blue
@@ -63,7 +63,7 @@ STATIC mp_obj_t pupdevices_ColorDistanceSensor_light_on(void *context, const pbi
 }
 
 // pybricks.pupdevices.ColorDistanceSensor.__init__
-STATIC mp_obj_t pupdevices_ColorDistanceSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pupdevices_ColorDistanceSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -80,7 +80,7 @@ STATIC mp_obj_t pupdevices_ColorDistanceSensor_make_new(const mp_obj_type_t *typ
 }
 
 // Ensures sensor is in RGB mode then converts the measured raw RGB value to HSV.
-STATIC void get_hsv_data(pupdevices_ColorDistanceSensor_obj_t *self, pbio_color_hsv_t *hsv) {
+static void get_hsv_data(pupdevices_ColorDistanceSensor_obj_t *self, pbio_color_hsv_t *hsv) {
     int16_t *raw = pb_type_device_get_data(MP_OBJ_FROM_PTR(&self->device_base), PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__RGB_I);
 
     // Max observed value is ~440 so we scale to get a range of 0..255.
@@ -92,51 +92,51 @@ STATIC void get_hsv_data(pupdevices_ColorDistanceSensor_obj_t *self, pbio_color_
 }
 
 // pybricks.pupdevices.ColorDistanceSensor.color
-STATIC mp_obj_t get_color(mp_obj_t self_in) {
+static mp_obj_t get_color(mp_obj_t self_in) {
     pupdevices_ColorDistanceSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pbio_color_hsv_t hsv;
     get_hsv_data(self, &hsv);
     return pb_color_map_get_color(&self->color_map, &hsv);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_color_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__RGB_I, get_color);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_color_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__RGB_I, get_color);
 
 // pybricks.pupdevices.ColorDistanceSensor.distance
-STATIC mp_obj_t get_distance(mp_obj_t self_in) {
+static mp_obj_t get_distance(mp_obj_t self_in) {
     int8_t *data = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__PROX);
     return mp_obj_new_int(data[0] * 10);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_distance_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__PROX, get_distance);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_distance_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__PROX, get_distance);
 
 // pybricks.pupdevices.ColorDistanceSensor.reflection
-STATIC mp_obj_t get_reflection(mp_obj_t self_in) {
+static mp_obj_t get_reflection(mp_obj_t self_in) {
     int16_t *rgb = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__RGB_I);
     return mp_obj_new_int((rgb[0] + rgb[1] + rgb[2]) / 12);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_reflection_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__RGB_I, get_reflection);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_reflection_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__RGB_I, get_reflection);
 
 // pybricks.pupdevices.ColorDistanceSensor.ambient
-STATIC mp_obj_t get_ambient(mp_obj_t self_in) {
+static mp_obj_t get_ambient(mp_obj_t self_in) {
     int8_t *ambient = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__AMBI);
     return mp_obj_new_int(ambient[0]);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_ambient_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__AMBI, get_ambient);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_ambient_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__AMBI, get_ambient);
 
 // pybricks.pupdevices.ColorDistanceSensor.hsv
-STATIC mp_obj_t get_hsv(mp_obj_t self_in) {
+static mp_obj_t get_hsv(mp_obj_t self_in) {
     pupdevices_ColorDistanceSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pb_type_Color_obj_t *color = pb_type_Color_new_empty();
     get_hsv_data(self, &color->hsv);
     return MP_OBJ_FROM_PTR(color);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_hsv_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__RGB_I, get_hsv);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_hsv_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_DISTANCE_SENSOR__RGB_I, get_hsv);
 
-STATIC const pb_attr_dict_entry_t pupdevices_ColorDistanceSensor_attr_dict[] = {
+static const pb_attr_dict_entry_t pupdevices_ColorDistanceSensor_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, pupdevices_ColorDistanceSensor_obj_t, light),
     PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.pupdevices.ColorDistanceSensor)
-STATIC const mp_rom_map_elem_t pupdevices_ColorDistanceSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t pupdevices_ColorDistanceSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_color),       MP_ROM_PTR(&get_color_obj)                },
     { MP_ROM_QSTR(MP_QSTR_reflection),  MP_ROM_PTR(&get_reflection_obj)           },
     { MP_ROM_QSTR(MP_QSTR_ambient),     MP_ROM_PTR(&get_ambient_obj)              },
@@ -144,7 +144,7 @@ STATIC const mp_rom_map_elem_t pupdevices_ColorDistanceSensor_locals_dict_table[
     { MP_ROM_QSTR(MP_QSTR_hsv),         MP_ROM_PTR(&get_hsv_obj)                  },
     { MP_ROM_QSTR(MP_QSTR_detectable_colors),   MP_ROM_PTR(&pb_ColorSensor_detectable_colors_obj)                            },
 };
-STATIC MP_DEFINE_CONST_DICT(pupdevices_ColorDistanceSensor_locals_dict, pupdevices_ColorDistanceSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pupdevices_ColorDistanceSensor_locals_dict, pupdevices_ColorDistanceSensor_locals_dict_table);
 
 // type(pybricks.pupdevices.ColorDistanceSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_pupdevices_ColorDistanceSensor,

--- a/pybricks/pupdevices/pb_type_pupdevices_colorlightmatrix.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_colorlightmatrix.c
@@ -20,7 +20,7 @@ typedef struct _pupdevices_ColorLightMatrix_obj_t {
 } pupdevices_ColorLightMatrix_obj_t;
 
 // pybricks.pupdevices.ColorLightMatrix.__init__
-STATIC mp_obj_t pupdevices_ColorLightMatrix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pupdevices_ColorLightMatrix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -31,7 +31,7 @@ STATIC mp_obj_t pupdevices_ColorLightMatrix_make_new(const mp_obj_type_t *type, 
 }
 
 // pybricks.pupdevices.ColorLightMatrix._get_color_id
-STATIC uint8_t get_color_id(mp_obj_t color_in) {
+static uint8_t get_color_id(mp_obj_t color_in) {
 
     // Assert type and get hsv.
     const pbio_color_hsv_t *hsv = pb_type_Color_get_hsv(color_in);
@@ -58,7 +58,7 @@ STATIC uint8_t get_color_id(mp_obj_t color_in) {
 }
 
 // pybricks.pupdevices.ColorLightMatrix.on
-STATIC mp_obj_t pupdevices_ColorLightMatrix_on(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pupdevices_ColorLightMatrix_on(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pupdevices_ColorLightMatrix_obj_t, self,
         PB_ARG_REQUIRED(colors));
@@ -84,10 +84,10 @@ STATIC mp_obj_t pupdevices_ColorLightMatrix_on(size_t n_args, const mp_obj_t *po
     // Activate all colors.
     return pb_type_device_set_data(&self->device_base, PBDRV_LEGODEV_MODE_PUP_COLOR_LIGHT_MATRIX__PIX_O, color_ids, sizeof(color_ids));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pupdevices_ColorLightMatrix_on_obj, 1, pupdevices_ColorLightMatrix_on);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pupdevices_ColorLightMatrix_on_obj, 1, pupdevices_ColorLightMatrix_on);
 
 // pybricks.pupdevices.ColorLightMatrix.off
-STATIC mp_obj_t pupdevices_ColorLightMatrix_off(mp_obj_t self_in) {
+static mp_obj_t pupdevices_ColorLightMatrix_off(mp_obj_t self_in) {
     pupdevices_ColorLightMatrix_obj_t *self = MP_OBJ_TO_PTR(self_in);
     int8_t color_ids[9] = { };
     return pb_type_device_set_data(&self->device_base, PBDRV_LEGODEV_MODE_PUP_COLOR_LIGHT_MATRIX__PIX_O, color_ids, sizeof(color_ids));
@@ -95,11 +95,11 @@ STATIC mp_obj_t pupdevices_ColorLightMatrix_off(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(pupdevices_ColorLightMatrix_off_obj, pupdevices_ColorLightMatrix_off);
 
 // dir(pybricks.pupdevices.ColorLightMatrix)
-STATIC const mp_rom_map_elem_t pupdevices_ColorLightMatrix_locals_dict_table[] = {
+static const mp_rom_map_elem_t pupdevices_ColorLightMatrix_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_on),       MP_ROM_PTR(&pupdevices_ColorLightMatrix_on_obj) },
     { MP_ROM_QSTR(MP_QSTR_off),      MP_ROM_PTR(&pupdevices_ColorLightMatrix_off_obj)},
 };
-STATIC MP_DEFINE_CONST_DICT(pupdevices_ColorLightMatrix_locals_dict, pupdevices_ColorLightMatrix_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pupdevices_ColorLightMatrix_locals_dict, pupdevices_ColorLightMatrix_locals_dict_table);
 
 // type(pybricks.pupdevices.ColorLightMatrix)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_pupdevices_ColorLightMatrix,

--- a/pybricks/pupdevices/pb_type_pupdevices_colorsensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_colorsensor.c
@@ -25,7 +25,7 @@ typedef struct _pupdevices_ColorSensor_obj_t {
 } pupdevices_ColorSensor_obj_t;
 
 // pybricks.pupdevices.ColorSensor.__init__
-STATIC mp_obj_t pupdevices_ColorSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pupdevices_ColorSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -45,23 +45,23 @@ STATIC mp_obj_t pupdevices_ColorSensor_make_new(const mp_obj_type_t *type, size_
 }
 
 // pybricks.pupdevices.ColorSensor.reflection
-STATIC mp_obj_t get_reflection(mp_obj_t self_in) {
+static mp_obj_t get_reflection(mp_obj_t self_in) {
     // Get reflection from average RGB reflection, which ranges from 0 to 3*1024
     int16_t *data = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__RGB_I);
     return mp_obj_new_int((data[0] + data[1] + data[2]) * 100 / 3072);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_reflection_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__RGB_I, get_reflection);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_reflection_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__RGB_I, get_reflection);
 
 // pybricks.pupdevices.ColorSensor.ambient
-STATIC mp_obj_t get_ambient(mp_obj_t self_in) {
+static mp_obj_t get_ambient(mp_obj_t self_in) {
     // Get ambient from "V" in SHSV (0--10000), scaled to 0 to 100
     int16_t *data = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__SHSV);
     return pb_obj_new_fraction(data[2], 100);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_ambient_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__SHSV, get_ambient);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_ambient_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__SHSV, get_ambient);
 
 // Helper for getting HSV with the light on.
-STATIC void get_hsv_reflected(mp_obj_t self_in, pbio_color_hsv_t *hsv) {
+static void get_hsv_reflected(mp_obj_t self_in, pbio_color_hsv_t *hsv) {
     int16_t *data = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__RGB_I);
     const pbio_color_rgb_t rgb = {
         .r = data[0] == 1024 ? 255 : data[0] >> 2,
@@ -73,7 +73,7 @@ STATIC void get_hsv_reflected(mp_obj_t self_in, pbio_color_hsv_t *hsv) {
 
 // Helper for getting HSV with the light off, scale saturation and value to
 // match 0-100% range in typical applications.
-STATIC void get_hsv_ambient(mp_obj_t self_in, pbio_color_hsv_t *hsv) {
+static void get_hsv_ambient(mp_obj_t self_in, pbio_color_hsv_t *hsv) {
     int16_t *data = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__SHSV);
     hsv->h = data[0];
     hsv->s = data[1] / 10;
@@ -87,41 +87,41 @@ STATIC void get_hsv_ambient(mp_obj_t self_in, pbio_color_hsv_t *hsv) {
 }
 
 // pybricks.pupdevices.ColorSensor.hsv(surface=True)
-STATIC mp_obj_t get_hsv_surface_true(mp_obj_t self_in) {
+static mp_obj_t get_hsv_surface_true(mp_obj_t self_in) {
     pb_type_Color_obj_t *color = pb_type_Color_new_empty();
     get_hsv_reflected(self_in, &color->hsv);
     return MP_OBJ_FROM_PTR(color);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_hsv_surface_true_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__RGB_I, get_hsv_surface_true);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_hsv_surface_true_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__RGB_I, get_hsv_surface_true);
 
 // pybricks.pupdevices.ColorSensor.hsv(surface=False)
-STATIC mp_obj_t get_hsv_surface_false(mp_obj_t self_in) {
+static mp_obj_t get_hsv_surface_false(mp_obj_t self_in) {
     pb_type_Color_obj_t *color = pb_type_Color_new_empty();
     get_hsv_ambient(self_in, &color->hsv);
     return MP_OBJ_FROM_PTR(color);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_hsv_surface_false_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__SHSV, get_hsv_surface_false);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_hsv_surface_false_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__SHSV, get_hsv_surface_false);
 
 // pybricks.pupdevices.ColorSensor.color(surface=True)
-STATIC mp_obj_t get_color_surface_true(mp_obj_t self_in) {
+static mp_obj_t get_color_surface_true(mp_obj_t self_in) {
     pbio_color_hsv_t hsv;
     get_hsv_reflected(self_in, &hsv);
     pupdevices_ColorSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return pb_color_map_get_color(&self->color_map, &hsv);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_color_surface_true_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__RGB_I, get_color_surface_true);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_color_surface_true_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__RGB_I, get_color_surface_true);
 
 // pybricks.pupdevices.ColorSensor.color(surface=False)
-STATIC mp_obj_t get_color_surface_false(mp_obj_t self_in) {
+static mp_obj_t get_color_surface_false(mp_obj_t self_in) {
     pbio_color_hsv_t hsv;
     get_hsv_ambient(self_in, &hsv);
     pupdevices_ColorSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return pb_color_map_get_color(&self->color_map, &hsv);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_color_surface_false_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__SHSV, get_color_surface_false);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_color_surface_false_obj, PBDRV_LEGODEV_MODE_PUP_COLOR_SENSOR__SHSV, get_color_surface_false);
 
 // pybricks.pupdevices.ColorSensor.hsv
-STATIC mp_obj_t get_hsv(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t get_hsv(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pupdevices_ColorSensor_obj_t, self,
         PB_ARG_DEFAULT_TRUE(surface));
@@ -132,10 +132,10 @@ STATIC mp_obj_t get_hsv(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
     }
     return pb_type_device_method_call(MP_OBJ_FROM_PTR(&get_hsv_surface_false_obj), 1, 0, pos_args);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(get_hsv_obj, 1, get_hsv);
+static MP_DEFINE_CONST_FUN_OBJ_KW(get_hsv_obj, 1, get_hsv);
 
 // pybricks.pupdevices.ColorSensor.color
-STATIC mp_obj_t get_color(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t get_color(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pupdevices_ColorSensor_obj_t, self,
         PB_ARG_DEFAULT_TRUE(surface));
@@ -146,22 +146,22 @@ STATIC mp_obj_t get_color(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_
     }
     return pb_type_device_method_call(MP_OBJ_FROM_PTR(&get_color_surface_false_obj), 1, 0, pos_args);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(get_color_obj, 1, get_color);
+static MP_DEFINE_CONST_FUN_OBJ_KW(get_color_obj, 1, get_color);
 
-STATIC const pb_attr_dict_entry_t pupdevices_ColorSensor_attr_dict[] = {
+static const pb_attr_dict_entry_t pupdevices_ColorSensor_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_lights, pupdevices_ColorSensor_obj_t, lights),
     PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.pupdevices.ColorSensor)
-STATIC const mp_rom_map_elem_t pupdevices_ColorSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t pupdevices_ColorSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_hsv),         MP_ROM_PTR(&get_hsv_obj)                  },
     { MP_ROM_QSTR(MP_QSTR_color),       MP_ROM_PTR(&get_color_obj)                },
     { MP_ROM_QSTR(MP_QSTR_reflection),  MP_ROM_PTR(&get_reflection_obj)           },
     { MP_ROM_QSTR(MP_QSTR_ambient),     MP_ROM_PTR(&get_ambient_obj)              },
     { MP_ROM_QSTR(MP_QSTR_detectable_colors),   MP_ROM_PTR(&pb_ColorSensor_detectable_colors_obj)                    },
 };
-STATIC MP_DEFINE_CONST_DICT(pupdevices_ColorSensor_locals_dict, pupdevices_ColorSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pupdevices_ColorSensor_locals_dict, pupdevices_ColorSensor_locals_dict_table);
 
 // type(pybricks.pupdevices.ColorSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_pupdevices_ColorSensor,

--- a/pybricks/pupdevices/pb_type_pupdevices_forcesensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_forcesensor.c
@@ -27,7 +27,7 @@ typedef struct _pupdevices_ForceSensor_obj_t {
 } pupdevices_ForceSensor_obj_t;
 
 // pybricks.pupdevices.ForceSensor.__init__
-STATIC mp_obj_t pupdevices_ForceSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pupdevices_ForceSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -53,13 +53,13 @@ STATIC mp_obj_t pupdevices_ForceSensor_make_new(const mp_obj_type_t *type, size_
 }
 
 // pybricks.pupdevices.ForceSensor._raw
-STATIC int32_t get_raw(mp_obj_t self_in) {
+static int32_t get_raw(mp_obj_t self_in) {
     int16_t *raw = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_FORCE_SENSOR__FRAW);
     return *raw;
 }
 
 // pybricks.pupdevices.ForceSensor._force
-STATIC int32_t get_force_mN(mp_obj_t self_in) {
+static int32_t get_force_mN(mp_obj_t self_in) {
     // Get force in millinewtons
     pupdevices_ForceSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     int32_t force = (10000 * (get_raw(self_in) - self->raw_released - self->raw_offset)) / (self->raw_end - self->raw_released);
@@ -68,37 +68,37 @@ STATIC int32_t get_force_mN(mp_obj_t self_in) {
 }
 
 // pybricks.pupdevices.ForceSensor.touched
-STATIC mp_obj_t get_touched(mp_obj_t self_in) {
+static mp_obj_t get_touched(mp_obj_t self_in) {
     pupdevices_ForceSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     // Return true if raw value is just above detectable change, with a small
     // margin to account for small calibration tolerances.
     return mp_obj_new_bool(get_raw(self_in) > self->raw_released + 4);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_touched_obj, PBDRV_LEGODEV_MODE_PUP_FORCE_SENSOR__FRAW, get_touched);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_touched_obj, PBDRV_LEGODEV_MODE_PUP_FORCE_SENSOR__FRAW, get_touched);
 
 // pybricks.pupdevices.ForceSensor.force
-STATIC mp_obj_t get_force(mp_obj_t self_in) {
+static mp_obj_t get_force(mp_obj_t self_in) {
     return pb_obj_new_fraction(get_force_mN(self_in), 1000);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_force_obj, PBDRV_LEGODEV_MODE_PUP_FORCE_SENSOR__FRAW, get_force);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_force_obj, PBDRV_LEGODEV_MODE_PUP_FORCE_SENSOR__FRAW, get_force);
 
 // pybricks.pupdevices.ForceSensor.distance
-STATIC mp_obj_t get_distance(mp_obj_t self_in) {
+static mp_obj_t get_distance(mp_obj_t self_in) {
     pupdevices_ForceSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     int32_t distance_um = (6670 * (get_raw(self_in) - self->raw_released)) / (self->raw_end - self->raw_released);
     return pb_obj_new_fraction(distance_um, 1000);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_distance_obj, PBDRV_LEGODEV_MODE_PUP_FORCE_SENSOR__FRAW, get_distance);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_distance_obj, PBDRV_LEGODEV_MODE_PUP_FORCE_SENSOR__FRAW, get_distance);
 
 // pybricks.pupdevices.ForceSensor.pressed(force=default)
-STATIC mp_obj_t get_pressed_simple(mp_obj_t self_in) {
+static mp_obj_t get_pressed_simple(mp_obj_t self_in) {
     pupdevices_ForceSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(get_force_mN(self_in) >= self->pressed_threshold);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_pressed_simple_obj, PBDRV_LEGODEV_MODE_PUP_FORCE_SENSOR__FRAW, get_pressed_simple);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_pressed_simple_obj, PBDRV_LEGODEV_MODE_PUP_FORCE_SENSOR__FRAW, get_pressed_simple);
 
 // pybricks.pupdevices.ForceSensor.pressed
-STATIC mp_obj_t get_pressed(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t get_pressed(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pupdevices_ForceSensor_obj_t, self,
         PB_ARG_DEFAULT_INT(force, 3));
@@ -114,13 +114,13 @@ STATIC mp_obj_t get_pressed(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
 MP_DEFINE_CONST_FUN_OBJ_KW(get_pressed_obj, 1, get_pressed);
 
 // dir(pybricks.pupdevices.ForceSensor)
-STATIC const mp_rom_map_elem_t pupdevices_ForceSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t pupdevices_ForceSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_touched),     MP_ROM_PTR(&get_touched_obj)              },
     { MP_ROM_QSTR(MP_QSTR_force),       MP_ROM_PTR(&get_force_obj)                },
     { MP_ROM_QSTR(MP_QSTR_pressed),     MP_ROM_PTR(&get_pressed_obj)              },
     { MP_ROM_QSTR(MP_QSTR_distance),    MP_ROM_PTR(&get_distance_obj)             },
 };
-STATIC MP_DEFINE_CONST_DICT(pupdevices_ForceSensor_locals_dict, pupdevices_ForceSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pupdevices_ForceSensor_locals_dict, pupdevices_ForceSensor_locals_dict_table);
 
 // type(pybricks.pupdevices.ForceSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_pupdevices_ForceSensor,

--- a/pybricks/pupdevices/pb_type_pupdevices_infraredsensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_infraredsensor.c
@@ -20,7 +20,7 @@ typedef struct _pupdevices_InfraredSensor_obj_t {
 } pupdevices_InfraredSensor_obj_t;
 
 // pybricks.pupdevices.InfraredSensor.__init__
-STATIC mp_obj_t pupdevices_InfraredSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pupdevices_InfraredSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -35,34 +35,34 @@ STATIC mp_obj_t pupdevices_InfraredSensor_make_new(const mp_obj_type_t *type, si
 }
 
 // pybricks.pupdevices.InfraredSensor.count
-STATIC mp_obj_t get_count(mp_obj_t self_in) {
+static mp_obj_t get_count(mp_obj_t self_in) {
     pupdevices_InfraredSensor_obj_t *self = MP_OBJ_TO_PTR(self_in);
     int32_t *count = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_WEDO2_MOTION_SENSOR__COUNT);
     return mp_obj_new_int(count[0] - self->count_offset);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_count_obj, PBDRV_LEGODEV_MODE_PUP_WEDO2_MOTION_SENSOR__COUNT, get_count);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_count_obj, PBDRV_LEGODEV_MODE_PUP_WEDO2_MOTION_SENSOR__COUNT, get_count);
 
 // pybricks.pupdevices.InfraredSensor.reflection
-STATIC mp_obj_t get_reflection(mp_obj_t self_in) {
+static mp_obj_t get_reflection(mp_obj_t self_in) {
     int16_t *data = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_WEDO2_MOTION_SENSOR__CAL);
     return pb_obj_new_fraction(data[0], 5);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_reflection_obj, PBDRV_LEGODEV_MODE_PUP_WEDO2_MOTION_SENSOR__CAL, get_reflection);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_reflection_obj, PBDRV_LEGODEV_MODE_PUP_WEDO2_MOTION_SENSOR__CAL, get_reflection);
 
 // pybricks.pupdevices.InfraredSensor.distance
-STATIC mp_obj_t get_distance(mp_obj_t self_in) {
+static mp_obj_t get_distance(mp_obj_t self_in) {
     int16_t *data = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_WEDO2_MOTION_SENSOR__CAL);
     return mp_obj_new_int(1100 / (10 + data[0]));
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_distance_obj, PBDRV_LEGODEV_MODE_PUP_WEDO2_MOTION_SENSOR__CAL, get_distance);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_distance_obj, PBDRV_LEGODEV_MODE_PUP_WEDO2_MOTION_SENSOR__CAL, get_distance);
 
 // dir(pybricks.pupdevices.InfraredSensor)
-STATIC const mp_rom_map_elem_t pupdevices_InfraredSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t pupdevices_InfraredSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_count),       MP_ROM_PTR(&get_count_obj)                },
     { MP_ROM_QSTR(MP_QSTR_reflection),  MP_ROM_PTR(&get_reflection_obj)           },
     { MP_ROM_QSTR(MP_QSTR_distance),    MP_ROM_PTR(&get_distance_obj)             },
 };
-STATIC MP_DEFINE_CONST_DICT(pupdevices_InfraredSensor_locals_dict, pupdevices_InfraredSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pupdevices_InfraredSensor_locals_dict, pupdevices_InfraredSensor_locals_dict_table);
 
 // type(pybricks.pupdevices.InfraredSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_pupdevices_InfraredSensor,

--- a/pybricks/pupdevices/pb_type_pupdevices_light.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_light.c
@@ -24,7 +24,7 @@ typedef struct _pupdevices_Light_obj_t {
 } pupdevices_Light_obj_t;
 
 // pybricks.pupdevices.Light.__init__
-STATIC mp_obj_t pupdevices_Light_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pupdevices_Light_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -43,7 +43,7 @@ STATIC mp_obj_t pupdevices_Light_make_new(const mp_obj_type_t *type, size_t n_ar
 }
 
 // pybricks.pupdevices.Light.on
-STATIC mp_obj_t pupdevices_Light_on(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pupdevices_Light_on(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pupdevices_Light_obj_t, self,
         PB_ARG_DEFAULT_INT(brightness, 100));
@@ -57,19 +57,19 @@ STATIC mp_obj_t pupdevices_Light_on(size_t n_args, const mp_obj_t *pos_args, mp_
 MP_DEFINE_CONST_FUN_OBJ_KW(pupdevices_Light_on_obj, 1, pupdevices_Light_on);
 
 // pybricks.pupdevices.Light.off
-STATIC mp_obj_t pupdevices_Light_off(mp_obj_t self_in) {
+static mp_obj_t pupdevices_Light_off(mp_obj_t self_in) {
     pupdevices_Light_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pb_assert(pbio_dcmotor_user_command(self->dcmotor, true, 0));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pupdevices_Light_off_obj, pupdevices_Light_off);
+static MP_DEFINE_CONST_FUN_OBJ_1(pupdevices_Light_off_obj, pupdevices_Light_off);
 
 // dir(pybricks.pupdevices.Light)
-STATIC const mp_rom_map_elem_t pupdevices_Light_locals_dict_table[] = {
+static const mp_rom_map_elem_t pupdevices_Light_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_on),      MP_ROM_PTR(&pupdevices_Light_on_obj)           },
     { MP_ROM_QSTR(MP_QSTR_off),     MP_ROM_PTR(&pupdevices_Light_off_obj)          },
 };
-STATIC MP_DEFINE_CONST_DICT(pupdevices_Light_locals_dict, pupdevices_Light_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pupdevices_Light_locals_dict, pupdevices_Light_locals_dict_table);
 
 // type(pybricks.pupdevices.Light)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_pupdevices_Light,

--- a/pybricks/pupdevices/pb_type_pupdevices_pfmotor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_pfmotor.c
@@ -31,7 +31,7 @@ typedef struct _pupdevices_PFMotor_obj_t {
 } pupdevices_PFMotor_obj_t;
 
 // pybricks.pupdevices.PFMotor.__init__
-STATIC mp_obj_t pupdevices_PFMotor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pupdevices_PFMotor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(sensor),
         PB_ARG_REQUIRED(channel),
@@ -64,7 +64,7 @@ STATIC mp_obj_t pupdevices_PFMotor_make_new(const mp_obj_type_t *type, size_t n_
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC mp_obj_t pupdevices_PFMotor__send(pupdevices_PFMotor_obj_t *self, int16_t message) {
+static mp_obj_t pupdevices_PFMotor__send(pupdevices_PFMotor_obj_t *self, int16_t message) {
     // Choose blue or red output
     message |= (self->use_blue_port) << 4;
 
@@ -81,7 +81,7 @@ STATIC mp_obj_t pupdevices_PFMotor__send(pupdevices_PFMotor_obj_t *self, int16_t
 }
 
 // pybricks.pupdevices.PFMotor.dc
-STATIC mp_obj_t pupdevices_PFMotor_dc(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pupdevices_PFMotor_dc(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pupdevices_PFMotor_obj_t, self,
         PB_ARG_REQUIRED(duty));
@@ -108,24 +108,24 @@ STATIC mp_obj_t pupdevices_PFMotor_dc(size_t n_args, const mp_obj_t *pos_args, m
 MP_DEFINE_CONST_FUN_OBJ_KW(pupdevices_PFMotor_dc_obj, 1, pupdevices_PFMotor_dc);
 
 // pybricks.pupdevices.PFMotor.stop
-STATIC mp_obj_t pupdevices_PFMotor_stop(mp_obj_t self_in) {
+static mp_obj_t pupdevices_PFMotor_stop(mp_obj_t self_in) {
     return pupdevices_PFMotor__send(MP_OBJ_TO_PTR(self_in), 0);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pupdevices_PFMotor_stop_obj, pupdevices_PFMotor_stop);
 
 // pybricks.pupdevices.PFMotor.brake
-STATIC mp_obj_t pupdevices_PFMotor_brake(mp_obj_t self_in) {
+static mp_obj_t pupdevices_PFMotor_brake(mp_obj_t self_in) {
     return pupdevices_PFMotor__send(MP_OBJ_TO_PTR(self_in), 8);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pupdevices_PFMotor_brake_obj, pupdevices_PFMotor_brake);
 
 // dir(pybricks.pupdevices.PFMotor)
-STATIC const mp_rom_map_elem_t pupdevices_PFMotor_locals_dict_table[] = {
+static const mp_rom_map_elem_t pupdevices_PFMotor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_dc),      MP_ROM_PTR(&pupdevices_PFMotor_dc_obj)},
     { MP_ROM_QSTR(MP_QSTR_stop),    MP_ROM_PTR(&pupdevices_PFMotor_stop_obj)},
     { MP_ROM_QSTR(MP_QSTR_brake),   MP_ROM_PTR(&pupdevices_PFMotor_brake_obj)},
 };
-STATIC MP_DEFINE_CONST_DICT(pupdevices_PFMotor_locals_dict, pupdevices_PFMotor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pupdevices_PFMotor_locals_dict, pupdevices_PFMotor_locals_dict_table);
 
 // type(pybricks.pupdevices.PFMotor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_pupdevices_PFMotor,

--- a/pybricks/pupdevices/pb_type_pupdevices_tiltsensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_tiltsensor.c
@@ -19,7 +19,7 @@ typedef struct _pupdevices_TiltSensor_obj_t {
 } pupdevices_TiltSensor_obj_t;
 
 // pybricks.pupdevices.TiltSensor.__init__
-STATIC mp_obj_t pupdevices_TiltSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pupdevices_TiltSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -29,20 +29,20 @@ STATIC mp_obj_t pupdevices_TiltSensor_make_new(const mp_obj_type_t *type, size_t
 }
 
 // pybricks.pupdevices.TiltSensor.tilt
-STATIC mp_obj_t get_tilt(mp_obj_t self_in) {
+static mp_obj_t get_tilt(mp_obj_t self_in) {
     int8_t *tilt = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_WEDO2_TILT_SENSOR__ANGLE);
     mp_obj_t ret[2];
     ret[0] = mp_obj_new_int(tilt[1]);
     ret[1] = mp_obj_new_int(tilt[0]);
     return mp_obj_new_tuple(MP_ARRAY_SIZE(ret), ret);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_tilt_obj, PBDRV_LEGODEV_MODE_PUP_WEDO2_TILT_SENSOR__ANGLE, get_tilt);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_tilt_obj, PBDRV_LEGODEV_MODE_PUP_WEDO2_TILT_SENSOR__ANGLE, get_tilt);
 
 // dir(pybricks.pupdevices.TiltSensor)
-STATIC const mp_rom_map_elem_t pupdevices_TiltSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t pupdevices_TiltSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_tilt),       MP_ROM_PTR(&get_tilt_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(pupdevices_TiltSensor_locals_dict, pupdevices_TiltSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pupdevices_TiltSensor_locals_dict, pupdevices_TiltSensor_locals_dict_table);
 
 // type(pybricks.pupdevices.TiltSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_pupdevices_TiltSensor,

--- a/pybricks/pupdevices/pb_type_pupdevices_ultrasonicsensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_ultrasonicsensor.c
@@ -22,7 +22,7 @@ typedef struct _pupdevices_UltrasonicSensor_obj_t {
 } pupdevices_UltrasonicSensor_obj_t;
 
 // pybricks.pupdevices.UltrasonicSensor.__init__
-STATIC mp_obj_t pupdevices_UltrasonicSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pupdevices_UltrasonicSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port));
 
@@ -36,30 +36,30 @@ STATIC mp_obj_t pupdevices_UltrasonicSensor_make_new(const mp_obj_type_t *type, 
 }
 
 // pybricks.pupdevices.UltrasonicSensor.distance
-STATIC mp_obj_t get_distance(mp_obj_t self_in) {
+static mp_obj_t get_distance(mp_obj_t self_in) {
     int16_t *data = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_ULTRASONIC_SENSOR__DISTL);
     return mp_obj_new_int(data[0] < 0 || data[0] >= 2000 ? 2000 : data[0]);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_distance_obj, PBDRV_LEGODEV_MODE_PUP_ULTRASONIC_SENSOR__DISTL, get_distance);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_distance_obj, PBDRV_LEGODEV_MODE_PUP_ULTRASONIC_SENSOR__DISTL, get_distance);
 
 // pybricks.pupdevices.UltrasonicSensor.presence
-STATIC mp_obj_t get_presence(mp_obj_t self_in) {
+static mp_obj_t get_presence(mp_obj_t self_in) {
     int8_t *data = pb_type_device_get_data(self_in, PBDRV_LEGODEV_MODE_PUP_ULTRASONIC_SENSOR__LISTN);
     return mp_obj_new_bool(data[0]);
 }
-STATIC PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_presence_obj, PBDRV_LEGODEV_MODE_PUP_ULTRASONIC_SENSOR__LISTN, get_presence);
+static PB_DEFINE_CONST_TYPE_DEVICE_METHOD_OBJ(get_presence_obj, PBDRV_LEGODEV_MODE_PUP_ULTRASONIC_SENSOR__LISTN, get_presence);
 
-STATIC const pb_attr_dict_entry_t pupdevices_UltrasonicSensor_attr_dict[] = {
+static const pb_attr_dict_entry_t pupdevices_UltrasonicSensor_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_lights, pupdevices_UltrasonicSensor_obj_t, lights),
     PB_ATTR_DICT_SENTINEL
 };
 
 // dir(pybricks.pupdevices.UltrasonicSensor)
-STATIC const mp_rom_map_elem_t pupdevices_UltrasonicSensor_locals_dict_table[] = {
+static const mp_rom_map_elem_t pupdevices_UltrasonicSensor_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_distance),     MP_ROM_PTR(&get_distance_obj)              },
     { MP_ROM_QSTR(MP_QSTR_presence),     MP_ROM_PTR(&get_presence_obj)              },
 };
-STATIC MP_DEFINE_CONST_DICT(pupdevices_UltrasonicSensor_locals_dict, pupdevices_UltrasonicSensor_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pupdevices_UltrasonicSensor_locals_dict, pupdevices_UltrasonicSensor_locals_dict_table);
 
 // type(pybricks.pupdevices.UltrasonicSensor)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_pupdevices_UltrasonicSensor,

--- a/pybricks/pybricks.c
+++ b/pybricks/pybricks.c
@@ -24,11 +24,11 @@
 
 #include "genhdr/mpversion.h"
 
-STATIC const MP_DEFINE_STR_OBJ(pybricks_info_hub_obj, PYBRICKS_HUB_NAME);
-STATIC const MP_DEFINE_STR_OBJ(pybricks_info_release_obj, PBIO_VERSION_STR);
-STATIC const MP_DEFINE_STR_OBJ(pybricks_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
+static const MP_DEFINE_STR_OBJ(pybricks_info_hub_obj, PYBRICKS_HUB_NAME);
+static const MP_DEFINE_STR_OBJ(pybricks_info_release_obj, PBIO_VERSION_STR);
+static const MP_DEFINE_STR_OBJ(pybricks_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
 
-STATIC const mp_rom_obj_tuple_t pybricks_info_obj = {
+static const mp_rom_obj_tuple_t pybricks_info_obj = {
     {&mp_type_tuple},
     3,
     {
@@ -39,7 +39,7 @@ STATIC const mp_rom_obj_tuple_t pybricks_info_obj = {
 };
 
 #if MICROPY_MODULE_ATTR_DELEGATION
-STATIC void pb_package_pybricks_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+static void pb_package_pybricks_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     // This will get called when external imports tries to store the module
     // as an attribute to this package. This is not currently supported, but
     // it should not cause an exception, so indicate success.
@@ -47,14 +47,14 @@ STATIC void pb_package_pybricks_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest
 }
 #endif
 
-STATIC const mp_rom_map_elem_t pybricks_globals_table[] = {
+static const mp_rom_map_elem_t pybricks_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),            MP_ROM_QSTR(MP_QSTR_pybricks) },
     { MP_ROM_QSTR(MP_QSTR_version),             MP_ROM_PTR(&pybricks_info_obj)},
     #if MICROPY_MODULE_ATTR_DELEGATION
     MP_MODULE_ATTR_DELEGATION_ENTRY(&pb_package_pybricks_attr),
     #endif
 };
-STATIC MP_DEFINE_CONST_DICT(pb_package_pybricks_globals, pybricks_globals_table);
+static MP_DEFINE_CONST_DICT(pb_package_pybricks_globals, pybricks_globals_table);
 
 const mp_obj_module_t pb_package_pybricks = {
     .base = { &mp_type_module },

--- a/pybricks/robotics/pb_module_robotics.c
+++ b/pybricks/robotics/pb_module_robotics.c
@@ -11,7 +11,7 @@
 #include "py/builtin.h"
 #include "py/runtime.h"
 
-STATIC const mp_rom_map_elem_t robotics_globals_table[] = {
+static const mp_rom_map_elem_t robotics_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),    MP_ROM_QSTR(MP_QSTR_robotics)   },
     #if PYBRICKS_PY_COMMON_MOTORS
     { MP_ROM_QSTR(MP_QSTR_Car),         MP_ROM_PTR(&pb_type_car)        },
@@ -21,7 +21,7 @@ STATIC const mp_rom_map_elem_t robotics_globals_table[] = {
     #endif
     #endif
 };
-STATIC MP_DEFINE_CONST_DICT(pb_module_robotics_globals, robotics_globals_table);
+static MP_DEFINE_CONST_DICT(pb_module_robotics_globals, robotics_globals_table);
 
 const mp_obj_module_t pb_module_robotics = {
     .base = { &mp_type_module },

--- a/pybricks/robotics/pb_type_car.c
+++ b/pybricks/robotics/pb_type_car.c
@@ -36,7 +36,7 @@ typedef struct {
     int32_t max_angle;
 } pb_type_Car_obj_t;
 
-STATIC int32_t run_until_stalled_blocking(pbio_servo_t *srv, pbio_direction_t direction, mp_obj_t torque_limit_in) {
+static int32_t run_until_stalled_blocking(pbio_servo_t *srv, pbio_direction_t direction, mp_obj_t torque_limit_in) {
 
     pb_module_tools_assert_blocking();
 
@@ -70,7 +70,7 @@ STATIC int32_t run_until_stalled_blocking(pbio_servo_t *srv, pbio_direction_t di
 }
 
 // pybricks.robotics.Car.__init__
-STATIC mp_obj_t pb_type_Car_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pb_type_Car_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
 
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(steer_motor),
@@ -124,7 +124,7 @@ STATIC mp_obj_t pb_type_Car_make_new(const mp_obj_type_t *type, size_t n_args, s
 }
 
 // pybricks.robotics.Car.drive_power
-STATIC mp_obj_t pb_type_Car_drive_power(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Car_drive_power(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Car_obj_t, self,
         PB_ARG_REQUIRED(power));
@@ -142,10 +142,10 @@ STATIC mp_obj_t pb_type_Car_drive_power(size_t n_args, const mp_obj_t *pos_args,
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Car_drive_power_obj, 1, pb_type_Car_drive_power);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Car_drive_power_obj, 1, pb_type_Car_drive_power);
 
 // pybricks.robotics.Car.drive_speed
-STATIC mp_obj_t pb_type_Car_drive_speed(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Car_drive_speed(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Car_obj_t, self,
         PB_ARG_REQUIRED(speed));
@@ -158,10 +158,10 @@ STATIC mp_obj_t pb_type_Car_drive_speed(size_t n_args, const mp_obj_t *pos_args,
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Car_drive_speed_obj, 1, pb_type_Car_drive_speed);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Car_drive_speed_obj, 1, pb_type_Car_drive_speed);
 
 // pybricks.robotics.Car.steer
-STATIC mp_obj_t pb_type_Car_steer(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_Car_steer(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_Car_obj_t, self,
         PB_ARG_REQUIRED(percentage));
@@ -171,15 +171,15 @@ STATIC mp_obj_t pb_type_Car_steer(size_t n_args, const mp_obj_t *pos_args, mp_ma
     pb_assert(pbio_servo_track_target(self->srv_steer, angle));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Car_steer_obj, 1, pb_type_Car_steer);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_Car_steer_obj, 1, pb_type_Car_steer);
 
 // dir(pybricks.robotics.Car)
-STATIC const mp_rom_map_elem_t pb_type_Car_locals_dict_table[] = {
+static const mp_rom_map_elem_t pb_type_Car_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_drive_power),      MP_ROM_PTR(&pb_type_Car_drive_power_obj) },
     { MP_ROM_QSTR(MP_QSTR_drive_speed),      MP_ROM_PTR(&pb_type_Car_drive_speed_obj) },
     { MP_ROM_QSTR(MP_QSTR_steer),            MP_ROM_PTR(&pb_type_Car_steer_obj)       },
 };
-STATIC MP_DEFINE_CONST_DICT(pb_type_Car_locals_dict, pb_type_Car_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pb_type_Car_locals_dict, pb_type_Car_locals_dict_table);
 
 // type(pybricks.robotics.Car)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_car,

--- a/pybricks/robotics/pb_type_drivebase.c
+++ b/pybricks/robotics/pb_type_drivebase.c
@@ -39,7 +39,7 @@ struct _pb_type_DriveBase_obj_t {
 };
 
 // pybricks.robotics.DriveBase.reset
-STATIC mp_obj_t pb_type_DriveBase_reset(mp_obj_t self_in) {
+static mp_obj_t pb_type_DriveBase_reset(mp_obj_t self_in) {
     pb_type_DriveBase_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     int32_t distance, drive_speed, angle, turn_rate;
@@ -53,7 +53,7 @@ STATIC mp_obj_t pb_type_DriveBase_reset(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_DriveBase_reset_obj, pb_type_DriveBase_reset);
 
 // pybricks.robotics.DriveBase.__init__
-STATIC mp_obj_t pb_type_DriveBase_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pb_type_DriveBase_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
 
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(left_motor),
@@ -90,7 +90,7 @@ STATIC mp_obj_t pb_type_DriveBase_make_new(const mp_obj_type_t *type, size_t n_a
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC bool pb_type_DriveBase_test_completion(mp_obj_t self_in, uint32_t end_time) {
+static bool pb_type_DriveBase_test_completion(mp_obj_t self_in, uint32_t end_time) {
 
     pb_type_DriveBase_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -103,13 +103,13 @@ STATIC bool pb_type_DriveBase_test_completion(mp_obj_t self_in, uint32_t end_tim
     return pbio_drivebase_is_done(self->db);
 }
 
-STATIC void pb_type_DriveBase_cancel(mp_obj_t self_in) {
+static void pb_type_DriveBase_cancel(mp_obj_t self_in) {
     pb_type_DriveBase_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pb_assert(pbio_drivebase_stop(self->db, PBIO_CONTROL_ON_COMPLETION_COAST));
 }
 
 // All drive base methods use the same kind of completion awaitable.
-STATIC mp_obj_t await_or_wait(pb_type_DriveBase_obj_t *self) {
+static mp_obj_t await_or_wait(pb_type_DriveBase_obj_t *self) {
     return pb_type_awaitable_await_or_wait(
         MP_OBJ_FROM_PTR(self),
         self->awaitables,
@@ -121,7 +121,7 @@ STATIC mp_obj_t await_or_wait(pb_type_DriveBase_obj_t *self) {
 }
 
 // pybricks.robotics.DriveBase.straight
-STATIC mp_obj_t pb_type_DriveBase_straight(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_DriveBase_straight(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_DriveBase_obj_t, self,
         PB_ARG_REQUIRED(distance),
@@ -140,10 +140,10 @@ STATIC mp_obj_t pb_type_DriveBase_straight(size_t n_args, const mp_obj_t *pos_ar
     // Handle completion by awaiting or blocking.
     return await_or_wait(self);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_DriveBase_straight_obj, 1, pb_type_DriveBase_straight);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_DriveBase_straight_obj, 1, pb_type_DriveBase_straight);
 
 // pybricks.robotics.DriveBase.turn
-STATIC mp_obj_t pb_type_DriveBase_turn(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_DriveBase_turn(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_DriveBase_obj_t, self,
         PB_ARG_REQUIRED(angle),
@@ -163,10 +163,10 @@ STATIC mp_obj_t pb_type_DriveBase_turn(size_t n_args, const mp_obj_t *pos_args, 
     // Handle completion by awaiting or blocking.
     return await_or_wait(self);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_DriveBase_turn_obj, 1, pb_type_DriveBase_turn);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_DriveBase_turn_obj, 1, pb_type_DriveBase_turn);
 
 // pybricks.robotics.DriveBase.curve
-STATIC mp_obj_t pb_type_DriveBase_curve(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_DriveBase_curve(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_DriveBase_obj_t, self,
         PB_ARG_REQUIRED(radius),
@@ -187,10 +187,10 @@ STATIC mp_obj_t pb_type_DriveBase_curve(size_t n_args, const mp_obj_t *pos_args,
     // Handle completion by awaiting or blocking.
     return await_or_wait(self);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_DriveBase_curve_obj, 1, pb_type_DriveBase_curve);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_DriveBase_curve_obj, 1, pb_type_DriveBase_curve);
 
 // pybricks.robotics.DriveBase.drive
-STATIC mp_obj_t pb_type_DriveBase_drive(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_DriveBase_drive(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_DriveBase_obj_t, self,
         PB_ARG_REQUIRED(speed),
@@ -206,10 +206,10 @@ STATIC mp_obj_t pb_type_DriveBase_drive(size_t n_args, const mp_obj_t *pos_args,
     pb_assert(pbio_drivebase_drive_forever(self->db, speed, turn_rate));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_DriveBase_drive_obj, 1, pb_type_DriveBase_drive);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_DriveBase_drive_obj, 1, pb_type_DriveBase_drive);
 
 // pybricks.robotics.DriveBase.stop
-STATIC mp_obj_t pb_type_DriveBase_stop(mp_obj_t self_in) {
+static mp_obj_t pb_type_DriveBase_stop(mp_obj_t self_in) {
 
     // Cancel awaitables.
     pb_type_DriveBase_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -223,7 +223,7 @@ STATIC mp_obj_t pb_type_DriveBase_stop(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_DriveBase_stop_obj, pb_type_DriveBase_stop);
 
 // pybricks.robotics.DriveBase.brake
-STATIC mp_obj_t pb_type_DriveBase_brake(mp_obj_t self_in) {
+static mp_obj_t pb_type_DriveBase_brake(mp_obj_t self_in) {
 
     // Cancel awaitables.
     pb_type_DriveBase_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -237,7 +237,7 @@ STATIC mp_obj_t pb_type_DriveBase_brake(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_DriveBase_brake_obj, pb_type_DriveBase_brake);
 
 // pybricks.robotics.DriveBase.distance
-STATIC mp_obj_t pb_type_DriveBase_distance(mp_obj_t self_in) {
+static mp_obj_t pb_type_DriveBase_distance(mp_obj_t self_in) {
     pb_type_DriveBase_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     int32_t distance, _;
@@ -248,7 +248,7 @@ STATIC mp_obj_t pb_type_DriveBase_distance(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_DriveBase_distance_obj, pb_type_DriveBase_distance);
 
 // pybricks.robotics.DriveBase.angle
-STATIC mp_obj_t pb_type_DriveBase_angle(mp_obj_t self_in) {
+static mp_obj_t pb_type_DriveBase_angle(mp_obj_t self_in) {
     pb_type_DriveBase_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     int32_t heading, _;
@@ -259,7 +259,7 @@ STATIC mp_obj_t pb_type_DriveBase_angle(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_DriveBase_angle_obj, pb_type_DriveBase_angle);
 
 // pybricks.robotics.DriveBase.state
-STATIC mp_obj_t pb_type_DriveBase_state(mp_obj_t self_in) {
+static mp_obj_t pb_type_DriveBase_state(mp_obj_t self_in) {
     pb_type_DriveBase_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     int32_t distance, drive_speed, heading, turn_rate;
@@ -276,14 +276,14 @@ STATIC mp_obj_t pb_type_DriveBase_state(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_DriveBase_state_obj, pb_type_DriveBase_state);
 
 // pybricks.robotics.DriveBase.done
-STATIC mp_obj_t pb_type_DriveBase_done(mp_obj_t self_in) {
+static mp_obj_t pb_type_DriveBase_done(mp_obj_t self_in) {
     pb_type_DriveBase_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(pbio_drivebase_is_done(self->db));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_DriveBase_done_obj, pb_type_DriveBase_done);
 
 // pybricks.robotics.DriveBase.stalled
-STATIC mp_obj_t pb_type_DriveBase_stalled(mp_obj_t self_in) {
+static mp_obj_t pb_type_DriveBase_stalled(mp_obj_t self_in) {
     pb_type_DriveBase_obj_t *self = MP_OBJ_TO_PTR(self_in);
     bool stalled;
     uint32_t stall_duration;
@@ -293,7 +293,7 @@ STATIC mp_obj_t pb_type_DriveBase_stalled(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(pb_type_DriveBase_stalled_obj, pb_type_DriveBase_stalled);
 
 // pybricks.robotics.DriveBase.settings
-STATIC mp_obj_t pb_type_DriveBase_settings(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_DriveBase_settings(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_DriveBase_obj_t, self,
@@ -340,22 +340,22 @@ STATIC mp_obj_t pb_type_DriveBase_settings(size_t n_args, const mp_obj_t *pos_ar
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_DriveBase_settings_obj, 1, pb_type_DriveBase_settings);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_DriveBase_settings_obj, 1, pb_type_DriveBase_settings);
 
 #if PYBRICKS_PY_ROBOTICS_DRIVEBASE_GYRO
 // pybricks.robotics.DriveBase.use_gyro
-STATIC mp_obj_t pb_type_DriveBase_use_gyro(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_type_DriveBase_use_gyro(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_type_DriveBase_obj_t, self,
         PB_ARG_REQUIRED(use_gyro));
     pb_assert(pbio_drivebase_set_use_gyro(self->db, mp_obj_is_true(use_gyro_in)));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_DriveBase_use_gyro_obj, 1, pb_type_DriveBase_use_gyro);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_type_DriveBase_use_gyro_obj, 1, pb_type_DriveBase_use_gyro);
 #endif
 
 #if PYBRICKS_PY_COMMON_CONTROL
-STATIC const pb_attr_dict_entry_t pb_type_DriveBase_attr_dict[] = {
+static const pb_attr_dict_entry_t pb_type_DriveBase_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_heading_control, pb_type_DriveBase_obj_t, heading_control),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_distance_control, pb_type_DriveBase_obj_t, distance_control),
     PB_ATTR_DICT_SENTINEL
@@ -363,7 +363,7 @@ STATIC const pb_attr_dict_entry_t pb_type_DriveBase_attr_dict[] = {
 #endif
 
 // dir(pybricks.robotics.DriveBase)
-STATIC const mp_rom_map_elem_t pb_type_DriveBase_locals_dict_table[] = {
+static const mp_rom_map_elem_t pb_type_DriveBase_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_curve),            MP_ROM_PTR(&pb_type_DriveBase_curve_obj)    },
     { MP_ROM_QSTR(MP_QSTR_straight),         MP_ROM_PTR(&pb_type_DriveBase_straight_obj) },
     { MP_ROM_QSTR(MP_QSTR_turn),             MP_ROM_PTR(&pb_type_DriveBase_turn_obj)     },
@@ -382,7 +382,7 @@ STATIC const mp_rom_map_elem_t pb_type_DriveBase_locals_dict_table[] = {
     #endif
 };
 // First N entries are common to both drive base classes.
-STATIC MP_DEFINE_CONST_DICT(pb_type_DriveBase_locals_dict, pb_type_DriveBase_locals_dict_table);
+static MP_DEFINE_CONST_DICT(pb_type_DriveBase_locals_dict, pb_type_DriveBase_locals_dict_table);
 
 // type(pybricks.robotics.DriveBase)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_drivebase,

--- a/pybricks/robotics/pb_type_spikebase.c
+++ b/pybricks/robotics/pb_type_spikebase.c
@@ -30,7 +30,7 @@ typedef struct _robotics_SpikeBase_obj_t {
 } robotics_SpikeBase_obj_t;
 
 // pybricks.robotics.SpikeBase.__init__
-STATIC mp_obj_t robotics_SpikeBase_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t robotics_SpikeBase_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
 
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(left_motor),
@@ -55,7 +55,7 @@ STATIC mp_obj_t robotics_SpikeBase_make_new(const mp_obj_type_t *type, size_t n_
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC void wait_for_completion_drivebase(pbio_drivebase_t *db) {
+static void wait_for_completion_drivebase(pbio_drivebase_t *db) {
     while (!pbio_drivebase_is_done(db)) {
         mp_hal_delay_ms(5);
     }
@@ -65,7 +65,7 @@ STATIC void wait_for_completion_drivebase(pbio_drivebase_t *db) {
 }
 
 // pybricks.robotics.SpikeBase.tank_move_for_degrees
-STATIC mp_obj_t robotics_SpikeBase_tank_move_for_degrees(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t robotics_SpikeBase_tank_move_for_degrees(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         robotics_SpikeBase_obj_t, self,
         PB_ARG_REQUIRED(speed_left),
@@ -87,10 +87,10 @@ STATIC mp_obj_t robotics_SpikeBase_tank_move_for_degrees(size_t n_args, const mp
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(robotics_SpikeBase_tank_move_for_degrees_obj, 1, robotics_SpikeBase_tank_move_for_degrees);
+static MP_DEFINE_CONST_FUN_OBJ_KW(robotics_SpikeBase_tank_move_for_degrees_obj, 1, robotics_SpikeBase_tank_move_for_degrees);
 
 // pybricks.robotics.SpikeBase.steering_move_for_degrees
-STATIC mp_obj_t robotics_SpikeBase_steering_move_for_degrees(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t robotics_SpikeBase_steering_move_for_degrees(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         robotics_SpikeBase_obj_t, self,
         PB_ARG_REQUIRED(speed),
@@ -117,10 +117,10 @@ STATIC mp_obj_t robotics_SpikeBase_steering_move_for_degrees(size_t n_args, cons
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(robotics_SpikeBase_steering_move_for_degrees_obj, 1, robotics_SpikeBase_steering_move_for_degrees);
+static MP_DEFINE_CONST_FUN_OBJ_KW(robotics_SpikeBase_steering_move_for_degrees_obj, 1, robotics_SpikeBase_steering_move_for_degrees);
 
 // pybricks.robotics.SpikeBase.tank_move_for_time
-STATIC mp_obj_t robotics_SpikeBase_tank_move_for_time(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t robotics_SpikeBase_tank_move_for_time(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         robotics_SpikeBase_obj_t, self,
         PB_ARG_REQUIRED(speed_left),
@@ -142,10 +142,10 @@ STATIC mp_obj_t robotics_SpikeBase_tank_move_for_time(size_t n_args, const mp_ob
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(robotics_SpikeBase_tank_move_for_time_obj, 1, robotics_SpikeBase_tank_move_for_time);
+static MP_DEFINE_CONST_FUN_OBJ_KW(robotics_SpikeBase_tank_move_for_time_obj, 1, robotics_SpikeBase_tank_move_for_time);
 
 // pybricks.robotics.SpikeBase.steering_move_for_time
-STATIC mp_obj_t robotics_SpikeBase_steering_move_for_time(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t robotics_SpikeBase_steering_move_for_time(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         robotics_SpikeBase_obj_t, self,
         PB_ARG_REQUIRED(speed),
@@ -172,10 +172,10 @@ STATIC mp_obj_t robotics_SpikeBase_steering_move_for_time(size_t n_args, const m
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(robotics_SpikeBase_steering_move_for_time_obj, 1, robotics_SpikeBase_steering_move_for_time);
+static MP_DEFINE_CONST_FUN_OBJ_KW(robotics_SpikeBase_steering_move_for_time_obj, 1, robotics_SpikeBase_steering_move_for_time);
 
 // pybricks.robotics.SpikeBase.tank_move_forever
-STATIC mp_obj_t robotics_SpikeBase_tank_move_forever(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t robotics_SpikeBase_tank_move_forever(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         robotics_SpikeBase_obj_t, self,
         PB_ARG_REQUIRED(speed_left),
@@ -189,10 +189,10 @@ STATIC mp_obj_t robotics_SpikeBase_tank_move_forever(size_t n_args, const mp_obj
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(robotics_SpikeBase_tank_move_forever_obj, 1, robotics_SpikeBase_tank_move_forever);
+static MP_DEFINE_CONST_FUN_OBJ_KW(robotics_SpikeBase_tank_move_forever_obj, 1, robotics_SpikeBase_tank_move_forever);
 
 // pybricks.robotics.SpikeBase.steering_move_forever
-STATIC mp_obj_t robotics_SpikeBase_steering_move_forever(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t robotics_SpikeBase_steering_move_forever(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         robotics_SpikeBase_obj_t, self,
         PB_ARG_REQUIRED(speed),
@@ -210,17 +210,17 @@ STATIC mp_obj_t robotics_SpikeBase_steering_move_forever(size_t n_args, const mp
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(robotics_SpikeBase_steering_move_forever_obj, 1, robotics_SpikeBase_steering_move_forever);
+static MP_DEFINE_CONST_FUN_OBJ_KW(robotics_SpikeBase_steering_move_forever_obj, 1, robotics_SpikeBase_steering_move_forever);
 
 // pybricks.robotics.SpikeBase.stop
-STATIC mp_obj_t robotics_SpikeBase_stop(mp_obj_t self_in) {
+static mp_obj_t robotics_SpikeBase_stop(mp_obj_t self_in) {
     robotics_SpikeBase_obj_t *self = MP_OBJ_TO_PTR(self_in);
     pb_assert(pbio_drivebase_stop(self->db, PBIO_CONTROL_ON_COMPLETION_COAST));
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_1(robotics_SpikeBase_stop_obj, robotics_SpikeBase_stop);
 
-STATIC const pb_attr_dict_entry_t robotics_SpikeBase_attr_dict[] = {
+static const pb_attr_dict_entry_t robotics_SpikeBase_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_left, robotics_SpikeBase_obj_t, left),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_right, robotics_SpikeBase_obj_t, right),
     #if PYBRICKS_PY_COMMON_CONTROL
@@ -231,7 +231,7 @@ STATIC const pb_attr_dict_entry_t robotics_SpikeBase_attr_dict[] = {
 };
 
 // dir(pybricks.robotics.SpikeBase)
-STATIC const mp_rom_map_elem_t robotics_SpikeBase_locals_dict_table[] = {
+static const mp_rom_map_elem_t robotics_SpikeBase_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_tank_move_for_degrees),     MP_ROM_PTR(&robotics_SpikeBase_tank_move_for_degrees_obj)     },
     { MP_ROM_QSTR(MP_QSTR_tank_move_for_time),        MP_ROM_PTR(&robotics_SpikeBase_tank_move_for_time_obj)        },
     { MP_ROM_QSTR(MP_QSTR_tank_move_forever),         MP_ROM_PTR(&robotics_SpikeBase_tank_move_forever_obj)             },
@@ -240,7 +240,7 @@ STATIC const mp_rom_map_elem_t robotics_SpikeBase_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_steering_move_forever),     MP_ROM_PTR(&robotics_SpikeBase_steering_move_forever_obj)     },
     { MP_ROM_QSTR(MP_QSTR_stop),                      MP_ROM_PTR(&robotics_SpikeBase_stop_obj)                      },
 };
-STATIC MP_DEFINE_CONST_DICT(robotics_SpikeBase_locals_dict, robotics_SpikeBase_locals_dict_table);
+static MP_DEFINE_CONST_DICT(robotics_SpikeBase_locals_dict, robotics_SpikeBase_locals_dict_table);
 
 // type(pybricks.robotics.SpikeBase)
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_spikebase,

--- a/pybricks/tools/pb_module_tools.c
+++ b/pybricks/tools/pb_module_tools.c
@@ -30,7 +30,7 @@
 
 // Global state of the run loop for async user programs. Gets set when run_task
 // is called and cleared when it completes
-STATIC bool run_loop_is_active;
+static bool run_loop_is_active;
 
 bool pb_module_tools_run_loop_is_active(void) {
     return run_loop_is_active;
@@ -48,11 +48,11 @@ void pb_module_tools_assert_blocking(void) {
 // us share the same code with other awaitables. It also minimizes allocation.
 MP_REGISTER_ROOT_POINTER(mp_obj_t wait_awaitables);
 
-STATIC bool pb_module_tools_wait_test_completion(mp_obj_t obj, uint32_t end_time) {
+static bool pb_module_tools_wait_test_completion(mp_obj_t obj, uint32_t end_time) {
     return mp_hal_ticks_ms() - end_time < UINT32_MAX / 2;
 }
 
-STATIC mp_obj_t pb_module_tools_wait(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_module_tools_wait(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_FUNCTION(n_args, pos_args, kw_args,
         PB_ARG_REQUIRED(time));
 
@@ -80,7 +80,7 @@ STATIC mp_obj_t pb_module_tools_wait(size_t n_args, const mp_obj_t *pos_args, mp
         pb_type_awaitable_cancel_none,
         PB_TYPE_AWAITABLE_OPT_NONE);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_module_tools_wait_obj, 0, pb_module_tools_wait);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_module_tools_wait_obj, 0, pb_module_tools_wait);
 
 /**
  * Waits for a task to complete.
@@ -133,7 +133,7 @@ void pb_module_tools_pbio_task_do_blocking(pbio_task_t *task, mp_int_t timeout) 
 // here instead of with each Bluetooth-related MicroPython object.
 MP_REGISTER_ROOT_POINTER(mp_obj_t pbio_task_awaitables);
 
-STATIC bool pb_module_tools_pbio_task_test_completion(mp_obj_t obj, uint32_t end_time) {
+static bool pb_module_tools_pbio_task_test_completion(mp_obj_t obj, uint32_t end_time) {
     pbio_task_t *task = MP_OBJ_TO_PTR(obj);
 
     // Keep going if not done yet.
@@ -171,7 +171,7 @@ mp_obj_t pb_module_tools_pbio_task_wait_or_await(pbio_task_t *task) {
  * @returns The resulting byte if there was one, converted as above, otherwise @c None .
  *
  */
-STATIC mp_obj_t pb_module_tools_read_input_byte(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_module_tools_read_input_byte(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_FUNCTION(n_args, pos_args, kw_args,
         PB_ARG_DEFAULT_FALSE(last),
         PB_ARG_DEFAULT_FALSE(chr));
@@ -209,9 +209,9 @@ STATIC mp_obj_t pb_module_tools_read_input_byte(size_t n_args, const mp_obj_t *p
     const char result[] = {chr};
     return mp_obj_new_str(result, sizeof(result));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_module_tools_read_input_byte_obj, 0, pb_module_tools_read_input_byte);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_module_tools_read_input_byte_obj, 0, pb_module_tools_read_input_byte);
 
-STATIC mp_obj_t pb_module_tools_run_task(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pb_module_tools_run_task(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_FUNCTION(n_args, pos_args, kw_args,
         PB_ARG_DEFAULT_NONE(task),
         PB_ARG_DEFAULT_INT(loop_time, 10));
@@ -260,7 +260,7 @@ STATIC mp_obj_t pb_module_tools_run_task(size_t n_args, const mp_obj_t *pos_args
     }
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(pb_module_tools_run_task_obj, 0, pb_module_tools_run_task);
+static MP_DEFINE_CONST_FUN_OBJ_KW(pb_module_tools_run_task_obj, 0, pb_module_tools_run_task);
 
 // Reset global awaitable state when user program starts.
 void pb_module_tools_init(void) {
@@ -271,7 +271,7 @@ void pb_module_tools_init(void) {
 
 #if PYBRICKS_PY_TOOLS_HUB_MENU
 
-STATIC void pb_module_tools_hub_menu_display_symbol(mp_obj_t symbol) {
+static void pb_module_tools_hub_menu_display_symbol(mp_obj_t symbol) {
     if (mp_obj_is_str(symbol)) {
         pb_type_LightMatrix_display_char(pbsys_hub_light_matrix, symbol);
     } else {
@@ -285,7 +285,7 @@ STATIC void pb_module_tools_hub_menu_display_symbol(mp_obj_t symbol) {
  * @param [in]  press   Choose @c true to wait for press or @c false to wait for release.
  * @returns             When waiting for pressed, it returns the button that was pressed, otherwise returns 0.
  */
-STATIC pbio_button_flags_t pb_module_tools_hub_menu_wait_for_press(bool press) {
+static pbio_button_flags_t pb_module_tools_hub_menu_wait_for_press(bool press) {
 
     // This function should only be used in a blocking context.
     pb_module_tools_assert_blocking();
@@ -306,7 +306,7 @@ STATIC pbio_button_flags_t pb_module_tools_hub_menu_wait_for_press(bool press) {
  * @param [in]  n_args  The number of args.
  * @param [in]  args    The args passed in Python code (the menu entries).
  */
-STATIC mp_obj_t pb_module_tools_hub_menu(size_t n_args, const mp_obj_t *args) {
+static mp_obj_t pb_module_tools_hub_menu(size_t n_args, const mp_obj_t *args) {
 
     // Validate arguments by displaying all of them, ending with the first.
     // This ensures we fail right away instead of midway through the menu. It
@@ -359,11 +359,11 @@ STATIC mp_obj_t pb_module_tools_hub_menu(size_t n_args, const mp_obj_t *args) {
         return mp_const_none;
     }
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(pb_module_tools_hub_menu_obj, 2, pb_module_tools_hub_menu);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(pb_module_tools_hub_menu_obj, 2, pb_module_tools_hub_menu);
 
 #endif // PYBRICKS_PY_TOOLS_HUB_MENU
 
-STATIC const mp_rom_map_elem_t tools_globals_table[] = {
+static const mp_rom_map_elem_t tools_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),    MP_ROM_QSTR(MP_QSTR_tools)                    },
     { MP_ROM_QSTR(MP_QSTR_wait),        MP_ROM_PTR(&pb_module_tools_wait_obj)         },
     { MP_ROM_QSTR(MP_QSTR_read_input_byte), MP_ROM_PTR(&pb_module_tools_read_input_byte_obj) },
@@ -381,7 +381,7 @@ STATIC const mp_rom_map_elem_t tools_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_Axis),        MP_ROM_PTR(&pb_enum_type_Axis) },
     #endif // MICROPY_PY_BUILTINS_FLOAT
 };
-STATIC MP_DEFINE_CONST_DICT(pb_module_tools_globals, tools_globals_table);
+static MP_DEFINE_CONST_DICT(pb_module_tools_globals, tools_globals_table);
 
 const mp_obj_module_t pb_module_tools = {
     .base = { &mp_type_module },

--- a/pybricks/tools/pb_type_awaitable.c
+++ b/pybricks/tools/pb_type_awaitable.c
@@ -43,7 +43,7 @@ struct _pb_type_awaitable_obj_t {
 };
 
 // close() cancels the awaitable.
-STATIC mp_obj_t pb_type_awaitable_close(mp_obj_t self_in) {
+static mp_obj_t pb_type_awaitable_close(mp_obj_t self_in) {
     pb_type_awaitable_obj_t *self = MP_OBJ_TO_PTR(self_in);
     self->test_completion = AWAITABLE_FREE;
     // Handle optional clean up/cancelling of hardware operation.
@@ -52,9 +52,9 @@ STATIC mp_obj_t pb_type_awaitable_close(mp_obj_t self_in) {
     }
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_awaitable_close_obj, pb_type_awaitable_close);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_type_awaitable_close_obj, pb_type_awaitable_close);
 
-STATIC mp_obj_t pb_type_awaitable_iternext(mp_obj_t self_in) {
+static mp_obj_t pb_type_awaitable_iternext(mp_obj_t self_in) {
     pb_type_awaitable_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     // If completed callback was unset, then we completed previously.
@@ -79,7 +79,7 @@ STATIC mp_obj_t pb_type_awaitable_iternext(mp_obj_t self_in) {
     return mp_make_stop_iteration(self->return_value(self->obj));
 }
 
-STATIC const mp_rom_map_elem_t pb_type_awaitable_locals_dict_table[] = {
+static const mp_rom_map_elem_t pb_type_awaitable_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_close), MP_ROM_PTR(&pb_type_awaitable_close_obj) },
 };
 MP_DEFINE_CONST_DICT(pb_type_awaitable_locals_dict, pb_type_awaitable_locals_dict_table);
@@ -97,7 +97,7 @@ MP_DEFINE_CONST_OBJ_TYPE(pb_type_awaitable,
  *
  * @param [in] awaitables_in        List of awaitables associated with @p obj.
  */
-STATIC pb_type_awaitable_obj_t *pb_type_awaitable_get(mp_obj_t awaitables_in) {
+static pb_type_awaitable_obj_t *pb_type_awaitable_get(mp_obj_t awaitables_in) {
 
     mp_obj_list_t *awaitables = MP_OBJ_TO_PTR(awaitables_in);
 
@@ -127,7 +127,7 @@ STATIC pb_type_awaitable_obj_t *pb_type_awaitable_get(mp_obj_t awaitables_in) {
  * checker. This allows MicroPython to handle completion during the next call
  * to iternext.
  */
-STATIC bool pb_type_awaitable_completed(mp_obj_t self_in, uint32_t start_time) {
+static bool pb_type_awaitable_completed(mp_obj_t self_in, uint32_t start_time) {
     return true;
 }
 

--- a/pybricks/tools/pb_type_matrix.c
+++ b/pybricks/tools/pb_type_matrix.c
@@ -17,7 +17,7 @@
 #if MICROPY_PY_BUILTINS_FLOAT
 
 // pybricks.tools.Matrix.__init__
-STATIC mp_obj_t pb_type_Matrix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pb_type_Matrix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(rows));
 
@@ -178,7 +178,7 @@ void pb_type_Matrix_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
 }
 
 // pybricks.tools.Matrix._add
-STATIC mp_obj_t pb_type_Matrix__add(mp_obj_t lhs_obj, mp_obj_t rhs_obj, bool add) {
+static mp_obj_t pb_type_Matrix__add(mp_obj_t lhs_obj, mp_obj_t rhs_obj, bool add) {
 
     // Get left and right matrices
     pb_type_Matrix_obj_t *lhs = MP_OBJ_TO_PTR(lhs_obj);
@@ -222,7 +222,7 @@ STATIC mp_obj_t pb_type_Matrix__add(mp_obj_t lhs_obj, mp_obj_t rhs_obj, bool add
 }
 
 // pybricks.tools.Matrix._mul
-STATIC mp_obj_t pb_type_Matrix__mul(mp_obj_t lhs_in, mp_obj_t rhs_in) {
+static mp_obj_t pb_type_Matrix__mul(mp_obj_t lhs_in, mp_obj_t rhs_in) {
 
     // Get left and right matrices
     pb_type_Matrix_obj_t *lhs = MP_OBJ_TO_PTR(lhs_in);
@@ -272,7 +272,7 @@ STATIC mp_obj_t pb_type_Matrix__mul(mp_obj_t lhs_in, mp_obj_t rhs_in) {
 }
 
 // pybricks.tools.Matrix._scale
-STATIC mp_obj_t pb_type_Matrix__scale(mp_obj_t self_in, float scale) {
+static mp_obj_t pb_type_Matrix__scale(mp_obj_t self_in, float scale) {
     pb_type_Matrix_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     pb_type_Matrix_obj_t *copy = mp_obj_malloc(pb_type_Matrix_obj_t, &pb_type_Matrix);
@@ -300,7 +300,7 @@ float pb_type_Matrix_get_scalar(mp_obj_t self_in, size_t r, size_t c) {
 }
 
 // pybricks.tools.Matrix._T
-STATIC mp_obj_t pb_type_Matrix__T(mp_obj_t self_in) {
+static mp_obj_t pb_type_Matrix__T(mp_obj_t self_in) {
     pb_type_Matrix_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     pb_type_Matrix_obj_t *copy = mp_obj_malloc(pb_type_Matrix_obj_t, &pb_type_Matrix);
@@ -315,7 +315,7 @@ STATIC mp_obj_t pb_type_Matrix__T(mp_obj_t self_in) {
     return MP_OBJ_FROM_PTR(copy);
 }
 
-STATIC void pb_type_Matrix_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+static void pb_type_Matrix_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     // Read only
     if (dest[0] == MP_OBJ_NULL) {
         // Create and return transpose
@@ -338,7 +338,7 @@ STATIC void pb_type_Matrix_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     }
 }
 
-STATIC mp_obj_t pb_type_Matrix_unary_op(mp_unary_op_t op, mp_obj_t o_in) {
+static mp_obj_t pb_type_Matrix_unary_op(mp_unary_op_t op, mp_obj_t o_in) {
 
     pb_type_Matrix_obj_t *self = MP_OBJ_TO_PTR(o_in);
 
@@ -372,7 +372,7 @@ STATIC mp_obj_t pb_type_Matrix_unary_op(mp_unary_op_t op, mp_obj_t o_in) {
     }
 }
 
-STATIC mp_obj_t pb_type_Matrix_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
+static mp_obj_t pb_type_Matrix_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
 
     switch (op) {
         case MP_BINARY_OP_ADD:
@@ -402,7 +402,7 @@ STATIC mp_obj_t pb_type_Matrix_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_
     }
 }
 
-STATIC mp_obj_t pb_type_Matrix_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value_in) {
+static mp_obj_t pb_type_Matrix_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value_in) {
 
     pb_type_Matrix_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -473,7 +473,7 @@ typedef struct {
 _Static_assert(sizeof(pb_type_Matrix_it_t) <= sizeof(mp_obj_iter_buf_t),
     "pb_type_Matrix_it_t uses memory allocated for mp_obj_iter_buf_t");
 
-STATIC mp_obj_t pb_type_Matrix_it_iternext(mp_obj_t self_in) {
+static mp_obj_t pb_type_Matrix_it_iternext(mp_obj_t self_in) {
     pb_type_Matrix_it_t *self = MP_OBJ_TO_PTR(self_in);
     pb_type_Matrix_obj_t *matrix = MP_OBJ_TO_PTR(self->matrix);
 
@@ -484,7 +484,7 @@ STATIC mp_obj_t pb_type_Matrix_it_iternext(mp_obj_t self_in) {
     return MP_OBJ_STOP_ITERATION;
 }
 
-STATIC mp_obj_t pb_type_Matrix_it_iterprev(mp_obj_t self_in) {
+static mp_obj_t pb_type_Matrix_it_iterprev(mp_obj_t self_in) {
     pb_type_Matrix_it_t *self = MP_OBJ_TO_PTR(self_in);
     pb_type_Matrix_obj_t *matrix = MP_OBJ_TO_PTR(self->matrix);
 
@@ -495,7 +495,7 @@ STATIC mp_obj_t pb_type_Matrix_it_iterprev(mp_obj_t self_in) {
     return MP_OBJ_STOP_ITERATION;
 }
 
-STATIC mp_obj_t pb_type_Matrix_getiter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf) {
+static mp_obj_t pb_type_Matrix_getiter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf) {
     pb_type_Matrix_obj_t *matrix = MP_OBJ_TO_PTR(o_in);
     pb_type_Matrix_it_t *matrix_it = (pb_type_Matrix_it_t *)iter_buf;
 
@@ -563,7 +563,7 @@ mp_obj_t pb_type_Matrix_make_bitmap(size_t m, size_t n, float scale, uint32_t sr
 }
 
 // pybricks.tools.vector
-STATIC mp_obj_t pb_geometry_vector(size_t n_args, const mp_obj_t *args) {
+static mp_obj_t pb_geometry_vector(size_t n_args, const mp_obj_t *args) {
 
     // Convert user object to floats
     float data[3];
@@ -577,7 +577,7 @@ STATIC mp_obj_t pb_geometry_vector(size_t n_args, const mp_obj_t *args) {
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pb_geometry_vector_obj, 2, 3, pb_geometry_vector);
 
 // pybricks.tools.cross
-STATIC mp_obj_t pb_type_matrix_cross(mp_obj_t a_in, mp_obj_t b_in) {
+static mp_obj_t pb_type_matrix_cross(mp_obj_t a_in, mp_obj_t b_in) {
 
     // Get a and b vectors
     pb_type_Matrix_obj_t *a = MP_OBJ_TO_PTR(a_in);

--- a/pybricks/tools/pb_type_stopwatch.c
+++ b/pybricks/tools/pb_type_stopwatch.c
@@ -21,25 +21,25 @@ typedef struct _tools_StopWatch_obj_t {
     bool running;
 } tools_StopWatch_obj_t;
 
-STATIC mp_obj_t tools_StopWatch_reset(mp_obj_t self_in) {
+static mp_obj_t tools_StopWatch_reset(mp_obj_t self_in) {
     tools_StopWatch_obj_t *self = MP_OBJ_TO_PTR(self_in);
     self->time_start = mp_hal_ticks_ms();
     self->time_stop = self->time_start;
     self->time_spent_pausing = 0;
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(tools_StopWatch_reset_obj, tools_StopWatch_reset);
+static MP_DEFINE_CONST_FUN_OBJ_1(tools_StopWatch_reset_obj, tools_StopWatch_reset);
 
-STATIC mp_obj_t tools_StopWatch_time(mp_obj_t self_in) {
+static mp_obj_t tools_StopWatch_time(mp_obj_t self_in) {
     tools_StopWatch_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int_from_uint(
         self->running ?
         mp_hal_ticks_ms() - self->time_start - self->time_spent_pausing :
         self->time_stop - self->time_start - self->time_spent_pausing);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(tools_StopWatch_time_obj, tools_StopWatch_time);
+static MP_DEFINE_CONST_FUN_OBJ_1(tools_StopWatch_time_obj, tools_StopWatch_time);
 
-STATIC mp_obj_t tools_StopWatch_pause(mp_obj_t self_in) {
+static mp_obj_t tools_StopWatch_pause(mp_obj_t self_in) {
     tools_StopWatch_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->running) {
         self->running = false;
@@ -47,15 +47,15 @@ STATIC mp_obj_t tools_StopWatch_pause(mp_obj_t self_in) {
     }
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(tools_StopWatch_pause_obj, tools_StopWatch_pause);
+static MP_DEFINE_CONST_FUN_OBJ_1(tools_StopWatch_pause_obj, tools_StopWatch_pause);
 
-STATIC mp_obj_t tools_StopWatch_running(mp_obj_t self_in) {
+static mp_obj_t tools_StopWatch_running(mp_obj_t self_in) {
     tools_StopWatch_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(self->running);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(tools_StopWatch_running_obj, tools_StopWatch_running);
+static MP_DEFINE_CONST_FUN_OBJ_1(tools_StopWatch_running_obj, tools_StopWatch_running);
 
-STATIC mp_obj_t tools_StopWatch_resume(mp_obj_t self_in) {
+static mp_obj_t tools_StopWatch_resume(mp_obj_t self_in) {
     tools_StopWatch_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (!self->running) {
         self->running = true;
@@ -63,9 +63,9 @@ STATIC mp_obj_t tools_StopWatch_resume(mp_obj_t self_in) {
     }
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(tools_StopWatch_resume_obj, tools_StopWatch_resume);
+static MP_DEFINE_CONST_FUN_OBJ_1(tools_StopWatch_resume_obj, tools_StopWatch_resume);
 
-STATIC mp_obj_t tools_StopWatch_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t tools_StopWatch_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     tools_StopWatch_obj_t *self = m_new_obj(tools_StopWatch_obj_t);
     self->base.type = type;
     self->running = false;
@@ -74,14 +74,14 @@ STATIC mp_obj_t tools_StopWatch_make_new(const mp_obj_type_t *type, size_t n_arg
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC const mp_rom_map_elem_t tools_StopWatch_locals_dict_table[] = {
+static const mp_rom_map_elem_t tools_StopWatch_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_reset), MP_ROM_PTR(&tools_StopWatch_reset_obj) },
     { MP_ROM_QSTR(MP_QSTR_time), MP_ROM_PTR(&tools_StopWatch_time_obj) },
     { MP_ROM_QSTR(MP_QSTR_pause), MP_ROM_PTR(&tools_StopWatch_pause_obj) },
     { MP_ROM_QSTR(MP_QSTR_resume), MP_ROM_PTR(&tools_StopWatch_resume_obj) },
     { MP_ROM_QSTR(MP_QSTR_running), MP_ROM_PTR(&tools_StopWatch_running_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(tools_StopWatch_locals_dict, tools_StopWatch_locals_dict_table);
+static MP_DEFINE_CONST_DICT(tools_StopWatch_locals_dict, tools_StopWatch_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(pb_type_StopWatch,
     MP_QSTR_StopWatch,

--- a/pybricks/tools/pb_type_task.c
+++ b/pybricks/tools/pb_type_task.c
@@ -44,7 +44,7 @@ typedef struct {
 } pb_type_Task_obj_t;
 
 // Cancel all tasks by calling their close methods.
-STATIC mp_obj_t pb_type_Task_close(mp_obj_t self_in) {
+static mp_obj_t pb_type_Task_close(mp_obj_t self_in) {
     pb_type_Task_obj_t *self = MP_OBJ_TO_PTR(self_in);
     for (size_t i = 0; i < self->num_tasks; i++) {
         pb_type_Task_progress_t *task = &self->tasks[i];
@@ -63,9 +63,9 @@ STATIC mp_obj_t pb_type_Task_close(mp_obj_t self_in) {
     }
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Task_close_obj, pb_type_Task_close);
+static MP_DEFINE_CONST_FUN_OBJ_1(pb_type_Task_close_obj, pb_type_Task_close);
 
-STATIC mp_obj_t pb_type_Task_iternext(mp_obj_t self_in) {
+static mp_obj_t pb_type_Task_iternext(mp_obj_t self_in) {
     pb_type_Task_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     // Do one iteration of each task.
@@ -130,12 +130,12 @@ STATIC mp_obj_t pb_type_Task_iternext(mp_obj_t self_in) {
     }
 }
 
-STATIC const mp_rom_map_elem_t pb_type_Task_locals_dict_table[] = {
+static const mp_rom_map_elem_t pb_type_Task_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_close), MP_ROM_PTR(&pb_type_Task_close_obj) },
 };
 MP_DEFINE_CONST_DICT(pb_type_Task_locals_dict, pb_type_Task_locals_dict_table);
 
-STATIC mp_obj_t pb_type_Task_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t pb_type_Task_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
 
     // Whether to race until one task is done (True) or wait for all tasks (False).
     bool race = n_kw == 1 && mp_obj_is_true(args[n_args - 1]);

--- a/pybricks/util_mp/pb_kwarg_helper.h
+++ b/pybricks/util_mp/pb_kwarg_helper.h
@@ -55,7 +55,7 @@
 #define GEN_ARG_OBJ(IDX, arg_spec) mp_obj_t GET_ARG_NAME arg_spec = parsed_args[IDX].u_obj;
 
 // Create the arguments table, parse it, and declare mp_obj_t's for each one
-#define PB_PARSE_GENERIC(n_args, pos_args, kw_args, n_ignore, ...) STATIC const mp_arg_t allowed_args[] = { \
+#define PB_PARSE_GENERIC(n_args, pos_args, kw_args, n_ignore, ...) static const mp_arg_t allowed_args[] = { \
         FOR_EACH_IDX(PB_ARG_DO, __VA_ARGS__) \
 }; \
     PB_PARSE_ARGS(parsed_args, n_args, pos_args, kw_args, allowed_args, n_ignore); \

--- a/pybricks/util_pb/pb_color_map.c
+++ b/pybricks/util_pb/pb_color_map.c
@@ -44,7 +44,7 @@ void pb_color_map_rgb_to_hsv(const pbio_color_rgb_t *rgb, pbio_color_hsv_t *hsv)
     hsv->v = hsv->v * (200 - hsv->v) / 100;
 }
 
-STATIC const mp_rom_obj_tuple_t pb_color_map_default = {
+static const mp_rom_obj_tuple_t pb_color_map_default = {
     {&mp_type_tuple},
     6,
     {
@@ -98,7 +98,7 @@ typedef struct _pb_ColorSensor_obj_t {
 } pb_ColorSensor_obj_t;
 
 // pybricks._common.ColorDistanceSensor.detectable_colors
-STATIC mp_obj_t pupdevices_ColorDistanceSensor_detectable_colors(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pupdevices_ColorDistanceSensor_detectable_colors(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     PB_PARSE_ARGS_METHOD(n_args, pos_args, kw_args,
         pb_ColorSensor_obj_t, self,
         PB_ARG_DEFAULT_NONE(colors));


### PR DESCRIPTION
Upstream MicroPython removed the `STATIC` macro in v1.23. So to prepare for future updates, remove all uses of this macro.