### PR TITLE
pbio/platform/prime_hub: Enable slots.

### DIFF
--- a/lib/pbio/platform/prime_hub/pbsysconfig.h
+++ b/lib/pbio/platform/prime_hub/pbsysconfig.h
@@ -10,7 +10,7 @@
 #define PBSYS_CONFIG_BLUETOOTH                      (1)
 #define PBSYS_CONFIG_BLUETOOTH_TOGGLE               (1)
 #define PBSYS_CONFIG_BLUETOOTH_TOGGLE_BUTTON        (512) // PBIO_BUTTON_RIGHT_UP, but enum value cannot be used here.
-#define PBSYS_CONFIG_HMI_NUM_SLOTS                  (0)
+#define PBSYS_CONFIG_HMI_NUM_SLOTS                  (5)
 #define PBSYS_CONFIG_HUB_LIGHT_MATRIX               (1)
 #define PBSYS_CONFIG_HOST                           (1)
 #define PBSYS_CONFIG_MAIN                           (1)


### PR DESCRIPTION
Support for basic multi-program slots has been added a while ago, but it is not enabled by default while we wait on related featured to be completed.

This enables it for those who wish to try it out early.

**Try it out**
- Download the Prime Hub firmware file using the link in the post below.
- Install that file [using these instructions](https://pybricks.com/learn/getting-started/install-pybricks/#trying-the-nightly-version-optional).
- Code as usual using https://beta.pybricks.com/
- On the hub, choose slot 1 to 5 using the left/right buttons.
- A new program is downloaded to the selected slot.

**Caveats**
- There is no file manager yet. To delete programs, just download an empty program to that slot.
- Upgrading to a new firmware will erase the programs from the hub.
- All programs are kept in memory at once. If you write 5 giant programs, it will have a bit less memory remaining to run them.
