### PR TITLE
hack: Bad process

### DIFF
--- a/lib/pbio/drv/ioport/ioport_pup.c
+++ b/lib/pbio/drv/ioport/ioport_pup.c
@@ -70,7 +70,10 @@ PROCESS_THREAD(test_process, ev, data) {
 
         etimer_set(&timer, 1000);
 
-        PROCESS_WAIT_EVENT_UNTIL(ev == PROCESS_EVENT_TIMER && etimer_expired(&timer));
+        // And with this change it still doesn't work after connect, but it
+        // does get going when you kick it with an event like starting REPL.
+
+        PROCESS_WAIT_EVENT_UNTIL(/*ev == PROCESS_EVENT_TIMER &&*/ etimer_expired(&timer));
 
         printf("Hello, world\n");
     }

--- a/lib/pbio/drv/ioport/ioport_pup.c
+++ b/lib/pbio/drv/ioport/ioport_pup.c
@@ -75,7 +75,7 @@ PROCESS_THREAD(test_process, ev, data) {
 
         PROCESS_WAIT_EVENT_UNTIL(/*ev == PROCESS_EVENT_TIMER &&*/ etimer_expired(&timer));
 
-        printf("Hello, world\n");
+        printf("Hello, world: ev=%d\n", ev);
     }
 
     PROCESS_END();

--- a/lib/pbio/drv/ioport/ioport_pup.c
+++ b/lib/pbio/drv/ioport/ioport_pup.c
@@ -45,13 +45,37 @@ void pbdrv_ioport_enable_vcc(bool enable) {
 PROCESS(pbdrv_ioport_pup_process, "ioport_pup");
 #endif
 
+PROCESS(test_process, "testtest");
+
 void pbdrv_ioport_init(void) {
+    process_start(&test_process);
+
     init_ports();
 
     #if PBDRV_CONFIG_IOPORT_PUP_QUIRK_POWER_CYCLE
     pbdrv_init_busy_up();
     process_start(&pbdrv_ioport_pup_process);
     #endif
+}
+
+#include <stdio.h>
+
+PROCESS_THREAD(test_process, ev, data) {
+
+    static struct etimer timer;
+    
+    PROCESS_BEGIN();
+
+    for (;;) {
+
+        etimer_set(&timer, 1000);
+
+        PROCESS_WAIT_EVENT_UNTIL(ev == PROCESS_EVENT_TIMER && etimer_expired(&timer));
+
+        printf("Hello, world\n");
+    }
+
+    PROCESS_END();
 }
 
 void pbdrv_ioport_deinit(void) {


### PR DESCRIPTION
This should not be merged, but serves to document and reproduce an odd bug that I am seeing locally.

**Context**
I was working on a major revision of the port subsystem, and was running into issues with etimers and polling processes.

After some time, I was able to boil it down to a very small example that also builds from the current master branch. This makes it seem independent from the current work (which is not submitted here).

**To reproduce**
Build either of the two commits from this PR. If everything is working, you should see `Hello World` printed in Pybricks Code  every second after connecting.

- In the first commit, nothing is printed at all
- In the second, if we ignore the `ev` check, it doesn't work at first but it starts when kicked externally. For example, start the REPL (state changes trigger a event broadcast).

**Caveats**
This may be due to unrelated undefined behavior somewhere else. It seems to vary from build to build. At one point, adding comments made it (dis)appear, presumably because that changes the LC value of the switches. Similarly, experimenting with variations of `etimer_set` such as `etimer_reset` don't make the difference, even if they sometimes appear to make it work, but presumably that is the same as above.

This is one reason to create the CI build --- to see if it reproduces there too. EDIT: It does. I suppose that is a good thing.