### PR TITLE
pybricks.common.BLE: Implement observe_enable()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Relaxed speed limit from 1000 deg/s to 1200 deg/s for external Boost
   motor ([support#1623]).
+- Make `broadcast_channel` optional instead of defaulting to `0`.
 
 ### Fixed
 - Fixed persistent data not being deleted when swapping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Allow color objects to be iterated as h, s, v = color_object or indexed
   as color_object[0]. This allows access to these properties in block
   coding ([support#1661]).
+- Added `observe_enable` to the hub `BLE` class to selectively turn observing
+  on and off, just like you can with broadcasting ([support#1806]).
 
 ### Changed
 
@@ -32,6 +34,7 @@
 [support#1623]: https://github.com/pybricks/support/issues/1623
 [support#1661]: https://github.com/pybricks/support/issues/1661
 [support#1668]: https://github.com/pybricks/support/issues/1668
+[support#1806]: https://github.com/pybricks/support/issues/1806
 [support#1846]: https://github.com/pybricks/support/issues/1846
 [support#1858]: https://github.com/pybricks/support/issues/1858
 [support#1863]: https://github.com/pybricks/support/issues/1863

--- a/pybricks/hubs/pb_type_cityhub.c
+++ b/pybricks/hubs/pb_type_cityhub.c
@@ -28,7 +28,7 @@ typedef struct _hubs_CityHub_obj_t {
 static mp_obj_t hubs_CityHub_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     #if PYBRICKS_PY_COMMON_BLE
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_DEFAULT_INT(broadcast_channel, 0),
+        PB_ARG_DEFAULT_NONE(broadcast_channel),
         PB_ARG_DEFAULT_OBJ(observe_channels, mp_const_empty_tuple_obj));
     #endif
 

--- a/pybricks/hubs/pb_type_essentialhub.c
+++ b/pybricks/hubs/pb_type_essentialhub.c
@@ -42,7 +42,7 @@ static mp_obj_t hubs_EssentialHub_make_new(const mp_obj_type_t *type, size_t n_a
         PB_ARG_DEFAULT_OBJ(top_side, pb_type_Axis_Z_obj),
         PB_ARG_DEFAULT_OBJ(front_side, pb_type_Axis_X_obj)
         #if PYBRICKS_PY_COMMON_BLE
-        , PB_ARG_DEFAULT_INT(broadcast_channel, 0)
+        , PB_ARG_DEFAULT_NONE(broadcast_channel)
         , PB_ARG_DEFAULT_OBJ(observe_channels, mp_const_empty_tuple_obj)
         #endif
         );

--- a/pybricks/hubs/pb_type_movehub.c
+++ b/pybricks/hubs/pb_type_movehub.c
@@ -319,7 +319,7 @@ static mp_obj_t hubs_MoveHub_make_new(const mp_obj_type_t *type, size_t n_args, 
         PB_ARG_DEFAULT_INT(top_side, pb_type_Axis_Z_int_enum),
         PB_ARG_DEFAULT_INT(front_side, pb_type_Axis_X_int_enum)
         #if PYBRICKS_PY_COMMON_BLE
-        , PB_ARG_DEFAULT_INT(broadcast_channel, 0)
+        , PB_ARG_DEFAULT_NONE(broadcast_channel)
         , PB_ARG_DEFAULT_OBJ(observe_channels, mp_const_empty_tuple_obj)
         #endif
         );

--- a/pybricks/hubs/pb_type_primehub.c
+++ b/pybricks/hubs/pb_type_primehub.c
@@ -66,7 +66,7 @@ static mp_obj_t hubs_PrimeHub_make_new(const mp_obj_type_t *type, size_t n_args,
         PB_ARG_DEFAULT_OBJ(top_side, pb_type_Axis_Z_obj),
         PB_ARG_DEFAULT_OBJ(front_side, pb_type_Axis_X_obj)
         #if PYBRICKS_PY_COMMON_BLE
-        , PB_ARG_DEFAULT_INT(broadcast_channel, 0)
+        , PB_ARG_DEFAULT_NONE(broadcast_channel)
         , PB_ARG_DEFAULT_OBJ(observe_channels, mp_const_empty_tuple_obj)
         #endif
         );

--- a/pybricks/hubs/pb_type_technichub.c
+++ b/pybricks/hubs/pb_type_technichub.c
@@ -32,7 +32,7 @@ static mp_obj_t hubs_TechnicHub_make_new(const mp_obj_type_t *type, size_t n_arg
         PB_ARG_DEFAULT_OBJ(top_side, pb_type_Axis_Z_obj),
         PB_ARG_DEFAULT_OBJ(front_side, pb_type_Axis_X_obj)
         #if PYBRICKS_PY_COMMON_BLE
-        , PB_ARG_DEFAULT_INT(broadcast_channel, 0)
+        , PB_ARG_DEFAULT_NONE(broadcast_channel)
         , PB_ARG_DEFAULT_OBJ(observe_channels, mp_const_empty_tuple_obj)
         #endif
         );


### PR DESCRIPTION
This allows users to toggle observing off and on so that they can alternate between observing and broadcasting.

This results in better stability on Technic Hub which can lock up when simultaneous advertising and broadcasting.

Fixes https://github.com/pybricks/support/issues/1806

Also fix the remaining FIXME about the default broadcast channel while we are working on this code (first commit).

Usage:

```
hub.ble.observe_enable(True) # Enable observing (on by default)
hub.ble.observe_enable(False) # Disable observing
```

Can be combined with `hub.ble.broadcast(data)` and `hub.ble.broadcast(None)` to alternate between broadcasting and observing for better reliability on Technic Hub.

This isn't extensively tested yet, but making this available for others to try.

-------------

@NStrijbosch, @JJHackimoto 



