### PR TITLE
pbio/os: Prototype simpler and unified async OS.

### DIFF
--- a/bricks/_common/micropython.c
+++ b/bricks/_common/micropython.c
@@ -9,6 +9,7 @@
 
 #include <pbio/button.h>
 #include <pbio/main.h>
+#include <pbio/os.h>
 #include <pbio/util.h>
 #include <pbio/protocol.h>
 #include <pbsys/main.h>
@@ -39,14 +40,9 @@
 // Implementation for MICROPY_EVENT_POLL_HOOK
 void pb_event_poll_hook(void) {
 
-    // Drive pbio event loop.
-    while (pbio_do_one_event()) {
-    }
-
     mp_handle_pending(true);
 
-    // Platform-specific code to run on completing the poll hook.
-    pb_event_poll_hook_leave();
+    pbio_os_run_while_idle();
 }
 
 // callback for when stop button is pressed in IDE or on hub

--- a/bricks/_common/micropython.c
+++ b/bricks/_common/micropython.c
@@ -40,9 +40,12 @@
 // Implementation for MICROPY_EVENT_POLL_HOOK
 void pb_event_poll_hook(void) {
 
+    while (pbio_os_run_processes_once()) {
+    }
+
     mp_handle_pending(true);
 
-    pbio_os_run_while_idle();
+    pbio_os_run_processes_and_wait_for_event();
 }
 
 // callback for when stop button is pressed in IDE or on hub

--- a/bricks/_common/sources.mk
+++ b/bricks/_common/sources.mk
@@ -215,6 +215,7 @@ PBIO_SRC_C = $(addprefix lib/pbio/,\
 	src/motor_process.c \
 	src/motor/servo_settings.c \
 	src/observer.c \
+	src/os.c \
 	src/parent.c \
 	src/port.c \
 	src/port_dcm_pup.c \

--- a/bricks/_common_stm32/mpconfigport.h
+++ b/bricks/_common_stm32/mpconfigport.h
@@ -24,7 +24,7 @@ typedef unsigned mp_uint_t; // must be pointer size
 
 typedef long mp_off_t;
 
-#include <pbio/os.h>
+#include "pbio_os_config.h"
 
 #define MICROPY_BEGIN_ATOMIC_SECTION()     pbio_os_hook_disable_irq()
 #define MICROPY_END_ATOMIC_SECTION(state)  pbio_os_hook_enable_irq(state)

--- a/bricks/_common_stm32/mpconfigport.h
+++ b/bricks/_common_stm32/mpconfigport.h
@@ -24,31 +24,15 @@ typedef unsigned mp_uint_t; // must be pointer size
 
 typedef long mp_off_t;
 
-// We have inlined IRQ functions for efficiency (they are generally
-// 1 machine instruction).
-//
-// Note on IRQ state: you should not need to know the specific
-// value of the state variable, but rather just pass the return
-// value from disable_irq back to enable_irq.  If you really need
-// to know the machine-specific values, see irq.h.
+#include <pbio/os.h>
 
-static inline void enable_irq(mp_uint_t state) {
-    __set_PRIMASK(state);
-}
-
-static inline mp_uint_t disable_irq(void) {
-    mp_uint_t state = __get_PRIMASK();
-    __disable_irq();
-    return state;
-}
-
-#define MICROPY_BEGIN_ATOMIC_SECTION()     disable_irq()
-#define MICROPY_END_ATOMIC_SECTION(state)  enable_irq(state)
+#define MICROPY_BEGIN_ATOMIC_SECTION()     pbio_os_hook_disable_irq()
+#define MICROPY_END_ATOMIC_SECTION(state)  pbio_os_hook_enable_irq(state)
 
 #define MICROPY_VM_HOOK_LOOP \
     do { \
-        extern int pbio_do_one_event(void); \
-        pbio_do_one_event(); \
+        extern bool pbio_os_run_processes_once(void); \
+        pbio_os_run_processes_once(); \
     } while (0);
 
 #define MICROPY_GC_HOOK_LOOP(i) do { \

--- a/bricks/_common_stm32/mphalport.c
+++ b/bricks/_common_stm32/mphalport.c
@@ -24,20 +24,6 @@ void pb_stack_get_info(char **sstack, char **estack) {
     *estack = (char *)&_estack;
 }
 
-pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
-    mp_uint_t flags = __get_PRIMASK();
-    __disable_irq();
-    return flags;
-}
-
-void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
-    __set_PRIMASK(flags);
-}
-
-void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
-    __WFI();
-}
-
 // using "internal" pbdrv variable
 extern volatile uint32_t pbdrv_clock_ticks;
 

--- a/bricks/_common_stm32/mphalport.c
+++ b/bricks/_common_stm32/mphalport.c
@@ -24,17 +24,17 @@ void pb_stack_get_info(char **sstack, char **estack) {
     *estack = (char *)&_estack;
 }
 
-uint32_t pbio_os_hook_disable_irq(void) {
+pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
     mp_uint_t flags = __get_PRIMASK();
     __disable_irq();
     return flags;
 }
 
-void pbio_os_hook_enable_irq(uint32_t flags) {
+void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
     __set_PRIMASK(flags);
 }
 
-void pbio_os_hook_wait_for_interrupt(void) {
+void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
     __WFI();
 }
 

--- a/bricks/ev3/mpconfigport.h
+++ b/bricks/ev3/mpconfigport.h
@@ -79,18 +79,15 @@ typedef unsigned mp_uint_t; // must be pointer size
 
 typedef long mp_off_t;
 
-#define CPSR_IRQ_MASK (1 << 7)  // IRQ disable
-#define CPSR_FIQ_MASK (1 << 6)  // FIQ disable
+#include <pbio/os.h>
 
-#include <tiam1808/armv5/am1808/interrupt.h>
-
-#define MICROPY_BEGIN_ATOMIC_SECTION()     IntDisable()
-#define MICROPY_END_ATOMIC_SECTION(state)  IntEnable(state)
+#define MICROPY_BEGIN_ATOMIC_SECTION()     pbio_os_hook_disable_irq()
+#define MICROPY_END_ATOMIC_SECTION(state)  pbio_os_hook_enable_irq(state)
 
 #define MICROPY_VM_HOOK_LOOP \
     do { \
-        extern int pbio_do_one_event(void); \
-        pbio_do_one_event(); \
+        extern bool pbio_os_run_processes_once(void); \
+        pbio_os_run_processes_once(); \
     } while (0);
 
 #define MICROPY_GC_HOOK_LOOP(i) do { \

--- a/bricks/ev3/mpconfigport.h
+++ b/bricks/ev3/mpconfigport.h
@@ -79,7 +79,7 @@ typedef unsigned mp_uint_t; // must be pointer size
 
 typedef long mp_off_t;
 
-#include <pbio/os.h>
+#include "pbio_os_config.h"
 
 #define MICROPY_BEGIN_ATOMIC_SECTION()     pbio_os_hook_disable_irq()
 #define MICROPY_END_ATOMIC_SECTION(state)  pbio_os_hook_enable_irq(state)

--- a/bricks/ev3/mphalport.c
+++ b/bricks/ev3/mphalport.c
@@ -18,29 +18,11 @@
 #include "py/mpconfig.h"
 #include "py/stream.h"
 
-#include <tiam1808/armv5/am1808/interrupt.h>
-
 void pb_stack_get_info(char **sstack, char **estack) {
     extern uint32_t _estack;
     extern uint32_t _sstack;
     *sstack = (char *)&_sstack;
     *estack = (char *)&_estack;
-}
-
-pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
-    return IntDisable();
-}
-
-void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
-    IntEnable(flags);
-}
-
-void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
-    __asm volatile (
-        "mov	r0, #0\n"
-        "mcr	p15, 0, r0, c7, c0, 4\n"        /* wait for interrupt */
-        ::: "r0"
-        );
 }
 
 // Core delay function that does an efficient sleep and may switch thread context.

--- a/bricks/ev3/mphalport.c
+++ b/bricks/ev3/mphalport.c
@@ -27,15 +27,15 @@ void pb_stack_get_info(char **sstack, char **estack) {
     *estack = (char *)&_estack;
 }
 
-uint32_t pbio_os_hook_disable_irq(void) {
+pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
     return IntDisable();
 }
 
-void pbio_os_hook_enable_irq(uint32_t flags) {
+void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
     IntEnable(flags);
 }
 
