### PR TITLE
Battery updates

### DIFF
--- a/lib/pbio/include/pbdrv/charger.h
+++ b/lib/pbio/include/pbdrv/charger.h
@@ -72,13 +72,6 @@ pbio_error_t pbdrv_charger_get_current_now(uint16_t *current);
  */
 pbdrv_charger_status_t pbdrv_charger_get_status(void);
 
-/**
- * Enables or disables charging.
- * @param [in]  enable  True to enable charging or false for discharging.
- * @param [in]  limit   The current limit for the charging rate.
- */
-void pbdrv_charger_enable(bool enable, pbdrv_charger_limit_t limit);
-
 #else
 
 static inline pbio_error_t pbdrv_charger_get_current_now(uint16_t *current) {
@@ -88,9 +81,6 @@ static inline pbio_error_t pbdrv_charger_get_current_now(uint16_t *current) {
 
 static inline pbdrv_charger_status_t pbdrv_charger_get_status(void) {
     return PBDRV_CHARGER_STATUS_FAULT;
-}
-
-static inline void pbdrv_charger_enable(bool enable, pbdrv_charger_limit_t limit) {
 }
 
 #endif

--- a/lib/pbio/platform/prime_hub/platform.c
+++ b/lib/pbio/platform/prime_hub/platform.c
@@ -139,7 +139,7 @@ const pbdrv_bluetooth_btstack_platform_data_t pbdrv_bluetooth_btstack_platform_d
 
 const pbdrv_charger_mp2639a_platform_data_t pbdrv_charger_mp2639a_platform_data = {
     .mode_pwm_id = PWM_DEV_5_TLC5955,
-    .mode_pwm_ch = 15,
+    .mode_pwm_ch = 14,
     .chg_resistor_ladder_id = RESISTOR_LADDER_DEV_0,
     .chg_resistor_ladder_ch = PBDRV_RESISTOR_LADDER_CH_2,
     .ib_adc_ch = 3,

--- a/lib/pbio/src/battery.c
+++ b/lib/pbio/src/battery.c
@@ -14,6 +14,10 @@
 #include <pbio/battery.h>
 #include <pbio/int_math.h>
 
+#if !PBIO_CONFIG_MOTOR_PROCESS
+#error "PBIO_CONFIG_MOTOR_PROCESS must be enabled to continously update battery voltage."
+#endif
+
 // Slow moving average battery voltage.
 static int32_t battery_voltage_avg_scaled;
 

--- a/lib/pbio/sys/battery.c
+++ b/lib/pbio/sys/battery.c
@@ -99,32 +99,6 @@ void pbsys_battery_poll(void) {
     } else if (avg_battery_voltage >= battery_ok_mv) {
         pbsys_status_clear(PBIO_PYBRICKS_STATUS_BATTERY_LOW_VOLTAGE_WARNING);
     }
-
-    // REVISIT: we should be able to make this event driven rather than polled
-    #if PBDRV_CONFIG_CHARGER
-
-    pbdrv_usb_bcd_t bcd = pbdrv_usb_get_bcd();
-    bool enable = bcd != PBDRV_USB_BCD_NONE;
-    pbdrv_charger_limit_t limit;
-
-    // REVISIT: The only current battery charger chip will automatically monitor
-    // VBUS and limit the current if the VBUS voltage starts to drop, so these
-    // limits are a bit looser than they could be.
-    switch (bcd) {
-        case PBDRV_USB_BCD_NONE:
-            limit = PBDRV_CHARGER_LIMIT_NONE;
-            break;
-        case PBDRV_USB_BCD_STANDARD_DOWNSTREAM:
-            limit = PBDRV_CHARGER_LIMIT_STD_MAX;
-            break;
-        default:
-            limit = PBDRV_CHARGER_LIMIT_CHARGING;
-            break;
-    }
-
-    pbdrv_charger_enable(enable, limit);
-
-    #endif // PBDRV_CONFIG_CHARGER
 }
 
 /**


### PR DESCRIPTION
This takes initial steps towards resolving https://github.com/orgs/pybricks/discussions/1872.

This follows the observed pattern in the official firmware (MINDSTORMS and SPIKE V3) where charging is briefly disabled for some time after about half an hour of charging. This ensures that the charging chip does not time out and disables charging.

------------

To try it out, please download the firmware file in the post below and install it using [these instructions](https://pybricks.com/learn/getting-started/install-pybricks/#trying-the-nightly-version-optional).

-------------------

Some considerations: Is this really optimal? We could consider doing this only if the timeout error is really reached. This would reduce charge cycles.

@dlech [wrote](https://github.com/orgs/pybricks/discussions/1872#discussioncomment-11833733):

> I wouldn't make it conditional. Even when it manages to charge full without error, it enters a discharge phase that drains the battery to 8V. Having this timer would help keep the battery topped off at a higher level.

If I understand the comments [here correctly](https://github.com/orgs/pybricks/discussions/1872), several people have independently confirmed that the official firmware stops charging briefly if still charging after after about half an hour. If so then following this pattern seems acceptable indeed.

Do we know how long it takes for the actual timeout error to be reached? Maybe we can make the software timeout a bit closer to that so we don't introduce more cycles than necessary.

I am currently running some experiments, but it is a slow process. I currently have a robot running around the room to simulate normal use. Then I'll try charging it to see if I can reproduce the issue.

Todo:
- [ ] This also removed the workaround for Technic Hub so we probably need to put that back.
