### PR TITLE
github: bump CI to Ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
 
   mpy_cross:
     name: mpy-cross
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
   unix_coverage:
     name: unix coverage
     needs: mpy_cross
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       PYBRICKS_NO_REDIRECT_STDOUT: 1
     steps:
@@ -90,7 +90,7 @@ jobs:
       matrix:
         hub: [cityhub, essentialhub, movehub, nxt, primehub, technichub, ev3]
     needs: [mpy_cross]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Install cross-compiler
       run: sudo apt-get update && sudo apt-get install --yes gcc-arm-none-eabi
@@ -142,7 +142,7 @@ jobs:
   virtualhub:
     name: virtual hub
     needs: [mpy_cross]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Install depedencies
       run: sudo apt-get update && sudo apt-get install lcov python3-numpy --yes
@@ -176,7 +176,7 @@ jobs:
 
   pbio:
     name: pbio tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       PBIO_TEST_RESULTS_DIR: lib/pbio/test/results
     steps:
@@ -207,7 +207,7 @@ jobs:
 
   finish:
     needs: [virtualhub, pbio]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/npm-firmware.yml
+++ b/.github/workflows/npm-firmware.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   npm_firmware:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: npm/firmware

--- a/.github/workflows/npm-mpy-cross.yml
+++ b/.github/workflows/npm-mpy-cross.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   npm_mpy_cross:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: npm/mpy-cross

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   upload_release:
     name: Upload Release Assets
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install cross-compiler
         run: sudo apt-get update && sudo apt-get install --yes gcc-arm-none-eabi

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   stats:
     name: Generate stats
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install cross-compiler
         run: sudo apt-get update && sudo apt-get install --yes gcc-arm-none-eabi

--- a/lib/pbio/test/Makefile
+++ b/lib/pbio/test/Makefile
@@ -185,7 +185,6 @@ build-coverage/lcov.info: Makefile $(SRC)
 		--directory build-coverage/lib/pbio/src \
 		--directory build-coverage/lib/pbio/sys \
 		--exclude **/btstack/** \
-		--exclude **/contiki-core/** \
 
 coverage-html: build-coverage/lcov.info
 	$(Q)genhtml $^ --output-directory build-coverage/html


### PR DESCRIPTION
Get a newer version of the cross compiler by using Ubuntu 24.04. This fixes some known issues with building the EV3 firmware.