-void pbio_os_hook_wait_for_interrupt(void) {
+void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
     __asm volatile (
         "mov	r0, #0\n"
         "mcr	p15, 0, r0, c7, c0, 4\n"        /* wait for interrupt */

--- a/bricks/nxt/mpconfigport.h
+++ b/bricks/nxt/mpconfigport.h
@@ -79,7 +79,7 @@ typedef long mp_off_t;
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>
 
-#include <pbio/os.h>
+#include "pbio_os_config.h"
 
 #define MICROPY_BEGIN_ATOMIC_SECTION()     pbio_os_hook_disable_irq()
 #define MICROPY_END_ATOMIC_SECTION(state)  pbio_os_hook_enable_irq(state)

--- a/bricks/nxt/mphalport.c
+++ b/bricks/nxt/mphalport.c
@@ -4,10 +4,8 @@
 
 #include <stdint.h>
 
-#include <at91sam7s256.h>
 #include <contiki.h>
 
-#include <nxos/interrupts.h>
 #include <nxos/drivers/systick.h>
 #include <nxos/drivers/bt.h>
 
@@ -19,19 +17,6 @@
 #include "py/mphal.h"
 #include "py/mpconfig.h"
 #include "py/stream.h"
-
-pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
-    return nx_interrupts_disable();
-}
-
-void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
-    nx_interrupts_enable(flags);
-}
-
-void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
-    // disable the processor clock which puts it in Idle Mode.
-    AT91C_BASE_PMC->PMC_SCDR = AT91C_PMC_PCK;
-}
 
 void pb_stack_get_info(char **sstack, char **estack) {
     extern uint32_t __stack_start__;

--- a/bricks/nxt/mphalport.c
+++ b/bricks/nxt/mphalport.c
@@ -20,15 +20,15 @@
 #include "py/mpconfig.h"
 #include "py/stream.h"
 
-uint32_t pbio_os_hook_disable_irq(void) {
+pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
     return nx_interrupts_disable();
 }
 
-void pbio_os_hook_enable_irq(uint32_t flags) {
+void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
     nx_interrupts_enable(flags);
 }
 
-void pbio_os_hook_wait_for_interrupt(void) {
+void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
     // disable the processor clock which puts it in Idle Mode.
     AT91C_BASE_PMC->PMC_SCDR = AT91C_PMC_PCK;
 }

--- a/bricks/nxt/mphalport.c
+++ b/bricks/nxt/mphalport.c
@@ -20,21 +20,17 @@
 #include "py/mpconfig.h"
 #include "py/stream.h"
 
-void pb_event_poll_hook_leave(void) {
-    // There is a possible race condition where an interrupt occurs and sets
-    // the Contiki poll_requested flag after all events have been processed. So
-    // we have a critical section where we disable interrupts and check see if
-    // there are any last second events. If not, we can enter Idle Mode, which
-    // still wakes up the CPU on interrupt even though interrupts are otherwise
-    // disabled.
-    uint32_t state = nx_interrupts_disable();
+uint32_t pbio_os_hook_disable_irq(void) {
+    return nx_interrupts_disable();
+}
 
-    if (!process_nevents()) {
-        // disable the processor clock which puts it in Idle Mode.
-        AT91C_BASE_PMC->PMC_SCDR = AT91C_PMC_PCK;
-    }
+void pbio_os_hook_enable_irq(uint32_t flags) {
+    nx_interrupts_enable(flags);
+}
 
-    nx_interrupts_enable(state);
+void pbio_os_hook_wait_for_interrupt(void) {
+    // disable the processor clock which puts it in Idle Mode.
+    AT91C_BASE_PMC->PMC_SCDR = AT91C_PMC_PCK;
 }
 
 void pb_stack_get_info(char **sstack, char **estack) {

--- a/bricks/virtualhub/mp_port.c
+++ b/bricks/virtualhub/mp_port.c
@@ -89,9 +89,12 @@ void pb_virtualhub_port_deinit(void) {
 // Implementation for MICROPY_EVENT_POLL_HOOK
 void pb_event_poll_hook(void) {
 
+    while (pbio_os_run_processes_once()) {
+    }
+
     mp_handle_pending(true);
 
-    pbio_os_run_while_idle();
+    pbio_os_run_processes_and_wait_for_event();
 }
 
 pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {

--- a/bricks/virtualhub/mp_port.c
+++ b/bricks/virtualhub/mp_port.c
@@ -14,6 +14,8 @@
 
 #include <contiki.h>
 
+#include "pbio_os_config.h"
+
 #include <pbio/main.h>
 #include <pbio/os.h>
 #include <pbsys/core.h>

--- a/bricks/virtualhub/mpconfigvariant.h
+++ b/bricks/virtualhub/mpconfigvariant.h
@@ -97,8 +97,8 @@
 } while (0)
 
 #define MICROPY_VM_HOOK_LOOP do { \
-        extern void pb_virtualhub_poll(void); \
-        pb_virtualhub_poll(); \
+        extern bool pbio_os_run_processes_once(void); \
+        pbio_os_run_processes_once(); \
 } while (0);
 
 #define MICROPY_GC_HOOK_LOOP(i) do { \
@@ -108,6 +108,6 @@
 } while (0)
 
 #define MICROPY_EVENT_POLL_HOOK do { \
-        extern void pb_virtualhub_event_poll(void); \
-        pb_virtualhub_event_poll(); \
+        extern void pb_event_poll_hook(void); \
+        pb_event_poll_hook(); \
 } while (0);

--- a/lib/pbio/drv/charger/charger_mp2639a.c
+++ b/lib/pbio/drv/charger/charger_mp2639a.c
@@ -282,7 +282,7 @@ pbio_error_t pbdrv_charger_mp2639a_process_thread(pbio_os_state_t *state, void *
 
 void pbdrv_charger_init(void) {
     pbdrv_init_busy_up();
-    pbio_os_start_process(&pbdrv_charger_mp2639a_process, pbdrv_charger_mp2639a_process_thread, NULL);
+    pbio_os_process_start(&pbdrv_charger_mp2639a_process, pbdrv_charger_mp2639a_process_thread, NULL);
 }
 
 #endif // PBDRV_CONFIG_CHARGER_MP2639A

--- a/lib/pbio/drv/charger/charger_mp2639a.c
+++ b/lib/pbio/drv/charger/charger_mp2639a.c
@@ -178,7 +178,7 @@ static bool read_chg(void) {
 
 static pbio_os_process_t pbdrv_charger_mp2639a_process;
 
-pbio_error_t pbdrv_charger_mp2639a_process_thread(pbio_os_state_t *state) {
+pbio_error_t pbdrv_charger_mp2639a_process_thread(pbio_os_state_t *state, void *context) {
 
     static pbio_os_timer_t timer;
 
@@ -282,7 +282,7 @@ pbio_error_t pbdrv_charger_mp2639a_process_thread(pbio_os_state_t *state) {
 
 void pbdrv_charger_init(void) {
     pbdrv_init_busy_up();
-    pbio_os_start_process(&pbdrv_charger_mp2639a_process, pbdrv_charger_mp2639a_process_thread);
+    pbio_os_start_process(&pbdrv_charger_mp2639a_process, pbdrv_charger_mp2639a_process_thread, NULL);
 }
 
 #endif // PBDRV_CONFIG_CHARGER_MP2639A

--- a/lib/pbio/drv/charger/charger_mp2639a.c
+++ b/lib/pbio/drv/charger/charger_mp2639a.c
@@ -182,17 +182,17 @@ pbio_error_t pbdrv_charger_mp2639a_process_thread(pbio_os_state_t *state, void *
 
     static pbio_os_timer_t timer;
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     #if PBDRV_CONFIG_CHARGER_MP2639A_MODE_PWM
     while (pbdrv_pwm_get_dev(platform.mode_pwm_id, &mode_pwm) != PBIO_SUCCESS) {
-        AWAIT_ONCE(state);
+        PBIO_OS_AWAIT_ONCE_AND_POLL(state);
     }
     #endif
 
     #if PBDRV_CONFIG_CHARGER_MP2639A_ISET_PWM
     while (pbdrv_pwm_get_dev(platform.iset_pwm_id, &iset_pwm) != PBIO_SUCCESS) {
-        AWAIT_ONCE(state);
+        PBIO_OS_AWAIT_ONCE_AND_POLL(state);
     }
     #endif
 
@@ -214,7 +214,7 @@ pbio_error_t pbdrv_charger_mp2639a_process_thread(pbio_os_state_t *state, void *
     static uint32_t charge_count = 0;
 
     for (;;) {
-        AWAIT_MS(state, &timer, PBDRV_CHARGER_MP2639A_STATUS_SAMPLE_TIME);
+        PBIO_OS_AWAIT_MS(state, &timer, PBDRV_CHARGER_MP2639A_STATUS_SAMPLE_TIME);
 
         // Enable charger chip based on USB state. We don't need to disable it
         // on charger fault since the chip will automatically disable itself.
@@ -272,12 +272,12 @@ pbio_error_t pbdrv_charger_mp2639a_process_thread(pbio_os_state_t *state, void *
         if (charge_count > (PBDRV_CHARGER_MP2639A_CHARGE_TIMEOUT_MS / PBDRV_CHARGER_MP2639A_STATUS_SAMPLE_TIME)) {
             pbdrv_charger_status = PBDRV_CHARGER_STATUS_DISCHARGE;
             pbdrv_charger_enable(false, PBDRV_CHARGER_LIMIT_NONE);
-            AWAIT_MS(state, &timer, PBDRV_CHARGER_MP2639A_CHARGE_PAUSE_MS);
+            PBIO_OS_AWAIT_MS(state, &timer, PBDRV_CHARGER_MP2639A_CHARGE_PAUSE_MS);
             charge_count = 0;
         }
     }
 
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 void pbdrv_charger_init(void) {

--- a/lib/pbio/drv/charger/charger_mp2639a.c
+++ b/lib/pbio/drv/charger/charger_mp2639a.c
@@ -186,13 +186,13 @@ pbio_error_t pbdrv_charger_mp2639a_process_thread(pbio_os_state_t *state, void *
 
     #if PBDRV_CONFIG_CHARGER_MP2639A_MODE_PWM
     while (pbdrv_pwm_get_dev(platform.mode_pwm_id, &mode_pwm) != PBIO_SUCCESS) {
-        AWAIT_MS(state, &timer, 1);
+        AWAIT_ONCE(state);
     }
     #endif
 
     #if PBDRV_CONFIG_CHARGER_MP2639A_ISET_PWM
     while (pbdrv_pwm_get_dev(platform.iset_pwm_id, &iset_pwm) != PBIO_SUCCESS) {
-        AWAIT_MS(state, &timer, 1);
+        AWAIT_ONCE(state);
     }
     #endif
 

--- a/lib/pbio/drv/clock/clock_ev3.c
+++ b/lib/pbio/drv/clock/clock_ev3.c
@@ -13,6 +13,8 @@
 
 #include <contiki.h>
 
+#include <pbio/os.h>
+
 #include <tiam1808/armv5/am1808/interrupt.h>
 #include <tiam1808/armv5/cpu.h>
 #include <tiam1808/hw/hw_syscfg0_AM1808.h>
@@ -49,6 +51,7 @@ void systick_isr_C(void) {
     ++systick_ms;
 
     etimer_request_poll();
+    pbio_os_request_poll();
 
     /* Enable the timer interrupt */
     TimerIntEnable(SOC_TMR_0_REGS, TMR_INT_TMR34_NON_CAPT_MODE);

--- a/lib/pbio/drv/clock/clock_linux.c
+++ b/lib/pbio/drv/clock/clock_linux.c
@@ -9,6 +9,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <pbio/os.h>
+
 // The SIGNAL option adds a timer that acts as the 1ms tick on embedded systems.
 
 #if PBDRV_CONFIG_CLOCK_LINUX_SIGNAL
@@ -34,6 +36,7 @@ static void handle_signal(int sig) {
     // main thread is interrupted and the event poll hook runs.
     if (pthread_self() == main_thread) {
         etimer_request_poll();
+        pbio_os_request_poll();
     } else {
         pthread_kill(main_thread, TIMER_SIGNAL);
     }

--- a/lib/pbio/drv/clock/clock_nxt.c
+++ b/lib/pbio/drv/clock/clock_nxt.c
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include <pbio/os.h>
+
 #include <at91sam7s256.h>
 #include <contiki.h>
 #include <nxos/nxt.h>
@@ -41,6 +43,7 @@ static void systick_isr(void) {
     /* Do the system timekeeping. */
     pbdrv_clock_ticks++;
     etimer_request_poll();
+    pbio_os_request_poll();
 
     /* Keeping up with the AVR link is a crucial task in the system, and
      * must absolutely be kept up with at all costs.

--- a/lib/pbio/drv/clock/clock_stm32.c
+++ b/lib/pbio/drv/clock/clock_stm32.c
@@ -8,6 +8,8 @@
 
 #if PBDRV_CONFIG_CLOCK_STM32
 
+#include <pbio/os.h>
+
 #include STM32_H
 
 // NB: pbdrv_clock_ticks is intended to be private, but making it static
@@ -80,6 +82,7 @@ void SysTick_Handler(void) {
     SysTick->CTRL;
 
     etimer_request_poll();
+    pbio_os_request_poll();
 }
 
 uint32_t HAL_GetTick(void) {

--- a/lib/pbio/drv/clock/clock_test.c
+++ b/lib/pbio/drv/clock/clock_test.c
@@ -5,6 +5,8 @@
 
 #if PBDRV_CONFIG_CLOCK_TEST
 
+#include <pbio/os.h>
+
 // Clock implementation for tests. This allows tests to exactly control the
 // clock ticks to get repeatable tests rather than relying on a system clock.
 
@@ -21,6 +23,7 @@ static uint32_t clock_ticks;
 void pbio_test_clock_tick(uint32_t ticks) {
     clock_ticks += ticks;
     etimer_request_poll();
+    pbio_os_request_poll();
 }
 
 void pbdrv_clock_init(void) {

--- a/lib/pbio/drv/core.c
+++ b/lib/pbio/drv/core.c
@@ -5,6 +5,7 @@
 
 #include <pbdrv/config.h>
 #include <pbdrv/ioport.h>
+#include <pbio/os.h>
 
 #include "core.h"
 #include "adc/adc.h"
@@ -79,12 +80,12 @@ void pbdrv_init(void) {
     // Wait for all async pbdrv drivers to initialize before starting
     // higher level system processes.
     while (pbdrv_init_busy()) {
-        process_run();
+        pbio_os_run_processes_once();
     }
 
     #if PBDRV_CONFIG_IOPORT_PUP_QUIRK_POWER_CYCLE
     while (pbdrv_clock_get_ms() - ioport_reset_time < 500) {
-        process_run();
+        pbio_os_run_processes_once();
     }
     #endif
     pbdrv_ioport_enable_vcc(true);

--- a/lib/pbio/drv/i2c/i2c_ev3.c
+++ b/lib/pbio/drv/i2c/i2c_ev3.c
@@ -33,12 +33,6 @@
 struct _pbdrv_i2c_dev_t {
     /** Platform-specific data */
     const pbdrv_i2c_ev3_platform_data_t *pdata;
-    /**
-     * Parent process that handles incoming data.
-     *
-     * All protothreads in this module run within that process.
-     */
-    struct process *parent_process;
     //
     // TODO: i2c state goes here.
     //
@@ -46,7 +40,7 @@ struct _pbdrv_i2c_dev_t {
 
 static pbdrv_i2c_dev_t i2c_devs[PBDRV_CONFIG_I2C_EV3_NUM_DEV];
 
-pbio_error_t pbdrv_i2c_get_instance(uint8_t id, struct process *parent_process, pbdrv_i2c_dev_t **i2c_dev) {
+pbio_error_t pbdrv_i2c_get_instance(uint8_t id, pbdrv_i2c_dev_t **i2c_dev) {
     if (id >= PBDRV_CONFIG_I2C_EV3_NUM_DEV) {
         return PBIO_ERROR_INVALID_ARG;
     }
@@ -56,7 +50,6 @@ pbio_error_t pbdrv_i2c_get_instance(uint8_t id, struct process *parent_process, 
         return PBIO_ERROR_AGAIN;
     }
     *i2c_dev = dev;
-    (*i2c_dev)->parent_process = parent_process;
     return PBIO_SUCCESS;
 }
 

--- a/lib/pbio/drv/uart/uart_debug_first_port.c
+++ b/lib/pbio/drv/uart/uart_debug_first_port.c
@@ -74,21 +74,21 @@ static pbio_error_t pbdrv_uart_debug_process_thread(pbio_os_state_t *state, void
     static pbio_error_t err;
     static size_t write_size;
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     while (pbdrv_uart_get_instance(0, &debug_uart) != PBIO_SUCCESS) {
-        AWAIT_ONCE(state);
+        PBIO_OS_AWAIT_ONCE_AND_POLL(state);
     }
 
     pbdrv_uart_set_baud_rate(debug_uart, 115200);
 
     for (;;) {
-        AWAIT_UNTIL(state, ring_head != ring_tail);
+        PBIO_OS_AWAIT_UNTIL(state, ring_head != ring_tail);
 
         // Write up to the end of the buffer without wrapping.
         size_t end = ring_head > ring_tail ? ring_head: BUF_SIZE;
         write_size = end - ring_tail;
-        AWAIT(state, &child, pbdrv_uart_write(&child, debug_uart, &ring_buf[ring_tail], write_size, 100));
+        PBIO_OS_AWAIT(state, &child, pbdrv_uart_write(&child, debug_uart, &ring_buf[ring_tail], write_size, 100));
         ring_tail = (ring_tail + write_size) % BUF_SIZE;
 
         // Reset on failure.
@@ -105,7 +105,7 @@ static pbio_error_t pbdrv_uart_debug_process_thread(pbio_os_state_t *state, void
     }
 
     // Unreachable.
-    ASYNC_END(PBIO_ERROR_FAILED);
+    PBIO_OS_ASYNC_END(PBIO_ERROR_FAILED);
 }
 
 void pbdrv_uart_debug_init(void) {

--- a/lib/pbio/drv/uart/uart_ev3.c
+++ b/lib/pbio/drv/uart/uart_ev3.c
@@ -86,7 +86,7 @@ int32_t pbdrv_uart_get_char(pbdrv_uart_dev_t *uart) {
 
 pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout) {
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     if (uart->read_buf) {
         return PBIO_ERROR_BUSY;
@@ -101,7 +101,7 @@ pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uin
     }
 
     // Await completion or timeout.
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         // On every re-entry to the async read, drain the ring buffer
         // into the current read buffer. This ensures that we use
         // all available data if there have been multiple polls since our last
@@ -123,7 +123,7 @@ pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uin
         return PBIO_ERROR_TIMEDOUT;
     }
 
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 /**
@@ -176,7 +176,7 @@ static bool pbdrv_uart_can_write(pbdrv_uart_dev_t *uart) {
 
 pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout) {
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     // Can only write one thing at once.
     if (uart->write_buf) {
@@ -192,7 +192,7 @@ pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, ui
     }
 
     // Write one byte at a time until all bytes are written.
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         // Try to write one byte if any are remaining.
         if (uart->write_pos < uart->write_length) {
             if (pbdrv_uart_try_to_write_byte(uart, uart->write_buf[uart->write_pos])) {
@@ -210,7 +210,7 @@ pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, ui
         return PBIO_ERROR_TIMEDOUT;
     }
 
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 void pbdrv_uart_set_baud_rate(pbdrv_uart_dev_t *uart, uint32_t baud) {

--- a/lib/pbio/drv/uart/uart_stm32f0.c
+++ b/lib/pbio/drv/uart/uart_stm32f0.c
@@ -63,7 +63,7 @@ pbio_error_t pbdrv_uart_get_instance(uint8_t id, pbdrv_uart_dev_t **uart_dev) {
 
 pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout) {
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     if (!msg || !length) {
         return PBIO_ERROR_INVALID_ARG;
@@ -82,7 +82,7 @@ pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uin
     }
 
     // Await completion or timeout.
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         // On every re-entry to the async read, drain the ring buffer
         // into the current read buffer. This ensures that we use
         // all available data if there have been multiple polls since our last
@@ -101,12 +101,12 @@ pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uin
         return PBIO_ERROR_TIMEDOUT;
     }
 
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout) {
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     if (!msg || !length) {
         return PBIO_ERROR_INVALID_ARG;
@@ -127,7 +127,7 @@ pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, ui
     uart->USART->CR1 |= USART_CR1_TXEIE;
 
     // Await completion or timeout.
-    AWAIT_UNTIL(state, uart->tx_buf_index == uart->tx_buf_size || (timeout && pbio_os_timer_is_expired(&uart->tx_timer)));
+    PBIO_OS_AWAIT_UNTIL(state, uart->tx_buf_index == uart->tx_buf_size || (timeout && pbio_os_timer_is_expired(&uart->tx_timer)));
 
     uart->tx_buf = NULL;
 
@@ -136,7 +136,7 @@ pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, ui
         return PBIO_ERROR_TIMEDOUT;
     }
 
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 void pbdrv_uart_set_baud_rate(pbdrv_uart_dev_t *uart, uint32_t baud) {

--- a/lib/pbio/drv/uart/uart_stm32f4_ll_irq.c
+++ b/lib/pbio/drv/uart/uart_stm32f4_ll_irq.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2020 The Pybricks Authors
+// Copyright (c) 2018-2025 The Pybricks Authors
 
 // UART driver for STM32F4x using IRQ.
 
@@ -19,6 +19,7 @@
 
 #include <pbdrv/uart.h>
 #include <pbio/error.h>
+#include <pbio/os.h>
 #include <pbio/util.h>
 
 #include "../core.h"
@@ -32,9 +33,9 @@ struct _pbdrv_uart_dev_t {
     /** Circular buffer for caching received bytes. */
     struct ringbuf rx_buf;
     /** Timer for read timeout. */
-    struct etimer read_timer;
+    pbio_os_timer_t read_timer;
     /** Timer for write timeout. */
-    struct etimer write_timer;
+    pbio_os_timer_t write_timer;
     /** The buffer of the ongoing async read function. */
     uint8_t *read_buf;
     /** The length of read_buf in bytes. */
@@ -47,18 +48,12 @@ struct _pbdrv_uart_dev_t {
     uint8_t write_length;
     /** The current position in write_buf. */
     volatile uint8_t write_pos;
-    /**
-     * Parent process that handles incoming data.
-     *
-     * All protothreads in this module run within that process.
-     */
-    struct process *parent_process;
 };
 
 static pbdrv_uart_dev_t uart_devs[PBDRV_CONFIG_UART_STM32F4_LL_IRQ_NUM_UART];
 static uint8_t pbdrv_uart_rx_data[PBDRV_CONFIG_UART_STM32F4_LL_IRQ_NUM_UART][RX_DATA_SIZE];
 
-pbio_error_t pbdrv_uart_get_instance(uint8_t id, struct process *parent_process, pbdrv_uart_dev_t **uart_dev) {
+pbio_error_t pbdrv_uart_get_instance(uint8_t id, pbdrv_uart_dev_t **uart_dev) {
     if (id >= PBDRV_CONFIG_UART_STM32F4_LL_IRQ_NUM_UART) {
         return PBIO_ERROR_INVALID_ARG;
     }
@@ -67,19 +62,16 @@ pbio_error_t pbdrv_uart_get_instance(uint8_t id, struct process *parent_process,
         // has not been initialized yet
         return PBIO_ERROR_AGAIN;
     }
-    dev->parent_process = parent_process;
     *uart_dev = dev;
     return PBIO_SUCCESS;
 }
 
-PT_THREAD(pbdrv_uart_read(struct pt *pt, pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout, pbio_error_t *err)) {
+pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout) {
 
-    // Actual protothread starts here.
-    PT_BEGIN(pt);
+    ASYNC_BEGIN(state);
 
     if (uart->read_buf) {
-        *err = PBIO_ERROR_BUSY;
-        PT_EXIT(pt);
+        return PBIO_ERROR_BUSY;
     }
 
     uart->read_buf = msg;
@@ -87,11 +79,11 @@ PT_THREAD(pbdrv_uart_read(struct pt *pt, pbdrv_uart_dev_t *uart, uint8_t *msg, u
     uart->read_pos = 0;
 
     if (timeout) {
-        etimer_set(&uart->read_timer, timeout);
+        pbio_os_timer_set(&uart->read_timer, timeout);
     }
 
     // Await completion or timeout.
-    PT_WAIT_UNTIL(pt, ({
+    AWAIT_UNTIL(state, ({
         // On every re-entry to the async read, drain the ring buffer
         // into the current read buffer. This ensures that we use
         // all available data if there have been multiple polls since our last
@@ -104,28 +96,24 @@ PT_THREAD(pbdrv_uart_read(struct pt *pt, pbdrv_uart_dev_t *uart, uint8_t *msg, u
             }
             uart->read_buf[uart->read_pos++] = c;
         }
-        uart->read_pos == uart->read_length || (timeout && etimer_expired(&uart->read_timer));
+        uart->read_pos == uart->read_length || (timeout && pbio_os_timer_is_expired(&uart->read_timer));
     }));
 
-    // Set exit status based on completion condition.
-    if (timeout && etimer_expired(&uart->read_timer)) {
-        *err = PBIO_ERROR_TIMEDOUT;
-    } else {
-        etimer_stop(&uart->read_timer);
-        *err = PBIO_SUCCESS;
-    }
     uart->read_buf = NULL;
 
-    PT_END(pt);
+    if (timeout && pbio_os_timer_is_expired(&uart->read_timer)) {
+        return PBIO_ERROR_TIMEDOUT;
+    }
+
+    ASYNC_END(PBIO_SUCCESS);
 }
 
-PT_THREAD(pbdrv_uart_write(struct pt *pt, pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout, pbio_error_t *err)) {
+pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout) {
 
-    PT_BEGIN(pt);
+    ASYNC_BEGIN(state);
 
     if (uart->write_buf) {
-        *err = PBIO_ERROR_BUSY;
-        PT_EXIT(pt);
+        return PBIO_ERROR_BUSY;
     }
 
     uart->write_buf = msg;
@@ -133,27 +121,24 @@ PT_THREAD(pbdrv_uart_write(struct pt *pt, pbdrv_uart_dev_t *uart, uint8_t *msg, 
     uart->write_pos = 0;
 
     if (timeout) {
-        etimer_set(&uart->write_timer, timeout);
+        pbio_os_timer_set(&uart->write_timer, timeout);
     }
 
     LL_USART_EnableIT_TXE(uart->pdata->uart);
 
     // Await completion or timeout.
-    PT_WAIT_UNTIL(pt, uart->write_pos == uart->write_length || (timeout && etimer_expired(&uart->write_timer)));
-
-    // Set exit status based on completion condition.
-    if ((timeout && etimer_expired(&uart->write_timer))) {
-        LL_USART_DisableIT_TXE(uart->pdata->uart);
-        LL_USART_DisableIT_TC(uart->pdata->uart);
-        *err = PBIO_ERROR_TIMEDOUT;
-    } else {
-        etimer_stop(&uart->write_timer);
-        *err = PBIO_SUCCESS;
-    }
+    AWAIT_UNTIL(state, uart->write_pos == uart->write_length || (timeout && pbio_os_timer_is_expired(&uart->write_timer)));
 
     uart->write_buf = NULL;
 
-    PT_END(pt);
+    // Set exit status based on completion condition.
+    if ((timeout && pbio_os_timer_is_expired(&uart->write_timer))) {
+        LL_USART_DisableIT_TXE(uart->pdata->uart);
+        LL_USART_DisableIT_TC(uart->pdata->uart);
+        return PBIO_ERROR_TIMEDOUT;
+    }
+
+    ASYNC_END(PBIO_SUCCESS);
 }
 
 void pbdrv_uart_set_baud_rate(pbdrv_uart_dev_t *uart, uint32_t baud) {
@@ -207,7 +192,8 @@ void pbdrv_uart_stm32f4_ll_irq_handle_irq(uint8_t id) {
         ringbuf_put(&uart->rx_buf, LL_USART_ReceiveData8(USARTx));
         // Poll parent process for each received byte, since the IRQ handler
         // has no awareness of the expected length of the read operation.
-        process_poll(uart->parent_process);
+        pbio_os_request_poll();
+
     }
 
     if (sr & USART_SR_ORE) {
@@ -230,7 +216,7 @@ void pbdrv_uart_stm32f4_ll_irq_handle_irq(uint8_t id) {
     if (USARTx->CR1 & USART_CR1_TCIE && sr & USART_SR_TC) {
         LL_USART_DisableIT_TC(USARTx);
         // Poll parent process to indicate the write operation is complete.
-        process_poll(uart->parent_process);
+        pbio_os_request_poll();
     }
 }
 

--- a/lib/pbio/drv/uart/uart_stm32f4_ll_irq.c
+++ b/lib/pbio/drv/uart/uart_stm32f4_ll_irq.c
@@ -68,7 +68,7 @@ pbio_error_t pbdrv_uart_get_instance(uint8_t id, pbdrv_uart_dev_t **uart_dev) {
 
 pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout) {
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     if (uart->read_buf) {
         return PBIO_ERROR_BUSY;
@@ -83,7 +83,7 @@ pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uin
     }
 
     // Await completion or timeout.
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         // On every re-entry to the async read, drain the ring buffer
         // into the current read buffer. This ensures that we use
         // all available data if there have been multiple polls since our last
@@ -105,12 +105,12 @@ pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uin
         return PBIO_ERROR_TIMEDOUT;
     }
 
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout) {
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     if (uart->write_buf) {
         return PBIO_ERROR_BUSY;
@@ -127,7 +127,7 @@ pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, ui
     LL_USART_EnableIT_TXE(uart->pdata->uart);
 
     // Await completion or timeout.
-    AWAIT_UNTIL(state, uart->write_pos == uart->write_length || (timeout && pbio_os_timer_is_expired(&uart->write_timer)));
+    PBIO_OS_AWAIT_UNTIL(state, uart->write_pos == uart->write_length || (timeout && pbio_os_timer_is_expired(&uart->write_timer)));
 
     uart->write_buf = NULL;
 
@@ -138,7 +138,7 @@ pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, ui
         return PBIO_ERROR_TIMEDOUT;
     }
 
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 void pbdrv_uart_set_baud_rate(pbdrv_uart_dev_t *uart, uint32_t baud) {

--- a/lib/pbio/drv/uart/uart_stm32l4_ll_dma.c
+++ b/lib/pbio/drv/uart/uart_stm32l4_ll_dma.c
@@ -190,7 +190,7 @@ static uint32_t pbdrv_uart_get_num_available(pbdrv_uart_dev_t *uart) {
 
 pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout) {
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     if (uart->read_buf) {
         return PBIO_ERROR_BUSY;
@@ -205,7 +205,7 @@ pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uin
 
     // Wait until we have enough data or timeout. If there is enough data
     // already, this completes right away without yielding once first.
-    AWAIT_UNTIL(state, pbdrv_uart_get_num_available(uart) >= uart->read_length || (timeout && pbio_os_timer_is_expired(&uart->rx_timer)));
+    PBIO_OS_AWAIT_UNTIL(state, pbdrv_uart_get_num_available(uart) >= uart->read_length || (timeout && pbio_os_timer_is_expired(&uart->rx_timer)));
     if (timeout && pbio_os_timer_is_expired(&uart->rx_timer)) {
         uart->read_buf = NULL;
         uart->read_length = 0;
@@ -225,14 +225,14 @@ pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uin
     uart->read_buf = NULL;
     uart->read_length = 0;
 
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout) {
 
     const pbdrv_uart_stm32l4_ll_dma_platform_data_t *pdata = uart->pdata;
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     if (LL_USART_IsEnabledDMAReq_TX(pdata->uart)) {
         return PBIO_ERROR_BUSY;
@@ -252,13 +252,13 @@ pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, ui
         pbio_os_timer_set(&uart->tx_timer, timeout);
     }
 
-    AWAIT_WHILE(state, LL_USART_IsEnabledDMAReq_TX(pdata->uart) && !(timeout && pbio_os_timer_is_expired(&uart->tx_timer)));
+    PBIO_OS_AWAIT_WHILE(state, LL_USART_IsEnabledDMAReq_TX(pdata->uart) && !(timeout && pbio_os_timer_is_expired(&uart->tx_timer)));
     if ((timeout && pbio_os_timer_is_expired(&uart->tx_timer))) {
         LL_USART_DisableDMAReq_TX(pdata->uart);
         return PBIO_ERROR_TIMEDOUT;
     }
 
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 void pbdrv_uart_set_baud_rate(pbdrv_uart_dev_t *uart, uint32_t baud) {

--- a/lib/pbio/include/pbdrv/i2c.h
+++ b/lib/pbio/include/pbdrv/i2c.h
@@ -27,7 +27,7 @@ typedef struct _pbdrv_i2c_dev_t pbdrv_i2c_dev_t;
  * @param [in]  parent_process  The parent process. Allows I2C to poll process on IRQ events.
  * @param [out] i2c_dev         The I2C device.
  */
-pbio_error_t pbdrv_i2c_get_instance(uint8_t id, struct process *parent_process, pbdrv_i2c_dev_t **i2c_dev);
+pbio_error_t pbdrv_i2c_get_instance(uint8_t id, pbdrv_i2c_dev_t **i2c_dev);
 
 /**
  * Does an I2C operation. To be replaced.
@@ -45,7 +45,7 @@ pbio_error_t pbdrv_i2c_placeholder_operation(pbdrv_i2c_dev_t *i2c_dev, const cha
 
 #else // PBDRV_CONFIG_I2C
 
-static inline pbio_error_t pbdrv_i2c_get_instance(uint8_t id, struct process *parent_process, pbdrv_i2c_dev_t **i2c_dev) {
+static inline pbio_error_t pbdrv_i2c_get_instance(uint8_t id, pbdrv_i2c_dev_t **i2c_dev) {
     *i2c_dev = NULL;
     return PBIO_ERROR_NOT_SUPPORTED;
 }

--- a/lib/pbio/include/pbdrv/uart.h
+++ b/lib/pbio/include/pbdrv/uart.h
@@ -10,15 +10,14 @@
 #define _PBDRV_UART_H_
 
 #include <stdint.h>
+#include <stddef.h>
 
 #include <pbdrv/config.h>
 #include <pbio/error.h>
+#include <pbio/os.h>
 #include <pbio/port.h>
-#include <contiki.h>
 
 typedef struct _pbdrv_uart_dev_t pbdrv_uart_dev_t;
-
-typedef void (*pbdrv_uart_poll_callback_t)(void *context);
 
 #if PBDRV_CONFIG_UART
 
@@ -26,10 +25,9 @@ typedef void (*pbdrv_uart_poll_callback_t)(void *context);
  * Get an instance of the UART driver.
  *
  * @param [in]  id              The ID of the UART device.
- * @param [in]  parent_process  The parent process. Allows UART to poll process on IRQ events.
  * @param [out] uart_dev        The UART device.
  */
-pbio_error_t pbdrv_uart_get_instance(uint8_t id, struct process *parent_process, pbdrv_uart_dev_t **uart_dev);
+pbio_error_t pbdrv_uart_get_instance(uint8_t id, pbdrv_uart_dev_t **uart_dev);
 
 void pbdrv_uart_set_baud_rate(pbdrv_uart_dev_t *uart_dev, uint32_t baud);
 void pbdrv_uart_stop(pbdrv_uart_dev_t *uart_dev);
@@ -40,30 +38,31 @@ int32_t pbdrv_uart_get_char(pbdrv_uart_dev_t *uart_dev);
 /**
  * Asynchronously read from the UART.
  *
- * @param [in]  pt        The protothread.
+ * @param [in]  state     The protothread state.
  * @param [in]  uart_dev  The UART device.
  * @param [out] msg       The buffer to store the received message.
  * @param [in]  length    The length of the expected message.
  * @param [in]  timeout   The timeout in milliseconds or 0 for no timeout.
- * @param [out] err       The error code.
+ * @return The error code.
  */
-PT_THREAD(pbdrv_uart_read(struct pt *pt, pbdrv_uart_dev_t *uart_dev, uint8_t *msg, uint8_t length, uint32_t timeout, pbio_error_t *err));
+pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart_dev, uint8_t *msg, uint8_t length, uint32_t timeout);
 
 /**
  * Asynchronously write to the UART.
  *
- * @param [in]  pt        The protothread.
+ * @param [in]  state     The protothread state.
  * @param [in]  uart_dev  The UART device.
  * @param [in]  msg       The message to send.
  * @param [in]  length    The length of the message.
  * @param [in]  timeout   The timeout in milliseconds or 0 for no timeout.
- * @param [out] err       The error code.
+ *
+ * @return The error code.
  */
-PT_THREAD(pbdrv_uart_write(struct pt *pt, pbdrv_uart_dev_t *uart_dev, uint8_t *msg, uint8_t length, uint32_t timeout, pbio_error_t *err));
+pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart, uint8_t *msg, uint8_t length, uint32_t timeout);
 
 #else // PBDRV_CONFIG_UART
 
-static inline pbio_error_t pbdrv_uart_get_instance(uint8_t id, struct process *parent_process, pbdrv_uart_dev_t **uart_dev) {
+static inline pbio_error_t pbdrv_uart_get_instance(uint8_t id, pbdrv_uart_dev_t **uart_dev) {
     *uart_dev = NULL;
     return PBIO_ERROR_NOT_SUPPORTED;
 }
@@ -98,16 +97,12 @@ static inline int32_t pbdrv_uart_get_char(pbdrv_uart_dev_t *uart_dev) {
     return -1;
 }
 
-static inline PT_THREAD(pbdrv_uart_write(struct pt *pt, pbdrv_uart_dev_t *uart_dev, uint8_t *msg, uint8_t length, uint32_t timeout, pbio_error_t *err)) {
-    PT_BEGIN(pt);
-    *err = PBIO_ERROR_NOT_SUPPORTED;
-    PT_END(pt);
+static inline pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart_dev, uint8_t *msg, uint8_t length, uint32_t timeout) {
+    return PBIO_ERROR_NOT_SUPPORTED;
 }
 
-static inline PT_THREAD(pbdrv_uart_read(struct pt *pt, pbdrv_uart_dev_t *uart_dev, uint8_t *msg, uint8_t length, uint32_t timeout, pbio_error_t *err)) {
-    PT_BEGIN(pt);
-    *err = PBIO_ERROR_NOT_SUPPORTED;
-    PT_END(pt);
+static inline pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart_dev, uint8_t *msg, uint8_t length, uint32_t timeout) {
+    return PBIO_ERROR_NOT_SUPPORTED;
 }
 
 #endif // PBDRV_CONFIG_UART

--- a/lib/pbio/include/pbio/config.h
+++ b/lib/pbio/include/pbio/config.h
@@ -30,4 +30,11 @@
 
 #define PBIO_CONFIG_NUM_DRIVEBASES (PBIO_CONFIG_SERVO_NUM_DEV / 2)
 
+#ifndef PBIO_CONFIG_OS_IRQ_FLAGS_TYPE
+#include <stdint.h>
+#define PBIO_CONFIG_OS_IRQ_FLAGS_TYPE uint32_t
+#endif
+
+typedef PBIO_CONFIG_OS_IRQ_FLAGS_TYPE pbio_os_irq_flags_t;
+
 #endif // _PBIO_CONFIG_H_

--- a/lib/pbio/include/pbio/os.h
+++ b/lib/pbio/include/pbio/os.h
@@ -269,7 +269,7 @@ struct _pbio_os_process_t {
 
 bool pbio_os_run_processes_once(void);
 
-void pbio_os_run_while_idle(void);
+void pbio_os_run_processes_and_wait_for_event(void);
 
 void pbio_os_request_poll(void);
 

--- a/lib/pbio/include/pbio/os.h
+++ b/lib/pbio/include/pbio/os.h
@@ -48,6 +48,9 @@
  *
  * The code in this file stems from Contiki's implementation of protothreads as
  * listed above. This adaptation changes the API to work better with Pybricks.
+ *
+ * Caution: it is conceptually very similar to Contiki but it cannot be used as
+ * a drop-in replacement.
  */
 
 #ifndef _PBIO_OS_H_
@@ -148,8 +151,6 @@ struct _pbio_os_process_t {
  *
  * This macro is used for declaring that a protothread ends. It must
  * always be used together with a matching ASYNC_BEGIN() macro.
- *
- * NB: In contrast to Contiki, this does not call ASYNC_INIT() before exiting.
  *
  * @param [in]  err    Error code to return.
  */

--- a/lib/pbio/include/pbio/os.h
+++ b/lib/pbio/include/pbio/os.h
@@ -208,7 +208,7 @@ struct _pbio_os_process_t {
 
 /**
  * Awaits two protothreads until one of them completes successfully or returns
- * an error.
+ * an error. There is no cleanup of the other protothread.
  *
  * @param [in]  host_state             State of the host protothread in which this macro is used.
  * @param [in]  sub_state_1            State of the first sub protothread.
@@ -250,6 +250,13 @@ struct _pbio_os_process_t {
         }                                       \
     } while (0)
 
+/**
+ * Yields the protothread until the specified timer expires.
+ * 
+ * @param [in]  state     Protothread state.
+ * @param [in]  timer     The timer to check.
+ * @param [in]  duration  The duration to wait for in milliseconds.
+ */
 #define PBIO_OS_AWAIT_MS(state, timer, duration)      \
     do {                                              \
         pbio_os_timer_set(timer, duration);           \
@@ -269,7 +276,7 @@ pbio_error_t pbio_port_process_none_thread(pbio_os_state_t *state, void *context
 
 void pbio_os_process_start(pbio_os_process_t *process, pbio_os_process_func_t func, void *context);
 
-void pbio_os_process_reset(pbio_os_process_t *process, pbio_os_process_func_t func);
+void pbio_os_process_init(pbio_os_process_t *process, pbio_os_process_func_t func);
 
 /**
  * Disables interrupts and returns the previous interrupt state.

--- a/lib/pbio/include/pbio/os.h
+++ b/lib/pbio/include/pbio/os.h
@@ -136,9 +136,12 @@ struct _pbio_os_process_t {
  * which the protothread runs. All C statements above the ASYNC_BEGIN()
  * invocation will be executed each time the protothread is scheduled.
  *
+ * The do_yield_now variable is used only to facilitate the AWAIT_ONCE macro.
+ * It shouldn't take any space if unused and optimizations are enabled.
+ *
  * @param [in]  state    Protothread state.
  */
-#define ASYNC_BEGIN(state) { char do_yield_now = 0; if (do_yield_now) {;} PB_LC_RESUME(state)
+#define ASYNC_BEGIN(state) { char do_yield_now = 0; (void)do_yield_now; PB_LC_RESUME(state)
 
 /**
  * Declare the end of a protothread and returns with given code.

--- a/lib/pbio/include/pbio/os.h
+++ b/lib/pbio/include/pbio/os.h
@@ -279,29 +279,4 @@ void pbio_os_process_start(pbio_os_process_t *process, pbio_os_process_func_t fu
 
 void pbio_os_process_init(pbio_os_process_t *process, pbio_os_process_func_t func);
 
-/**
- * Disables interrupts and returns the previous interrupt state.
- *
- * Must be implemented by the platform.
- *
- * @return  The previous interrupt state.
- */
-pbio_os_irq_flags_t pbio_os_hook_disable_irq(void);
-
-/**
- * Enables interrupts.
- *
- * Must be implemented by the platform.
- *
- * @param [in]  flags  The previous interrupt state.
- */
-void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags);
-
-/**
- * Waits for an interrupt.
- *
- * Must be implemented by the platform.
- */
-void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags);
-
 #endif // _PBIO_OS_H_

--- a/lib/pbio/include/pbio/os.h
+++ b/lib/pbio/include/pbio/os.h
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2004-2005, Swedish Institute of Computer Science
+// Copyright (c) 2025 The Pybricks Authors
+
+/*
+ * Copyright (c) 2004-2005, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUASYNCION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ * Implementation of local continuations based on switch() statement
+ *
+ * This implementation of local continuations uses the C switch()
+ * statement to resume execution of a function somewhere inside the
+ * function's body. The implementation is based on the fact that
+ * switch() statements are able to jump directly into the bodies of
+ * control structures such as if() or while() statements.
+ *
+ * This implementation borrows heavily from Simon Tatham's coroutines
+ * implementation in C:
+ * http://www.chiark.greenend.org.uk/~sgtatham/coroutines.html
+ *
+ * ---------------------------------------------------------------------------
+ *
+ * The code in this file stems from Contiki's implementation of protothreads as
+ * listed above. This adaptation changes the API to work better with Pybricks.
+ */
+
+#ifndef _PBIO_OS_H_
+#define _PBIO_OS_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <pbio/error.h>
+
+/**
+ * Millisecond timer.
+ */
+typedef struct pbio_os_timer_t {
+    uint32_t start;
+    uint32_t duration;
+} pbio_os_timer_t;
+
+void pbio_os_timer_set(pbio_os_timer_t *timer, uint32_t duration);
+
+bool pbio_os_timer_is_expired(pbio_os_timer_t *timer);
+
+
+/**
+ * WARNING! LC implementation using switch() does not work if an
+ * PB_LC_SET() is done within another switch() statement!
+ */
+
+#define PB_LC_FALLTHROUGH __attribute__((fallthrough));
+#define PB_LC_INIT(state) *state = 0;
+#define PB_LC_RESUME(state) switch (*state) { case 0:
+#define PB_LC_SET(state) *state = __LINE__; PB_LC_FALLTHROUGH; case __LINE__:
+#define PB_LC_END() }
+
+/**
+ * Protothread state. Effectively the line number in the current file where it
+ * yields so it can jump there to resume later.
+ */
+typedef uint32_t pbio_os_state_t;
+
+typedef pbio_error_t (*pbio_os_process_func_t)(pbio_os_state_t *state);
+
+typedef struct _pbio_os_process_t pbio_os_process_t;
+
+/**
+ * A process.
+ */
+struct _pbio_os_process_t {
+    /**
+     * Pointer to the next process in the list.
+     */
+    pbio_os_process_t *next;
+    /**
+     * State of the protothread.
+     */
+    pbio_os_state_t state;
+    /**
+     * The protothread.
+     */
+    pbio_os_process_func_t func;
+    /**
+     * Most recent result of running one iteration of the protothread.
+     */
+    pbio_error_t err;
+};
+
+/**
+ * Initialize a protothread.
+ *
+ * Initializes a protothread. Initialization must be done prior to
+ * starting to execute the protothread.
+ *
+ * @param [in]  state    Protothread state.
+ */
+#define ASYNC_INIT(state)   PB_LC_INIT(state)
+
+/**
+ * Declare the start of a protothread inside the C function
+ * implementing the protothread.
+ *
+ * This macro is used to declare the starting point of a
+ * protothread. It should be placed at the start of the function in
+ * which the protothread runs. All C statements above the ASYNC_BEGIN()
+ * invocation will be executed each time the protothread is scheduled.
+ *
+ * @param [in]  state    Protothread state.
+ */
+#define ASYNC_BEGIN(state) { PB_LC_RESUME(state)
+
+/**
+ * Declare the end of a protothread and returns with given code.
+ *
+ * This macro is used for declaring that a protothread ends. It must
+ * always be used together with a matching ASYNC_BEGIN() macro.
+ *
+ * NB: In contrast to Contiki, this does not call ASYNC_INIT() before exiting.
+ *
+ * @param [in]  err    Error code to return.
+ */
+#define ASYNC_END(err) PB_LC_END(); return err; }
+
+/**
+ * Yields the protothread while the specified condition is true.
+ *
+ * @param [in]  state     Protothread state.
+ * @param [in]  condition The condition.
+ */
+#define AWAIT_WHILE(state, condition)            \
+    do {                                         \
+        PB_LC_SET(state);                        \
+        if (condition) {                         \
+            return PBIO_ERROR_AGAIN;             \
+        }                                        \
+    } while (0)
+
+
+#define AWAIT(state, child, statement)          \
+    do {                                        \
+        ASYNC_INIT((child));                    \
+        PB_LC_SET(state);                       \
+        if ((statement) == PBIO_ERROR_AGAIN) {  \
+            return PBIO_ERROR_AGAIN;            \
+        }                                       \
+    } while (0)
+
+#define AWAIT_MS(state, timer, duration)        \
+    do {                                        \
+        pbio_os_timer_set(timer, duration);     \
+        PB_LC_SET(state);                       \
+        if (!pbio_os_timer_is_expired(timer)) { \
+            return PBIO_ERROR_AGAIN;            \
+        }                                       \
+    } while (0)                                 \
+
+bool pbio_os_run_processes_once(void);
+
+void pbio_os_run_while_idle(void);
+
+void pbio_os_request_poll(void);
+
+void pbio_os_start_process(pbio_os_process_t *process, pbio_os_process_func_t func);
+
+/**
+ * Disables interrupts and returns the previous interrupt state.
+ *
+ * Must be implemented by the platform.
+ *
+ * @return  The previous interrupt state.
+ */
+uint32_t pbio_os_hook_disable_irq(void);
+
+/**
+ * Enables interrupts.
+ *
+ * Must be implemented by the platform.
+ *
+ * @param [in]  flags  The previous interrupt state.
+ */
+void pbio_os_hook_enable_irq(uint32_t flags);
+
+/**
+ * Waits for an interrupt.
+ *
+ * Must be implemented by the platform.
+ */
+void pbio_os_hook_wait_for_interrupt(void);
+
+#endif // _PBIO_OS_H_

--- a/lib/pbio/include/pbio/os.h
+++ b/lib/pbio/include/pbio/os.h
@@ -166,6 +166,19 @@ struct _pbio_os_process_t {
         }                                        \
     } while (0)
 
+/**
+ * Yields the protothread until the specified condition is true.
+ *
+ * @param [in]  state     Protothread state.
+ * @param [in]  condition The condition.
+ */
+#define AWAIT_UNTIL(state, condition)            \
+    do {                                         \
+        PB_LC_SET(state);                        \
+        if (!(condition)) {                      \
+            return PBIO_ERROR_AGAIN;             \
+        }                                        \
+    } while (0)
 
 #define AWAIT(state, child, statement)          \
     do {                                        \
@@ -174,6 +187,16 @@ struct _pbio_os_process_t {
         if ((statement) == PBIO_ERROR_AGAIN) {  \
             return PBIO_ERROR_AGAIN;            \
         }                                       \
+    } while (0)
+
+#define AWAIT_RACE(state, child1, child2, statement1, statement2)                    \
+    do {                                                                             \
+        ASYNC_INIT((child1));                                                        \
+        ASYNC_INIT((child2));                                                        \
+        PB_LC_SET(state);                                                            \
+        if ((statement1) == PBIO_ERROR_AGAIN && (statement2) == PBIO_ERROR_AGAIN) {  \
+            return PBIO_ERROR_AGAIN;                                                 \
+        }                                                                            \
     } while (0)
 
 #define AWAIT_MS(state, timer, duration)        \
@@ -191,7 +214,11 @@ void pbio_os_run_while_idle(void);
 
 void pbio_os_request_poll(void);
 
-void pbio_os_start_process(pbio_os_process_t *process, pbio_os_process_func_t func, void *context);
+pbio_error_t pbio_port_process_none_thread(pbio_os_state_t *state, void *context);
+
+void pbio_os_process_start(pbio_os_process_t *process, pbio_os_process_func_t func, void *context);
+
+void pbio_os_process_reset(pbio_os_process_t *process, pbio_os_process_func_t func);
 
 /**
  * Disables interrupts and returns the previous interrupt state.

--- a/lib/pbio/include/pbio/os.h
+++ b/lib/pbio/include/pbio/os.h
@@ -87,7 +87,7 @@ bool pbio_os_timer_is_expired(pbio_os_timer_t *timer);
  */
 typedef uint32_t pbio_os_state_t;
 
-typedef pbio_error_t (*pbio_os_process_func_t)(pbio_os_state_t *state);
+typedef pbio_error_t (*pbio_os_process_func_t)(pbio_os_state_t *state, void *context);
 
 typedef struct _pbio_os_process_t pbio_os_process_t;
 
@@ -107,6 +107,10 @@ struct _pbio_os_process_t {
      * The protothread.
      */
     pbio_os_process_func_t func;
+    /**
+     * Context passed on each call to the protothread.
+     */
+    void *context;
     /**
      * Most recent result of running one iteration of the protothread.
      */
@@ -187,7 +191,7 @@ void pbio_os_run_while_idle(void);
 
 void pbio_os_request_poll(void);
 
-void pbio_os_start_process(pbio_os_process_t *process, pbio_os_process_func_t func);
+void pbio_os_start_process(pbio_os_process_t *process, pbio_os_process_func_t func, void *context);
 
 /**
  * Disables interrupts and returns the previous interrupt state.

--- a/lib/pbio/include/pbio/os.h
+++ b/lib/pbio/include/pbio/os.h
@@ -58,6 +58,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <pbio/config.h>
 #include <pbio/error.h>
 
 /**
@@ -252,7 +253,7 @@ struct _pbio_os_process_t {
 
 /**
  * Yields the protothread until the specified timer expires.
- * 
+ *
  * @param [in]  state     Protothread state.
  * @param [in]  timer     The timer to check.
  * @param [in]  duration  The duration to wait for in milliseconds.
@@ -285,7 +286,7 @@ void pbio_os_process_init(pbio_os_process_t *process, pbio_os_process_func_t fun
  *
  * @return  The previous interrupt state.
  */
-uint32_t pbio_os_hook_disable_irq(void);
+pbio_os_irq_flags_t pbio_os_hook_disable_irq(void);
 
 /**
  * Enables interrupts.
@@ -294,13 +295,13 @@ uint32_t pbio_os_hook_disable_irq(void);
  *
  * @param [in]  flags  The previous interrupt state.
  */
-void pbio_os_hook_enable_irq(uint32_t flags);
+void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags);
 
 /**
  * Waits for an interrupt.
  *
  * Must be implemented by the platform.
  */
-void pbio_os_hook_wait_for_interrupt(void);
+void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags);
 
 #endif // _PBIO_OS_H_

--- a/lib/pbio/include/pbio/port_dcm.h
+++ b/lib/pbio/include/pbio/port_dcm.h
@@ -4,9 +4,9 @@
 #ifndef _PBIO_PORT_DCM_H_
 #define _PBIO_PORT_DCM_H_
 
-#include <contiki.h>
 #include <pbio/config.h>
 #include <pbio/port.h>
+#include <pbio/os.h>
 #include <pbdrv/ioport.h>
 
 typedef struct _pbio_port_dcm_t pbio_port_dcm_t;
@@ -27,7 +27,7 @@ typedef struct {
 
 #if PBIO_CONFIG_PORT_DCM
 
-PT_THREAD(pbio_port_dcm_thread(struct pt *pt, struct etimer *etimer, pbio_port_dcm_t *dcm, const pbdrv_ioport_pins_t *pins));
+pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer, pbio_port_dcm_t *dcm, const pbdrv_ioport_pins_t *pins);
 
 /**
  * Gets device connection manager state.
@@ -82,9 +82,8 @@ static inline pbio_port_dcm_analog_rgba_t *pbio_port_dcm_get_analog_rgba(pbio_po
     return NULL;
 }
 
-static inline PT_THREAD(pbio_port_dcm_thread(struct pt *pt, struct etimer *etimer, pbio_port_dcm_t *dcm, const pbdrv_ioport_pins_t *pins)) {
-    PT_BEGIN(pt);
-    PT_END(pt);
+static inline pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer, pbio_port_dcm_t *dcm, const pbdrv_ioport_pins_t *pins) {
+    return PBIO_ERROR_NOT_SUPPORTED;
 }
 
 #endif // PBIO_CONFIG_PORT_DCM

--- a/lib/pbio/include/pbio/port_interface.h
+++ b/lib/pbio/include/pbio/port_interface.h
@@ -70,8 +70,6 @@ void pbio_port_stop_user_actions(bool reset);
 
 pbio_error_t pbio_port_get_port(pbio_port_id_t id, pbio_port_t **port);
 
-void pbio_port_select_process(pbio_port_t *port);
-
 pbio_error_t pbio_port_get_dcmotor(pbio_port_t *port, lego_device_type_id_t *expected_type_id, pbio_dcmotor_t **dcmotor);
 
 pbio_error_t pbio_port_get_servo(pbio_port_t *port, lego_device_type_id_t *expected_type_id, pbio_servo_t **servo);

--- a/lib/pbio/include/pbio/port_lump.h
+++ b/lib/pbio/include/pbio/port_lump.h
@@ -4,9 +4,10 @@
 #ifndef _PBIO_PORT_LUMP_H_
 #define _PBIO_PORT_LUMP_H_
 
-#include <contiki.h>
 #include <pbio/angle.h>
 #include <pbio/port.h>
+#include <pbio/os.h>
+
 #include <pbdrv/ioport.h>
 #include <pbdrv/uart.h>
 
@@ -30,13 +31,13 @@ typedef struct {
 
 #if PBIO_CONFIG_PORT_LUMP
 
-pbio_port_lump_dev_t *pbio_port_lump_init_instance(uint8_t device_index, struct process *parent_process);
+pbio_port_lump_dev_t *pbio_port_lump_init_instance(uint8_t device_index);
 
-PT_THREAD(pbio_port_lump_sync_thread(struct pt *pt, pbio_port_lump_dev_t *lump_dev, pbdrv_uart_dev_t *uart_dev, struct etimer *etimer));
+pbio_error_t pbio_port_lump_sync_thread(pbio_os_state_t *state, pbio_port_lump_dev_t *lump_dev, pbdrv_uart_dev_t *uart_dev, pbio_os_timer_t *timer);
 
-PT_THREAD(pbio_port_lump_data_send_thread(struct pt *pt, pbio_port_lump_dev_t *lump_dev, pbdrv_uart_dev_t *uart_dev, struct etimer *etimer));
+pbio_error_t pbio_port_lump_data_send_thread(pbio_os_state_t *state, pbio_port_lump_dev_t *lump_dev, pbdrv_uart_dev_t *uart_dev, pbio_os_timer_t *timer);
 
-PT_THREAD(pbio_port_lump_data_recv_thread(struct pt *pt, pbio_port_lump_dev_t *lump_dev, pbdrv_uart_dev_t *uart_dev));
+pbio_error_t pbio_port_lump_data_recv_thread(pbio_os_state_t *state, pbio_port_lump_dev_t *lump_dev, pbdrv_uart_dev_t *uart_dev);
 
 pbio_error_t pbio_port_lump_is_ready(pbio_port_lump_dev_t *lump_dev);
 
@@ -58,7 +59,7 @@ pbio_port_power_requirements_t pbio_port_lump_get_power_requirements(pbio_port_l
 
 #else // PBIO_CONFIG_PORT_LUMP
 
-static inline pbio_port_lump_dev_t *pbio_port_lump_init_instance(uint8_t device_index, struct process *parent_process) {
+static inline pbio_port_lump_dev_t *pbio_port_lump_init_instance(uint8_t device_index) {
     return NULL;
 }
 
@@ -101,21 +102,17 @@ static inline pbio_port_power_requirements_t pbio_port_lump_get_power_requiremen
     return PBIO_PORT_POWER_REQUIREMENTS_NONE;
 }
 
-static inline PT_THREAD(pbio_port_lump_sync_thread(struct pt *pt, pbio_port_lump_dev_t *lump_dev, pbdrv_uart_dev_t *uart_dev, struct etimer *etimer)) {
-    PT_BEGIN(pt);
-    PT_END(pt);
+static inline pbio_error_t pbio_port_lump_sync_thread(pbio_os_state_t *state, pbio_port_lump_dev_t *lump_dev, pbdrv_uart_dev_t *uart_dev, pbio_os_timer_t *timer) {
+    return PBIO_ERROR_NOT_SUPPORTED;
 }
 
-static inline PT_THREAD(pbio_port_lump_data_send_thread(struct pt *pt, pbio_port_lump_dev_t *lump_dev, pbdrv_uart_dev_t *uart_dev, struct etimer *etimer)) {
-    PT_BEGIN(pt);
-    PT_END(pt);
+static inline pbio_error_t pbio_port_lump_data_send_thread(pbio_os_state_t *state, pbio_port_lump_dev_t *lump_dev, pbdrv_uart_dev_t *uart_dev, pbio_os_timer_t *timer) {
+    return PBIO_ERROR_NOT_SUPPORTED;
 }
 
-static inline PT_THREAD(pbio_port_lump_data_recv_thread(struct pt *pt, pbio_port_lump_dev_t *lump_dev, pbdrv_uart_dev_t *uart_dev)) {
-    PT_BEGIN(pt);
-    PT_END(pt);
+static inline pbio_error_t pbio_port_lump_data_recv_thread(pbio_os_state_t *state, pbio_port_lump_dev_t *lump_dev, pbdrv_uart_dev_t *uart_dev) {
+    return PBIO_ERROR_NOT_SUPPORTED;
 }
-
 
 #endif // PBIO_CONFIG_PORT_LUMP
 

--- a/lib/pbio/platform/city_hub/pbio_os_config.h
+++ b/lib/pbio/platform/city_hub/pbio_os_config.h
@@ -1,0 +1,19 @@
+#include <stdint.h>
+
+#include "stm32f0xx.h"
+
+typedef uint32_t pbio_os_irq_flags_t;
+
+static inline pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
+    uint32_t flags = __get_PRIMASK();
+    __disable_irq();
+    return flags;
+}
+
+static inline void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
+    __set_PRIMASK(flags);
+}
+
+static inline void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
+    __WFI();
+}

--- a/lib/pbio/platform/essential_hub/pbio_os_config.h
+++ b/lib/pbio/platform/essential_hub/pbio_os_config.h
@@ -1,0 +1,19 @@
+#include <stdint.h>
+
+#include "stm32f4xx.h"
+
+typedef uint32_t pbio_os_irq_flags_t;
+
+static inline pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
+    uint32_t flags = __get_PRIMASK();
+    __disable_irq();
+    return flags;
+}
+
+static inline void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
+    __set_PRIMASK(flags);
+}
+
+static inline void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
+    __WFI();
+}

--- a/lib/pbio/platform/ev3/pbio_os_config.h
+++ b/lib/pbio/platform/ev3/pbio_os_config.h
@@ -1,0 +1,21 @@
+#include <stdint.h>
+
+#include <tiam1808/armv5/am1808/interrupt.h>
+
+typedef uint32_t pbio_os_irq_flags_t;
+
+static inline pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
+    return IntDisable();
+}
+
+static inline void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
+    IntEnable(flags);
+}
+
+static inline void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
+    __asm volatile (
+        "mov	r0, #0\n"
+        "mcr	p15, 0, r0, c7, c0, 4\n"
+        ::: "r0"
+        );
+}

--- a/lib/pbio/platform/move_hub/pbio_os_config.h
+++ b/lib/pbio/platform/move_hub/pbio_os_config.h
@@ -1,0 +1,19 @@
+#include <stdint.h>
+
+#include "stm32f0xx.h"
+
+typedef uint32_t pbio_os_irq_flags_t;
+
+static inline pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
+    uint32_t flags = __get_PRIMASK();
+    __disable_irq();
+    return flags;
+}
+
+static inline void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
+    __set_PRIMASK(flags);
+}
+
+static inline void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
+    __WFI();
+}

--- a/lib/pbio/platform/nxt/pbio_os_config.h
+++ b/lib/pbio/platform/nxt/pbio_os_config.h
@@ -1,0 +1,19 @@
+#include <stdint.h>
+
+#include <nxos/interrupts.h>
+#include <at91sam7s256.h>
+
+typedef uint32_t pbio_os_irq_flags_t;
+
+static inline pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
+    return nx_interrupts_disable();
+}
+
+static inline void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
+    nx_interrupts_enable(flags);
+}
+
+static inline void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
+    // disable the processor clock which puts it in Idle Mode.
+    AT91C_BASE_PMC->PMC_SCDR = AT91C_PMC_PCK;
+}

--- a/lib/pbio/platform/nxt/platform.c
+++ b/lib/pbio/platform/nxt/platform.c
@@ -9,6 +9,8 @@
 #include <pbdrv/reset.h>
 #include <pbio/button.h>
 #include <pbio/main.h>
+#include <pbio/os.h>
+
 #include <pbsys/core.h>
 #include <pbsys/main.h>
 #include <pbsys/program_stop.h>
@@ -75,13 +77,13 @@ static bool bluetooth_connect(void) {
                     return false;
                 }
 
-                pbio_do_one_event();
+                pbio_os_run_processes_once();
             }
 
             nx_bt_stream_open(connection_handle);
         }
 
-        pbio_do_one_event();
+        pbio_os_run_processes_once();
     }
 
     nx_display_clear();
@@ -131,7 +133,7 @@ void SystemInit(void) {
                 goto out;
             }
 
-            pbio_do_one_event();
+            pbio_os_run_processes_once();
         }
 
         nx_display_string("Connected. REPL.\n");

--- a/lib/pbio/platform/prime_hub/pbio_os_config.h
+++ b/lib/pbio/platform/prime_hub/pbio_os_config.h
@@ -1,0 +1,19 @@
+#include <stdint.h>
+
+#include "stm32f4xx.h"
+
+typedef uint32_t pbio_os_irq_flags_t;
+
+static inline pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
+    uint32_t flags = __get_PRIMASK();
+    __disable_irq();
+    return flags;
+}
+
+static inline void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
+    __set_PRIMASK(flags);
+}
+
+static inline void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
+    __WFI();
+}

--- a/lib/pbio/platform/technic_hub/pbio_os_config.h
+++ b/lib/pbio/platform/technic_hub/pbio_os_config.h
@@ -1,0 +1,19 @@
+#include <stdint.h>
+
+#include "stm32l4xx.h"
+
+typedef uint32_t pbio_os_irq_flags_t;
+
+static inline pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
+    uint32_t flags = __get_PRIMASK();
+    __disable_irq();
+    return flags;
+}
+
+static inline void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
+    __set_PRIMASK(flags);
+}
+
+static inline void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
+    __WFI();
+}

--- a/lib/pbio/platform/test/pbio_os_config.h
+++ b/lib/pbio/platform/test/pbio_os_config.h
@@ -1,0 +1,13 @@
+#include <stdint.h>
+
+typedef uint32_t pbio_os_irq_flags_t;
+
+static inline pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
+    return 0;
+}
+
+static inline void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
+}
+
+static inline void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
+}

--- a/lib/pbio/platform/virtual_hub/pbio_os_config.h
+++ b/lib/pbio/platform/virtual_hub/pbio_os_config.h
@@ -1,0 +1,9 @@
+#include <signal.h>
+
+typedef sigset_t pbio_os_irq_flags_t;
+
+pbio_os_irq_flags_t pbio_os_hook_disable_irq(void);
+
+void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags);
+
+void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags);

--- a/lib/pbio/platform/virtual_hub/pbioconfig.h
+++ b/lib/pbio/platform/virtual_hub/pbioconfig.h
@@ -27,3 +27,6 @@
 #define PBIO_CONFIG_TACHO                   (1)
 
 #define PBIO_CONFIG_ENABLE_SYS              (1)
+
+#include <signal.h>
+#define PBIO_CONFIG_OS_IRQ_FLAGS_TYPE       sigset_t

--- a/lib/pbio/platform/virtual_hub/platform.c
+++ b/lib/pbio/platform/virtual_hub/platform.c
@@ -3,6 +3,8 @@
 
 #include "../../drv/motor_driver/motor_driver_virtual_simulation.h"
 
+#include "pbio_os_config.h"
+
 #include <pbio/port_interface.h>
 #include <pbdrv/config.h>
 #include <pbdrv/ioport.h>

--- a/lib/pbio/src/motor_process.c
+++ b/lib/pbio/src/motor_process.c
@@ -18,7 +18,7 @@ static pbio_error_t pbio_motor_process_thread(pbio_os_state_t *state, void *cont
 
     static pbio_os_timer_t timer;
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     timer.start = pbdrv_clock_get_ms() - PBIO_CONFIG_CONTROL_LOOP_TIME_MS;
     timer.duration = PBIO_CONFIG_CONTROL_LOOP_TIME_MS;
@@ -47,11 +47,11 @@ static pbio_error_t pbio_motor_process_thread(pbio_os_state_t *state, void *cont
             timer.start++;
         }
 
-        AWAIT_UNTIL(state, pbio_os_timer_is_expired(&timer));
+        PBIO_OS_AWAIT_UNTIL(state, pbio_os_timer_is_expired(&timer));
     }
 
     // Unreachable.
-    ASYNC_END(PBIO_ERROR_FAILED);
+    PBIO_OS_ASYNC_END(PBIO_ERROR_FAILED);
 }
 
 void pbio_motor_process_start(void) {

--- a/lib/pbio/src/os.c
+++ b/lib/pbio/src/os.c
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 The Pybricks Authors
+
+#include <stdbool.h>
+
+#include <pbio/os.h>
+#include <pbio/util.h>
+
+#include <stdio.h>
+#include <pbdrv/clock.h>
+
+/**
+ * Sets the timer to expire after the specified duration.
+ *
+ * The 1ms interrupt polls all processes, so no special events are needed.
+ *
+ * @param timer     The timer to initialize.
+ * @param duration  The duration in milliseconds.
+ */
+void pbio_os_timer_set(pbio_os_timer_t *timer, uint32_t duration) {
+    timer->start = pbdrv_clock_get_ms();
+    timer->duration = duration;
+}
+
+/**
+ * Whether the timer has expired.
+ *
+ * @param timer     The timer to check.
+ * @return          Whether the timer has expired.
+ */
+bool pbio_os_timer_is_expired(pbio_os_timer_t *timer) {
+    return pbdrv_clock_get_ms() - timer->start >= timer->duration;
+}
+
+/**
+ * Whether a poll request is pending.
+ */
+static bool poll_request_is_pending = false;
+
+/**
+ * Request that the event loop polls all processes.
+ */
+void pbio_os_request_poll(void) {
+    poll_request_is_pending = true;
+}
+
+static pbio_os_process_t *process_list = NULL;
+
+/**
+ * Starts a process.
+ *
+ * NB: Processes can be started only once. They cannot be restarted.
+ *
+ * @param process   The process to start.
+ * @param func      The process thread function.
+ */
+void pbio_os_start_process(pbio_os_process_t *process, pbio_os_process_func_t func) {
+
+    // Add the new process to the end of the list.
+    pbio_os_process_t *last = process_list;
+    if (!last) {
+        process_list = process;
+    } else {
+        while (last->next) {
+            last = last->next;
+        }
+        last->next = process;
+    }
+
+    // Initialize the process.
+    process->func = func;
+    process->next = NULL;
+    process->err = PBIO_ERROR_AGAIN;
+    process->state = 0;
+}
+
+/**
+ * Drives the event loop once: Runs one iteration of all processes.
+ *
+ * Can be used in hooks from blocking loops.
+ *
+ * @return          Whether there are more pending poll requests.
+ */
+bool pbio_os_run_processes_once(void) {
+
+    // DELETEME: Legacy hook to drive pbio event loop until all processes migrated.
+    extern int pbio_do_one_event(void);
+    bool pbio_event_pending = pbio_do_one_event();
+
+    if (!poll_request_is_pending) {
+
+        // DELETEME: Legacy pbio event loop hook until all processes migrated.
+        if (pbio_event_pending) {
+            return true;
+        }
+
+        return false;
+    }
+
+    poll_request_is_pending = false;
+
+    pbio_os_process_t *process = process_list;
+    while (process) {
+        // Run one iteration of the process if not yet completed or errored.
+        if (process->err == PBIO_ERROR_AGAIN) {
+            process->err = process->func(&process->state);
+        }
+        process = process->next;
+    }
+
+    // Poll requests may have been set while running the processes.
+    return poll_request_is_pending || pbio_event_pending;
+}
+
+/**
+ * Drives the event loop from code that is waiting or sleeping.
+ *
+ * Expected to be called in a loop. This will keep running the event loop but
+ * enter a low power mode when possible. It will sleep for at most one
+ * millisecond.
+ */
+void pbio_os_run_while_idle(void) {
+
+    // Run the event loop until there is no more pending poll request.
+    while (pbio_os_run_processes_once()) {
+        ;
+    }
+
+    // It is possible that an interrupt occurs *just now* and sets the
+    // poll_request_is_pending flag. If not, we can call wait_for_interrupt(),
+    // which still wakes up the CPU on interrupt even though interrupts are
+    // otherwise disabled.
+    uint32_t irq_flags = pbio_os_hook_disable_irq();
+
+    // DELETEME: Legacy hook for pbio event loop that plays the same role as
+    // the pending flag. Here it ensures we don't enter sleep if there are
+    // pending events. Can be removed when all processes are migrated.
+    extern int process_nevents(void);
+    if (process_nevents()) {
+        poll_request_is_pending = true;
+    }
+
+    if (!poll_request_is_pending) {
+        pbio_os_hook_wait_for_interrupt();
+    }
+    pbio_os_hook_enable_irq(irq_flags);
+
+    // Since this function is expected to be called in a loop, pending events
+    // will be handled right away on the next entry. If not, then they will be
+    // handled "soon".
+}

--- a/lib/pbio/src/os.c
+++ b/lib/pbio/src/os.c
@@ -160,7 +160,7 @@ void pbio_os_run_while_idle(void) {
     // poll_request_is_pending flag. If not, we can call wait_for_interrupt(),
     // which still wakes up the CPU on interrupt even though interrupts are
     // otherwise disabled.
-    uint32_t irq_flags = pbio_os_hook_disable_irq();
+    pbio_os_irq_flags_t irq_flags = pbio_os_hook_disable_irq();
 
     // DELETEME: Legacy hook for pbio event loop that plays the same role as
     // the pending flag. Here it ensures we don't enter sleep if there are
@@ -171,7 +171,7 @@ void pbio_os_run_while_idle(void) {
     }
 
     if (!poll_request_is_pending) {
-        pbio_os_hook_wait_for_interrupt();
+        pbio_os_hook_wait_for_interrupt(irq_flags);
     }
     pbio_os_hook_enable_irq(irq_flags);
 

--- a/lib/pbio/src/os.c
+++ b/lib/pbio/src/os.c
@@ -53,8 +53,9 @@ static pbio_os_process_t *process_list = NULL;
  *
  * @param process   The process to start.
  * @param func      The process thread function.
+ * @param context   The context to pass to the process.
  */
-void pbio_os_start_process(pbio_os_process_t *process, pbio_os_process_func_t func) {
+void pbio_os_start_process(pbio_os_process_t *process, pbio_os_process_func_t func, void *context) {
 
     // Add the new process to the end of the list.
     pbio_os_process_t *last = process_list;
@@ -69,6 +70,7 @@ void pbio_os_start_process(pbio_os_process_t *process, pbio_os_process_func_t fu
 
     // Initialize the process.
     process->func = func;
+    process->context = context;
     process->next = NULL;
     process->err = PBIO_ERROR_AGAIN;
     process->state = 0;
@@ -103,7 +105,7 @@ bool pbio_os_run_processes_once(void) {
     while (process) {
         // Run one iteration of the process if not yet completed or errored.
         if (process->err == PBIO_ERROR_AGAIN) {
-            process->err = process->func(&process->state);
+            process->err = process->func(&process->state, process->context);
         }
         process = process->next;
     }

--- a/lib/pbio/src/os.c
+++ b/lib/pbio/src/os.c
@@ -5,6 +5,8 @@
 #include <stdio.h>
 
 #include <pbio/os.h>
+#include "pbio_os_config.h"
+
 #include <pbio/util.h>
 
 #include <pbdrv/clock.h>

--- a/lib/pbio/src/os.c
+++ b/lib/pbio/src/os.c
@@ -2,11 +2,11 @@
 // Copyright (c) 2025 The Pybricks Authors
 
 #include <stdbool.h>
+#include <stdio.h>
 
 #include <pbio/os.h>
 #include <pbio/util.h>
 
-#include <stdio.h>
 #include <pbdrv/clock.h>
 
 /**
@@ -35,7 +35,7 @@ bool pbio_os_timer_is_expired(pbio_os_timer_t *timer) {
 /**
  * Whether a poll request is pending.
  */
-static bool poll_request_is_pending = false;
+static volatile bool poll_request_is_pending = false;
 
 /**
  * Request that the event loop polls all processes.

--- a/lib/pbio/src/os.c
+++ b/lib/pbio/src/os.c
@@ -149,7 +149,7 @@ bool pbio_os_run_processes_once(void) {
  * enter a low power mode when possible. It will sleep for at most one
  * millisecond.
  */
-void pbio_os_run_while_idle(void) {
+void pbio_os_run_processes_and_wait_for_event(void) {
 
     // Run the event loop until there is no more pending poll request.
     while (pbio_os_run_processes_once()) {

--- a/lib/pbio/src/os.c
+++ b/lib/pbio/src/os.c
@@ -80,16 +80,20 @@ void pbio_os_process_start(pbio_os_process_t *process, pbio_os_process_func_t fu
     process->next = NULL;
     process->context = context;
 
-    pbio_os_process_reset(process, func);
+    pbio_os_process_init(process, func);
 }
 
 /**
- * Resets an existing process to the initial state with a new function and context.
+ * Initializes a process to the initial state with a protothread function to run.
+ *
+ * Can also be used to reset a process to the initial state or to change the
+ * protothread function. Doing so should be done with caution, but can be useful
+ * to make a process behave in distinct operation modes.
  *
  * @param process   The process to start.
  * @param func      The process thread function. Choose NULL if it does not need changing.
  */
-void pbio_os_process_reset(pbio_os_process_t *process, pbio_os_process_func_t func) {
+void pbio_os_process_init(pbio_os_process_t *process, pbio_os_process_func_t func) {
     process->err = PBIO_ERROR_AGAIN;
     process->state = 0;
     if (func) {

--- a/lib/pbio/src/port.c
+++ b/lib/pbio/src/port.c
@@ -500,7 +500,7 @@ pbio_error_t pbio_port_set_mode(pbio_port_t *port, pbio_port_mode_t mode) {
     }
 
     // Disable thread activity by attaching a thread that does nothing.
-    pbio_os_process_reset(&port->process, pbio_port_process_none_thread);
+    pbio_os_process_init(&port->process, pbio_port_process_none_thread);
     port->mode = mode;
 
     switch (mode) {
@@ -511,7 +511,7 @@ pbio_error_t pbio_port_set_mode(pbio_port_t *port, pbio_port_mode_t mode) {
         case PBIO_PORT_MODE_LEGO_DCM:
             // Physical modes for this mode will be set by the process so this
             // is all we need to do here.
-            pbio_os_process_reset(&port->process, pbio_port_process_pup_thread);
+            pbio_os_process_init(&port->process, pbio_port_process_pup_thread);
             // Returning e-again allows user module to wait for the port to be
             // ready after first entering LEGO mode, avoiding NODEV errors when
             // switching from direct access modes back to LEGO mode.

--- a/lib/pbio/src/port_dcm_pup.c
+++ b/lib/pbio/src/port_dcm_pup.c
@@ -81,7 +81,7 @@ static const lego_device_type_id_t legodev_pup_type_id_lookup[3][3] = {
  */
 pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer, pbio_port_dcm_t *dcm, const pbdrv_ioport_pins_t *pins) {
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     dcm->prev_type_id = LEGO_DEVICE_TYPE_ID_NONE;
     dcm->dev_id_match_count = 0;
@@ -99,7 +99,7 @@ pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer
         // set ID2 as input
         pbdrv_gpio_input(&pins->p6);
 
-        AWAIT_MS(state, timer, DCM_AWAIT_MS);
+        PBIO_OS_AWAIT_MS(state, timer, DCM_AWAIT_MS);
 
         // save current ID2 value
         dcm->prev_gpio_value = pbdrv_gpio_input(&pins->p6);
@@ -107,7 +107,7 @@ pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer
         // set ID1 low
         pbdrv_gpio_out_low(&pins->uart_tx);
 
-        AWAIT_MS(state, timer, DCM_AWAIT_MS);
+        PBIO_OS_AWAIT_MS(state, timer, DCM_AWAIT_MS);
 
         // read ID2
         dcm->gpio_value = pbdrv_gpio_input(&pins->p6);
@@ -121,7 +121,7 @@ pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer
             pbdrv_gpio_out_high(&pins->uart_buf);
             pbdrv_gpio_input(&pins->uart_tx);
 
-            AWAIT_MS(state, timer, DCM_AWAIT_MS);
+            PBIO_OS_AWAIT_MS(state, timer, DCM_AWAIT_MS);
 
             // ID1 is inverse of touch sensor value
             // TODO: save this value to sensor dcm
@@ -137,7 +137,7 @@ pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer
             // set ID1 high
             pbdrv_gpio_out_high(&pins->uart_tx);
 
-            AWAIT_MS(state, timer, DCM_AWAIT_MS);
+            PBIO_OS_AWAIT_MS(state, timer, DCM_AWAIT_MS);
 
             // read ID1
             dcm->gpio_value = pbdrv_gpio_input(&pins->p5);
@@ -156,7 +156,7 @@ pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer
                 pbdrv_gpio_out_high(&pins->uart_buf);
                 pbdrv_gpio_input(&pins->uart_tx);
 
-                AWAIT_MS(state, timer, DCM_AWAIT_MS);
+                PBIO_OS_AWAIT_MS(state, timer, DCM_AWAIT_MS);
 
                 // read ID1
                 if (pbdrv_gpio_input(&pins->p5) == 1) {
@@ -168,7 +168,7 @@ pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer
                 }
             }
 
-            AWAIT_MS(state, timer, DCM_AWAIT_MS);
+            PBIO_OS_AWAIT_MS(state, timer, DCM_AWAIT_MS);
 
             // set ID1 as input
             pbdrv_gpio_out_high(&pins->uart_buf);
@@ -177,7 +177,7 @@ pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer
             // set ID2 high
             pbdrv_gpio_out_high(&pins->p6);
 
-            AWAIT_MS(state, timer, DCM_AWAIT_MS);
+            PBIO_OS_AWAIT_MS(state, timer, DCM_AWAIT_MS);
 
             // read ID1
             dcm->prev_gpio_value = pbdrv_gpio_input(&pins->p5);
@@ -185,7 +185,7 @@ pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer
             // set ID2 low
             pbdrv_gpio_out_low(&pins->p6);
 
-            AWAIT_MS(state, timer, DCM_AWAIT_MS);
+            PBIO_OS_AWAIT_MS(state, timer, DCM_AWAIT_MS);
 
             // read ID1
             dcm->gpio_value = pbdrv_gpio_input(&pins->p5);
@@ -210,7 +210,7 @@ pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer
                 // set ID2 high
                 pbdrv_gpio_out_high(&pins->p6);
 
-                AWAIT_MS(state, timer, DCM_AWAIT_MS);
+                PBIO_OS_AWAIT_MS(state, timer, DCM_AWAIT_MS);
 
                 // if ID2 is high
                 if (pbdrv_gpio_input(&pins->uart_rx) == 1) {
@@ -224,7 +224,7 @@ pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer
                     // detection.
                     pbdrv_gpio_out_low(&pins->uart_rx);
 
-                    AWAIT_MS(state, timer, DCM_AWAIT_MS);
+                    PBIO_OS_AWAIT_MS(state, timer, DCM_AWAIT_MS);
 
                     // if ID2 is low
                     if (pbdrv_gpio_input(&pins->uart_rx) == 0) {
@@ -247,7 +247,7 @@ pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer
             }
         }
 
-        AWAIT_MS(state, timer, DCM_AWAIT_MS);
+        PBIO_OS_AWAIT_MS(state, timer, DCM_AWAIT_MS);
 
         // set ID2 as input
         pbdrv_gpio_input(&pins->p6);
@@ -286,7 +286,7 @@ pbio_error_t pbio_port_dcm_thread(pbio_os_state_t *state, pbio_os_timer_t *timer
     // raise.
     dcm->dev_id_match_count = 0;
 
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 /**

--- a/lib/pbio/sys/core.c
+++ b/lib/pbio/sys/core.c
@@ -3,9 +3,8 @@
 
 #include <stdint.h>
 
-#include <contiki.h>
-
 #include <pbio/main.h>
+#include <pbio/os.h>
 
 #include <pbsys/battery.h>
 #include <pbsys/bluetooth.h>
@@ -51,7 +50,7 @@ void pbsys_init(void) {
     process_start(&pbsys_system_process);
 
     while (pbsys_init_busy()) {
-        pbio_do_one_event();
+        pbio_os_run_processes_once();
     }
 }
 
@@ -64,6 +63,6 @@ void pbsys_deinit(void) {
     // Wait for all relevant pbsys processes to end, but at least 500 ms so we
     // see a shutdown animation even if the button is released sooner.
     while (pbsys_init_busy() || pbdrv_clock_get_ms() - start < 500) {
-        pbio_do_one_event();
+        pbio_os_run_processes_once();
     }
 }

--- a/lib/pbio/sys/main.c
+++ b/lib/pbio/sys/main.c
@@ -10,6 +10,7 @@
 #include <pbdrv/reset.h>
 #include <pbdrv/usb.h>
 #include <pbio/main.h>
+#include <pbio/os.h>
 #include <pbio/port_interface.h>
 #include <pbio/protocol.h>
 #include <pbsys/core.h>
@@ -93,10 +94,8 @@ int main(int argc, char **argv) {
         pbsys_main_program_request_start(PBIO_PYBRICKS_USER_PROGRAM_ID_REPL, PBSYS_MAIN_PROGRAM_START_REQUEST_TYPE_BOOT);
         #endif
 
-        // REVISIT: this can be long waiting, so we could do a more efficient
-        // wait (i.e. __WFI() on embedded system)
-        while (pbio_do_one_event()) {
-        }
+        // Drives all processes while we wait for user input.
+        pbio_os_run_while_idle();
 
         if (!pbsys_main_program_start_requested()) {
             continue;
@@ -109,7 +108,7 @@ int main(int argc, char **argv) {
 
         // Handle pending events triggered by the status change, such as
         // starting status light animation.
-        while (pbio_do_one_event()) {
+        while (pbio_os_run_processes_once()) {
         }
 
         // Run the main application.

--- a/lib/pbio/sys/main.c
+++ b/lib/pbio/sys/main.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
         #endif
 
         // Drives all processes while we wait for user input.
-        pbio_os_run_while_idle();
+        pbio_os_run_processes_and_wait_for_event();
 
         if (!pbsys_main_program_start_requested()) {
             continue;

--- a/lib/pbio/test/src/test_lump.c
+++ b/lib/pbio/test/src/test_lump.c
@@ -53,10 +53,10 @@ static void simulate_uart_complete_irq(void) {
 }
 
 pbio_error_t simulate_rx_msg(pbio_os_state_t *state, const uint8_t *msg, uint8_t length) {
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     // First uartdev reads one byte header
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         pbio_test_clock_tick(1);
         test_uart.rx_msg_result == PBIO_ERROR_AGAIN;
     }));
@@ -71,7 +71,7 @@ pbio_error_t simulate_rx_msg(pbio_os_state_t *state, const uint8_t *msg, uint8_t
     }
 
     // then read rest of message
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         pbio_test_clock_tick(1);
         test_uart.rx_msg_result == PBIO_ERROR_AGAIN;
     }));
@@ -82,13 +82,13 @@ pbio_error_t simulate_rx_msg(pbio_os_state_t *state, const uint8_t *msg, uint8_t
     simulate_uart_complete_irq();
 
 end:
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 pbio_error_t simulate_tx_msg(pbio_os_state_t *state, const uint8_t *msg, uint8_t length) {
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         pbio_test_clock_tick(1);
         test_uart.tx_msg_result == PBIO_ERROR_AGAIN;
     }));
@@ -103,16 +103,16 @@ pbio_error_t simulate_tx_msg(pbio_os_state_t *state, const uint8_t *msg, uint8_t
     simulate_uart_complete_irq();
 
 end:
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 #define SIMULATE_RX_MSG(msg) do { \
-        AWAIT(state, &child, err = simulate_rx_msg(&child, (msg), PBIO_ARRAY_SIZE(msg))); \
+        PBIO_OS_AWAIT(state, &child, err = simulate_rx_msg(&child, (msg), PBIO_ARRAY_SIZE(msg))); \
         tt_assert_msg(err == PBIO_SUCCESS, #msg); \
 } while (0)
 
 #define SIMULATE_TX_MSG(msg) do { \
-        AWAIT(state, &child, err = simulate_tx_msg(&child, (msg), PBIO_ARRAY_SIZE(msg))); \
+        PBIO_OS_AWAIT(state, &child, err = simulate_tx_msg(&child, (msg), PBIO_ARRAY_SIZE(msg))); \
         tt_assert_msg(err == PBIO_SUCCESS, #msg); \
 } while (0)
 
@@ -235,7 +235,7 @@ static pbio_error_t test_boost_color_distance_sensor(pbio_os_state_t *state, voi
 
     pbio_error_t err;
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     // Should be able to get port, but device won't be ready yet since it isn't
     // synched up.
@@ -243,14 +243,14 @@ static pbio_error_t test_boost_color_distance_sensor(pbio_os_state_t *state, voi
     tt_uint_op(pbio_port_get_port(PBIO_PORT_ID_D, &port), ==, PBIO_SUCCESS);
 
     // starting baud rate of hub
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         pbio_test_clock_tick(1);
         test_uart.baud == 115200;
     }));
 
     // this device does not support syncing at 115200
     SIMULATE_TX_MSG(msg_speed_115200);
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         pbio_test_clock_tick(1);
         test_uart.baud == 2400;
     }));
@@ -343,7 +343,7 @@ static pbio_error_t test_boost_color_distance_sensor(pbio_os_state_t *state, voi
     SIMULATE_TX_MSG(msg83);
 
     // wait for baud rate change
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         pbio_test_clock_tick(1);
         test_uart.baud == 115200;
     }));
@@ -364,7 +364,7 @@ static pbio_error_t test_boost_color_distance_sensor(pbio_os_state_t *state, voi
     }
 
     // Wait for default mode to complete
-    AWAIT_WHILE(state, ({
+    PBIO_OS_AWAIT_WHILE(state, ({
         pbio_test_clock_tick(1);
         (err = pbio_port_get_lump_device(port, &expected_id, &lump_dev)) == PBIO_ERROR_AGAIN;
     }));
@@ -439,7 +439,7 @@ static pbio_error_t test_boost_color_distance_sensor(pbio_os_state_t *state, voi
     // data message with new mode
     SIMULATE_RX_MSG(msg88);
 
-    AWAIT_WHILE(state, ({
+    PBIO_OS_AWAIT_WHILE(state, ({
         pbio_test_clock_tick(1);
         (err = pbio_port_lump_is_ready(lump_dev)) == PBIO_ERROR_AGAIN;
     }));
@@ -452,7 +452,7 @@ static pbio_error_t test_boost_color_distance_sensor(pbio_os_state_t *state, voi
 
 
     // also do mode 8 since it requires the extended mode flag
-    AWAIT_WHILE(state, ({
+    PBIO_OS_AWAIT_WHILE(state, ({
         pbio_test_clock_tick(1);
         (err = pbio_port_lump_set_mode(lump_dev, 8)) == PBIO_ERROR_AGAIN;
     }));
@@ -468,7 +468,7 @@ static pbio_error_t test_boost_color_distance_sensor(pbio_os_state_t *state, voi
     SIMULATE_RX_MSG(msg90);
     SIMULATE_RX_MSG(msg91);
 
-    AWAIT_WHILE(state, ({
+    PBIO_OS_AWAIT_WHILE(state, ({
         pbio_test_clock_tick(1);
         (err = pbio_port_lump_is_ready(lump_dev)) == PBIO_ERROR_AGAIN;
     }));
@@ -481,7 +481,7 @@ static pbio_error_t test_boost_color_distance_sensor(pbio_os_state_t *state, voi
 
 end:
 
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 static pbio_error_t test_boost_interactive_motor(pbio_os_state_t *state, void *context) {
@@ -540,7 +540,7 @@ static pbio_error_t test_boost_interactive_motor(pbio_os_state_t *state, void *c
     static uint8_t num_modes;
     static pbio_error_t err;
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
 
     // Should be able to get port, but device won't be ready yet since it isn't
@@ -549,14 +549,14 @@ static pbio_error_t test_boost_interactive_motor(pbio_os_state_t *state, void *c
     tt_uint_op(pbio_port_get_port(PBIO_PORT_ID_D, &port), ==, PBIO_SUCCESS);
 
     // starting baud rate of hub
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         pbio_test_clock_tick(1);
         test_uart.baud == 115200;
     }));
 
     // this device does not support syncing at 115200
     SIMULATE_TX_MSG(msg_speed_115200);
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         pbio_test_clock_tick(1);
         test_uart.baud == 2400;
     }));
@@ -601,7 +601,7 @@ static pbio_error_t test_boost_interactive_motor(pbio_os_state_t *state, void *c
     SIMULATE_TX_MSG(msg34);
 
     // wait for baud rate change
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         pbio_test_clock_tick(1);
         test_uart.baud == 115200;
     }));
@@ -620,7 +620,7 @@ static pbio_error_t test_boost_interactive_motor(pbio_os_state_t *state, void *c
         SIMULATE_TX_MSG(msg37);
     }
 
-    AWAIT_WHILE(state, ({
+    PBIO_OS_AWAIT_WHILE(state, ({
         pbio_test_clock_tick(1);
         (err = pbio_port_get_lump_device(port, &expected_id, &lump_dev)) == PBIO_ERROR_AGAIN;
     }));
@@ -653,7 +653,7 @@ static pbio_error_t test_boost_interactive_motor(pbio_os_state_t *state, void *c
 
 end:
 
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 static pbio_error_t test_technic_large_motor(pbio_os_state_t *state, void *context) {
@@ -731,7 +731,7 @@ static pbio_error_t test_technic_large_motor(pbio_os_state_t *state, void *conte
     static uint8_t num_modes;
     static pbio_error_t err;
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
 
     // Expect no device at first.
@@ -739,7 +739,7 @@ static pbio_error_t test_technic_large_motor(pbio_os_state_t *state, void *conte
     tt_uint_op(pbio_port_get_port(PBIO_PORT_ID_D, &port), ==, PBIO_SUCCESS);
 
     // baud rate for sync messages
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         pbio_test_clock_tick(1);
         test_uart.baud == 115200;
     }));
@@ -823,7 +823,7 @@ static pbio_error_t test_technic_large_motor(pbio_os_state_t *state, void *conte
         SIMULATE_TX_MSG(msg58);
     }
 
-    AWAIT_WHILE(state, ({
+    PBIO_OS_AWAIT_WHILE(state, ({
         pbio_test_clock_tick(1);
         (err = pbio_port_get_lump_device(port, &expected_id, &lump_dev)) == PBIO_ERROR_AGAIN;
     }));
@@ -865,7 +865,7 @@ static pbio_error_t test_technic_large_motor(pbio_os_state_t *state, void *conte
 
 
 end:
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 static pbio_error_t test_technic_xl_motor(pbio_os_state_t *state, void *context) {
@@ -943,7 +943,7 @@ static pbio_error_t test_technic_xl_motor(pbio_os_state_t *state, void *context)
     static uint8_t num_modes;
     static pbio_error_t err;
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
 
     // Expect no device at first.
@@ -951,7 +951,7 @@ static pbio_error_t test_technic_xl_motor(pbio_os_state_t *state, void *context)
     tt_uint_op(pbio_port_get_port(PBIO_PORT_ID_D, &port), ==, PBIO_SUCCESS);
 
     // baud rate for sync messages
-    AWAIT_UNTIL(state, ({
+    PBIO_OS_AWAIT_UNTIL(state, ({
         pbio_test_clock_tick(1);
         test_uart.baud == 115200;
     }));
@@ -1035,7 +1035,7 @@ static pbio_error_t test_technic_xl_motor(pbio_os_state_t *state, void *context)
         SIMULATE_TX_MSG(msg58);
     }
 
-    AWAIT_WHILE(state, ({
+    PBIO_OS_AWAIT_WHILE(state, ({
         pbio_test_clock_tick(1);
         (err = pbio_port_get_lump_device(port, &expected_id, &lump_dev)) == PBIO_ERROR_AGAIN;
     }));
@@ -1076,7 +1076,7 @@ static pbio_error_t test_technic_xl_motor(pbio_os_state_t *state, void *context)
 
 
 end:
-    ASYNC_END(PBIO_SUCCESS);
+    PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
 struct testcase_t pbio_port_lump_tests[] = {
@@ -1112,9 +1112,9 @@ void pbdrv_uart_stop(pbdrv_uart_dev_t *uart_dev) {
 
 pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart_dev, uint8_t *msg, uint8_t length, uint32_t timeout) {
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
-    AWAIT_WHILE(state, uart_dev->rx_msg);
+    PBIO_OS_AWAIT_WHILE(state, uart_dev->rx_msg);
 
     uart_dev->rx_msg = msg;
     uart_dev->rx_msg_length = length;
@@ -1122,7 +1122,7 @@ pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart_dev,
     pbio_os_timer_set(&uart_dev->rx_timer, timeout);
 
     // If read_pos is less that read_length then we have not read everything yet
-    AWAIT_WHILE(state, uart_dev->rx_msg_result == PBIO_ERROR_AGAIN && !pbio_os_timer_is_expired(&uart_dev->rx_timer));
+    PBIO_OS_AWAIT_WHILE(state, uart_dev->rx_msg_result == PBIO_ERROR_AGAIN && !pbio_os_timer_is_expired(&uart_dev->rx_timer));
     if (pbio_os_timer_is_expired(&uart_dev->rx_timer)) {
         uart_dev->rx_msg_result = PBIO_ERROR_TIMEDOUT;
     }
@@ -1131,22 +1131,22 @@ pbio_error_t pbdrv_uart_read(pbio_os_state_t *state, pbdrv_uart_dev_t *uart_dev,
         uart_dev->rx_msg = NULL;
     }
 
-    ASYNC_END(uart_dev->rx_msg_result);
+    PBIO_OS_ASYNC_END(uart_dev->rx_msg_result);
 }
 
 pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart_dev, uint8_t *msg, uint8_t length, uint32_t timeout) {
 
-    ASYNC_BEGIN(state);
+    PBIO_OS_ASYNC_BEGIN(state);
 
     // Wait while other write operation already in progress.
-    AWAIT_WHILE(state, uart_dev->tx_msg);
+    PBIO_OS_AWAIT_WHILE(state, uart_dev->tx_msg);
 
     uart_dev->tx_msg = msg;
     uart_dev->tx_msg_length = length;
     uart_dev->tx_msg_result = PBIO_ERROR_AGAIN;
     pbio_os_timer_set(&uart_dev->tx_timer, timeout);
 
-    AWAIT_WHILE(state, uart_dev->tx_msg_result == PBIO_ERROR_AGAIN && !pbio_os_timer_is_expired(&uart_dev->tx_timer));
+    PBIO_OS_AWAIT_WHILE(state, uart_dev->tx_msg_result == PBIO_ERROR_AGAIN && !pbio_os_timer_is_expired(&uart_dev->tx_timer));
     if (pbio_os_timer_is_expired(&uart_dev->tx_timer)) {
         uart_dev->tx_msg_result = PBIO_ERROR_TIMEDOUT;
     }
@@ -1155,5 +1155,5 @@ pbio_error_t pbdrv_uart_write(pbio_os_state_t *state, pbdrv_uart_dev_t *uart_dev
         uart_dev->tx_msg = NULL;
     }
 
-    ASYNC_END(uart_dev->tx_msg_result);
+    PBIO_OS_ASYNC_END(uart_dev->tx_msg_result);
 }

--- a/lib/pbio/test/test-pbio.c
+++ b/lib/pbio/test/test-pbio.c
@@ -58,7 +58,7 @@ static void pbio_test_run_thread(void *env, bool start_pbio_processes) {
     clock_gettime(CLOCK_MONOTONIC, &start_time);
 
     while (PT_SCHEDULE(test_thread(&pt))) {
-        pbio_do_one_event();
+        pbio_os_run_processes_once();
         if (timeout > 0) {
             clock_gettime(CLOCK_MONOTONIC, &now_time);
             if (difftime(now_time.tv_sec, start_time.tv_sec) > timeout) {

--- a/lib/pbio/test/test-pbio.c
+++ b/lib/pbio/test/test-pbio.c
@@ -143,14 +143,14 @@ struct testcase_setup_t pbio_test_setup = {
     .cleanup_fn = cleanup,
 };
 
-uint32_t pbio_os_hook_disable_irq(void) {
+pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
     return 0;
 }
 
-void pbio_os_hook_enable_irq(uint32_t flags) {
+void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
 }
 
-void pbio_os_hook_wait_for_interrupt(void) {
+void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
 }
 
 extern struct testcase_t pbdrv_bluetooth_tests[];

--- a/lib/pbio/test/test-pbio.c
+++ b/lib/pbio/test/test-pbio.c
@@ -91,6 +91,16 @@ struct testcase_setup_t pbio_test_setup = {
     .cleanup_fn = cleanup,
 };
 
+uint32_t pbio_os_hook_disable_irq(void) {
+    return 0;
+}
+
+void pbio_os_hook_enable_irq(uint32_t flags) {
+}
+
+void pbio_os_hook_wait_for_interrupt(void) {
+}
+
 extern struct testcase_t pbdrv_bluetooth_tests[];
 extern struct testcase_t pbdrv_pwm_tests[];
 extern struct testcase_t pbio_angle_tests[];

--- a/lib/pbio/test/test-pbio.c
+++ b/lib/pbio/test/test-pbio.c
@@ -143,16 +143,6 @@ struct testcase_setup_t pbio_test_setup = {
     .cleanup_fn = cleanup,
 };
 
-pbio_os_irq_flags_t pbio_os_hook_disable_irq(void) {
-    return 0;
-}
-
-void pbio_os_hook_enable_irq(pbio_os_irq_flags_t flags) {
-}
-
-void pbio_os_hook_wait_for_interrupt(pbio_os_irq_flags_t flags) {
-}
-
 extern struct testcase_t pbdrv_bluetooth_tests[];
 extern struct testcase_t pbdrv_pwm_tests[];
 extern struct testcase_t pbio_angle_tests[];

--- a/lib/pbio/test/test-pbio.h
+++ b/lib/pbio/test/test-pbio.h
@@ -23,7 +23,13 @@
 #define PBIO_PT_THREAD_TEST_WITH_PBIO(name) \
     { #name, pbio_test_run_thread_with_pbio_processes, TT_FORK, &pbio_test_setup, name }
 
-void pbio_test_run_thread_with_pbio_processes(void *env);
+// Use this macro to define tests that _do_ require a pbio os event loop
+// with pbio processes enabled
+#define PBIO_PT_THREAD_TEST_WITH_PBIO_OS(name) \
+    { #name, pbio_test_run_thread_with_pbio_os_processes, TT_FORK, &pbio_test_setup, name }
+
+void pbio_test_run_thread_with_pbio_os_processes(void *env); // new thread format
+void pbio_test_run_thread_with_pbio_processes(void *env); // legacy thread format
 void pbio_test_run_thread_without_pbio_processes(void *env);
 
 extern struct testcase_setup_t pbio_test_setup;


### PR DESCRIPTION
Overall, the goals are to reduce complexity, reduce code size, and make it more cross platform.

In this PR, the new approach still drives the original `pbio` event loop as well, so we can convert one process at a time without breaking things. The charger process is done here as a simple test to illustrate what it looks like. Once all processes have been converted and everything is working, we could drop the Contiki dependency.

Not everything we need is implemented yet, but it is already easy to see that `pbio/os` is much easier to get into than the full contiki library. Mainly because we only implement what we need, but also due to the simplifications introduced below.

- Returning errors from protothreads is currently cumbersome. This modification allows protothreads to return error codes. `PBIO_ERROR_AGAIN` essentially takes the role of `PT_YIELDED` / `PT_WAITING`. Everything else indicates completion with the respective error or success.

- Contiki partially distinguishes (but not really) between waiting and yielding. In practice, both yield and the latter yields at least once. And then both macros exist separately for processes and protothreads so you end up with four variants that are almost the same but subtly different. I think we can do everything with a single set of `AWAIT` macros.

- The contiki event timers are more complicated than we need for our use case. Currently, a timer tick first polls the timer process and then posts N events depending on the number of active timers. This is not be safe if we have more timer events than fit in the event queue. Also, etimers use the global `PROCESS_CURRENT` which requires hacks such as `PROCESS_CONTEXT_BEGIN` when accessing them from elsewhere.

- Instead of using various events and polling individual processes throughout, I think we may be able to work with just a single `pbio_os_request_poll()` function. Then all processes will check their current wait condition. This should not be that much more computationally expensive than checking the `needs_poll` flag on each process (and it may be less due to overall simplicity).

- We currently use broadcasting between processes in a few places, which can be hard to follow and risks overflowing the event queue as already stated in a few existing `REVISIT`s around the code. We have recently eliminated this for the uart process. We should be able to do this for the status change too.

- We can move some of the logic for handling pending events and entering sleep mode to `pbio` instead of having it in `mphalport`. Aside from hooks such as `enable_irq` it becomes platform agnostic. This also brings the virtual hub a bit closer to the embedded hubs. It also unifies the EV3 and NXT with Powered Up.