### PR TITLE
lego/usb: fix Robot Inventor USB PIDs

### DIFF
--- a/lib/lego/lego_usb.h
+++ b/lib/lego/lego_usb.h
@@ -18,10 +18,10 @@
 #define LEGO_USB_PID_SPIKE_ESSENTIAL_DFU 0x000C
 /** Official LEGO USB Product ID for SPIKE Essential. */
 #define LEGO_USB_PID_SPIKE_ESSENTIAL 0x000D
-/** Official LEGO USB Product ID for MINDSTORMS Robot Inventor in DFU mode. */
-#define LEGO_USB_PID_ROBOT_INVENTOR_DFU 0x0010
 /** Official LEGO USB Product ID for MINDSTORMS Robot Inventor. */
-#define LEGO_USB_PID_ROBOT_INVENTOR 0x0011
+#define LEGO_USB_PID_ROBOT_INVENTOR 0x0010
+/** Official LEGO USB Product ID for MINDSTORMS Robot Inventor in DFU mode. */
+#define LEGO_USB_PID_ROBOT_INVENTOR_DFU 0x0011
 
 /** Official LEGO USB Manufacturer String. */
 #define LEGO_USB_MFG_STR "LEGO System A/S"


### PR DESCRIPTION
Swap the PIDs for the Robot Inventor hub and the Move hub. They don't follow the same patterns as SPIKE.