### PR TITLE
pbio/drv/bluetooth_stm32_cc2640: Only restart observe when needed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@
 - Extensive overhaul of UART and port drivers on all hubs. This affects all
   official LEGO sensors on all hubs.
 
+### Fixed
+- Reduced hanging when broadcasting and observing at the same time with Technic
+  Hub ([support#2206]).
+
 [support#220]: https://github.com/pybricks/support/issues/220
+[support#2206]: https://github.com/pybricks/support/issues/2206
 [pybricks-micropython#208]: https://github.com/pybricks/pybricks-micropython/pull/208
 
 ## [3.6.1] - 2025-03-11

--- a/pybricks/common/pb_type_ble.c
+++ b/pybricks/common/pb_type_ble.c
@@ -440,6 +440,12 @@ static mp_obj_t pb_module_ble_observe(mp_obj_t self_in, mp_obj_t channel_in) {
 
     // Have not received data yet or timed out.
     if (ch_data.rssi == INT8_MIN) {
+
+        #if PBDRV_CONFIG_BLUETOOTH_STM32_CC2640
+        extern void pbdrv_bluetooth_restart_observing_request(void);
+        pbdrv_bluetooth_restart_observing_request();
+        #endif
+
         return mp_const_none;
     }
 


### PR DESCRIPTION
This partially fixes https://github.com/pybricks/support/issues/2206. I don't think there is a true cure but it turns out we can reduce the symptoms significantly.

We used to believe that alternating between observing and broadcasting  was the right workaround, but on closer look it appears that this might not be the case. The freezes are not random. When the Bluetooth chip locks up, it is always just after an observe restart. It will then get stuck at the very next Bluetooth command, whatever that is. That was usually broadcasting, so this is why we assumed they were conflicting.

So every time we restart observing, there is a small chance of locking up the Bluetooth chip. The restart was added in the first place as a workaround for the scan queue getting full so new scan events were not coming in (https://github.com/pybricks/support/issues/1096). This usually doesn't happen for a long time, so we can avoid restarting observing until that happens.

This reduces the number of restart from once every 10 seconds to a few times per hour, significantly reducing the odds of a lock up. In practice, some applications that used to get stuck after 10 minutes can now run for hours.

Since there isn't a good way to know if the queue is full, we can request a restart if we are not receiving data when the user is expecting some data. In the worst case, this will still restart it every 10 seconds as it used to do. If all of the subscribed channels get incoming data, restarting is delayed, thus reducing the likelihood of a freeze.

This could potentially be made to work better if we told `bluetooth_stm32_cc2640` which channels to expect, but this resides at the module level. If it was at the driver level, we could do it at the right time even if the user wasn't calling `observe`. This requires much bigger changes though, so probably isn't worth it.