### PR TITLE
pybricks.tools.wait: Fix awaiting on wait(0).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,11 @@
 ### Fixed
 - Fixed not able to connect to new Technic Move hub with `LWP3Device()`.
 - Removed `gc_collect()` from `tools.run_task()` loop to fix unwanted delays.
+- Fixed `await wait(0)` never yielding, so parallel tasks could lock up ([support#1429]).
 
 [pybricks-micropython#250]: https://github.com/pybricks/pybricks-micropython/pull/250
 [pybricks-micropython#253]: https://github.com/pybricks/pybricks-micropython/pull/253
+[support#1429]: https://github.com/pybricks/support/issues/1429
 [support#1615]: https://github.com/pybricks/support/issues/1615
 [support#1622]: https://github.com/pybricks/support/issues/1622
 [support#1678]: https://github.com/pybricks/support/issues/1678

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,16 @@
 - Removed `gc_collect()` from `tools.run_task()` loop to fix unwanted delays.
 - Fixed `await wait(0)` never yielding, so parallel tasks could lock up ([support#1429]).
 
+### Removed
+- Removed `loop_time` argument to `pybricks.tools.run_task` as this wasn't
+  having the desired effect, and would cause loop round trips to take `10 ms`
+  for every `await wait(1)` ([support#1460]). Passing the argument is still
+  allowed for backwards compatibility, but it won't do anything.
+
 [pybricks-micropython#250]: https://github.com/pybricks/pybricks-micropython/pull/250
 [pybricks-micropython#253]: https://github.com/pybricks/pybricks-micropython/pull/253
 [support#1429]: https://github.com/pybricks/support/issues/1429
+[support#1460]: https://github.com/pybricks/support/issues/1460
 [support#1615]: https://github.com/pybricks/support/issues/1615
 [support#1622]: https://github.com/pybricks/support/issues/1622
 [support#1678]: https://github.com/pybricks/support/issues/1678

--- a/pybricks/tools/pb_module_tools.c
+++ b/pybricks/tools/pb_module_tools.c
@@ -75,7 +75,7 @@ static mp_obj_t pb_module_tools_wait(size_t n_args, const mp_obj_t *pos_args, mp
         NULL, // wait functions are not associated with an object
         MP_STATE_PORT(wait_awaitables),
         mp_hal_ticks_ms() + time,
-        pb_module_tools_wait_test_completion,
+        time > 0 ? pb_module_tools_wait_test_completion : pb_type_awaitable_test_completion_yield_once,
         pb_type_awaitable_return_none,
         pb_type_awaitable_cancel_none,
         PB_TYPE_AWAITABLE_OPT_NONE);

--- a/pybricks/tools/pb_type_awaitable.h
+++ b/pybricks/tools/pb_type_awaitable.h
@@ -82,6 +82,8 @@ typedef void (*pb_type_awaitable_cancel_t)(mp_obj_t obj);
 
 #define pb_type_awaitable_cancel_none (NULL)
 
+bool pb_type_awaitable_test_completion_yield_once(mp_obj_t obj, uint32_t end_time);
+
 void pb_type_awaitable_update_all(mp_obj_t awaitables_in, pb_type_awaitable_opt_t options);
 
 mp_obj_t pb_type_awaitable_await_or_wait(

--- a/tests/virtualhub/multitasking/basic.py
+++ b/tests/virtualhub/multitasking/basic.py
@@ -170,5 +170,4 @@ async def main():
     await test_race_2()
 
 
-# run as fast as possible for CI
-run_task(main(), loop_time=0)
+run_task(main())


### PR DESCRIPTION
Fixes https://github.com/pybricks/support/issues/1429
Fixes https://github.com/pybricks/support/issues/1775
Fixes https://github.com/pybricks/support/issues/1460

Alternate for https://github.com/pybricks/pybricks-micropython/pull/262.

The following program now prints normally, while before it would print nothing.

```python
from pybricks.tools import multitask, run_task, wait

async def main1():
    while True:
        await wait(0)

async def main2():
    while True:
        print('Hello!')
        await wait(500)


async def main():
    await multitask(main1(), main2())

run_task(main())
```