### PR TITLE
pybricks.iodevices.LWP3Device: Buffer incoming notifications.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Changed
 - Extensive overhaul of UART and port drivers on all hubs. This affects all
   official LEGO sensors on all hubs.
+- LWP3Device.read() now gives buffered notification values instead of blocking
+  until a value arrives.
 
 [support#220]: https://github.com/pybricks/support/issues/220
 [pybricks-micropython#208]: https://github.com/pybricks/pybricks-micropython/pull/208


### PR DESCRIPTION
Allows to read without blocking and allows subscribing to multiple sensor values without losing data.

As an example, here's how you can read both the color and the speed of the Duplo Train:

Fixes https://github.com/pybricks/support/issues/1648

It works well, but it can sometimes crash the hub when stopping the program. Perhaps because of the buffer being freed before the connection is closed, so this might need some more work.

```python
from pybricks.iodevices import LWP3Device
from pybricks.tools import wait

from ustruct import unpack

DUPLO_TRAIN_ID = 0x20
PORT_VALUE_MSG = const(0x45)

PORT_COLOR_SENSOR = 0x12
MODE_RGB = 0x03

PORT_SPEED = 0x13
MODE_SPEED = 0x00
MODE_POSITION = 0x01

print("Searching for the train. Make sure it is on and blinking its front light.")

# Buffer latest 16 notifications. Can reduce this if you read often.
device = LWP3Device(DUPLO_TRAIN_ID, num_notifications=16)

# Subscribe to color sensor and speed
device.write(bytes([0x0a, 0x00, 0x41, PORT_COLOR_SENSOR, MODE_RGB, 0x01, 0x00, 0x00, 0x00, 0x01]))
device.write(bytes([0x0a, 0x00, 0x41, PORT_SPEED, MODE_SPEED, 0x01, 0x00, 0x00, 0x00, 0x01]))

print("Connected!")
wait(500)

def parse_all():
    while (data := device.read()) is not None:

        if len(data) < 4:
            continue

        kind = data[2]
        port = data[3]
        
        if kind != PORT_VALUE_MSG:
            continue

        if port == PORT_COLOR_SENSOR and len(data) == 10:
            r, g, b = unpack("<hhh", data[4:10])
            print(r, g, b)

        if port == PORT_SPEED and len(data) == 6:
            speed, = unpack("<h", data[4:6])
            print(speed)

while True:

    parse_all()

    # All data parsed, go do something else here.
    wait(100)
```

Tagging @NStrijbosch.