### PR TITLE
pybricks.common.Speaker: fix negative duration in beep()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,14 @@
 - Fixed `DriveBase.angle()` getting an incorrectly rounded gyro value, which
   could cause `turn(360)` to be off by a degree ([support#1844]).
 - Fixed `hub` silently ignoring non-orthogonal base axis when it should raise.
+- Fixed not handling negative duration in `Speaker.beep()` ([support#1996]).
 
 [pybricks-micropython#274]: https://github.com/pybricks/pybricks-micropython/pull/274
 [support#943]: https://github.com/pybricks/support/issues/943
 [support#1886]: https://github.com/pybricks/support/issues/1886
 [support#1844]: https://github.com/pybricks/support/issues/1844
-[support#1875]: https://github.com/pybricks/support/issues/1975
+[support#1975]: https://github.com/pybricks/support/issues/1975
+[support#1996]: https://github.com/pybricks/support/issues/1996
 
 ## [3.6.0b2] - 2024-10-15
 

--- a/pybricks/common/pb_type_speaker.c
+++ b/pybricks/common/pb_type_speaker.c
@@ -152,7 +152,7 @@ static mp_obj_t pb_type_Speaker_beep(size_t n_args, const mp_obj_t *pos_args, mp
     pb_type_Speaker_start_beep(frequency, self->sample_attenuator);
 
     if (duration < 0) {
-        duration = 0;
+        return mp_const_none;
     }
 
     self->beep_end_time = mp_hal_ticks_ms() + (uint32_t)duration;


### PR DESCRIPTION
Return immediately if duration is negative as per documentation.

This works the same as with motor methods, with `wait=False` in that the method is not awaitable when duration is negative.

Issue: https://github.com/pybricks/support/issues/1996