### PR TITLE
pybricks.common.charger: change return value of connected()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,17 @@
 - Re-implemented `hub.imu.heading()` to use optionally use the projection of 3D
   orientation to improve performance when the hub is lifted off the ground.
   The 1D-based heading remains the default for now.
+- Change return value of connected() property from bool to int using the value
+  of pbdrv_usb_get_bcd(). This will allow pro users to be able to tell if they
+  have a "nonstandard" charger that could prevent proper
+  charging ([pybricks-micropython#274]).
 
 ### Fixed
 - Fixed `DriveBase.angle()` getting an incorrectly rounded gyro value, which
   could cause `turn(360)` to be off by a degree ([support#1844]).
 - Fixed `hub` silently ignoring non-orthogonal base axis when it should raise.
 
+[pybricks-micropython#274]: https://github.com/pybricks/pybricks-micropython/pull/274
 [support#943]: https://github.com/pybricks/support/issues/943
 [support#1886]: https://github.com/pybricks/support/issues/1886
 [support#1844]: https://github.com/pybricks/support/issues/1844

--- a/lib/pbio/include/pbdrv/usb.h
+++ b/lib/pbio/include/pbdrv/usb.h
@@ -15,16 +15,18 @@
  * Indicates battery charging capabilites that were detected on a USB port.
  */
 typedef enum {
+    // NOTE: These values are part of the MicroPython API, don't change the numbers.
+
     /** The USB cable is not connected (no VBUS). */
-    PBDRV_USB_BCD_NONE,
+    PBDRV_USB_BCD_NONE = 0,
     /** The USB cable is connected to a non-standard charger or PS/2 port. */
-    PBDRV_USB_BCD_NONSTANDARD,
+    PBDRV_USB_BCD_NONSTANDARD = 1,
     /** The USB cable is connected to standard downstream port. */
-    PBDRV_USB_BCD_STANDARD_DOWNSTREAM,
+    PBDRV_USB_BCD_STANDARD_DOWNSTREAM = 2,
     /** The USB cable is connected to charging downstream port. */
-    PBDRV_USB_BCD_CHARGING_DOWNSTREAM,
+    PBDRV_USB_BCD_CHARGING_DOWNSTREAM = 3,
     /** The USB cable is connected to dedicated charging port. */
-    PBDRV_USB_BCD_DEDICATED_CHARGING,
+    PBDRV_USB_BCD_DEDICATED_CHARGING = 4,
 } pbdrv_usb_bcd_t;
 
 #if PBDRV_CONFIG_USB

--- a/pybricks/common/pb_type_charger.c
+++ b/pybricks/common/pb_type_charger.c
@@ -32,7 +32,7 @@ static mp_obj_t Charger_status(mp_obj_t self_in) {
 static MP_DEFINE_CONST_FUN_OBJ_1(Charger_status_obj, Charger_status);
 
 static mp_obj_t Charger_connected(mp_obj_t self_in) {
-    return mp_obj_new_bool(pbdrv_usb_get_bcd() != PBDRV_USB_BCD_NONE);
+    return mp_obj_new_int(pbdrv_usb_get_bcd());
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(Charger_connected_obj, Charger_connected);
 


### PR DESCRIPTION
Change return value of `connected()` property from `bool` to `int` using the value of `pbdrv_usb_get_bcd()`. This will allow pro users to be able to tell if they have a "nonstandard" charger that could prevent proper charging.

Related discussion: https://github.com/orgs/pybricks/discussions/1872#discussioncomment-11278180

Alternative to consider: We could have the battery status light reflect this status somehow to make it even easier for users. Although having programmatically accessible in addition to that still seems useful for advanced use cases.