### PR TITLE
pbio/port_lump: Fix ColorLightMatrix by sending initial NACK.

### DIFF
--- a/lib/pbio/src/port_lump.c
+++ b/lib/pbio/src/port_lump.c
@@ -881,8 +881,6 @@ sync:
         default_mode = LEGO_DEVICE_MODE_PUP_REL_MOTOR__POS;
     } else if (lump_dev->type_id == LEGO_DEVICE_TYPE_ID_COLOR_DIST_SENSOR) {
         default_mode = LEGO_DEVICE_MODE_PUP_COLOR_DISTANCE_SENSOR__RGB_I;
-    } else if (lump_dev->type_id == LEGO_DEVICE_TYPE_ID_EV3_COLOR_SENSOR) {
-        default_mode = LEGO_DEVICE_MODE_EV3_COLOR_SENSOR__AMBIENT;
     }
     if (default_mode) {
         pbio_port_lump_request_mode(lump_dev, default_mode);
@@ -1014,7 +1012,7 @@ pbio_error_t pbio_port_lump_data_recv_thread(pbio_os_state_t *state, pbio_port_l
 
         lump_dev->rx_msg_size = ev3_uart_get_msg_size(lump_dev->rx_msg[0]);
         if (lump_dev->rx_msg_size < 3 || lump_dev->rx_msg_size > EV3_UART_MAX_MESSAGE_SIZE) {
-            debug_pr("Bad data message size %d\n", lump_dev->rx_msg_size);
+            debug_pr("Bad data message size\n");
             continue;
         }
 


### PR DESCRIPTION
It turns out the ColorLightMatrix needs the NACK to get going at all, so make sure we always send one before we start waiting on the keep-alive timeout. In b17e5033dcc4edd75722839c4832c791f0e698a8, we removed grace period of 6 keep-alive messages to go unanswered, which was essentially masking this issue so the device worked before.