### PR TITLE
bricks/_common/mpconfigport.h: enable MICROPY_GC_ALLOC_THRESHOLD

### DIFF
--- a/bricks/_common/mpconfigport.h
+++ b/bricks/_common/mpconfigport.h
@@ -50,7 +50,7 @@
 #define MICROPY_DEBUG_PRINTERS                  (0)
 #define MICROPY_ENABLE_GC                       (1)
 #define MICROPY_ENABLE_FINALISER                (1)
-#define MICROPY_GC_ALLOC_THRESHOLD              (0)
+#define MICROPY_GC_ALLOC_THRESHOLD              (PYBRICKS_OPT_EXTRA_LEVEL2)
 #define MICROPY_STACK_CHECK                     (1)
 #define MICROPY_HELPER_REPL                     (1)
 #define MICROPY_HELPER_LEXER_UNIX               (0)


### PR DESCRIPTION
This can be a useful performance tweak for some applications.

Probably not worth turning on on hubs with smaller RAM though.