### PR TITLE
bricks/ev3: use .elf instead of uImage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Install cross-compiler
-      run: sudo apt-get update && sudo apt-get install --yes gcc-arm-none-eabi u-boot-tools
+      run: sudo apt-get update && sudo apt-get install --yes gcc-arm-none-eabi
     - name: Checkout repo
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install cross-compiler
-        run: sudo apt-get update && sudo apt-get install --yes gcc-arm-none-eabi u-boot-tools
+        run: sudo apt-get update && sudo apt-get install --yes gcc-arm-none-eabi
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install cross-compiler
-        run: sudo apt-get update && sudo apt-get install --yes gcc-arm-none-eabi u-boot-tools
+        run: sudo apt-get update && sudo apt-get install --yes gcc-arm-none-eabi
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/bricks/ev3/README.md
+++ b/bricks/ev3/README.md
@@ -24,12 +24,6 @@ firmware for one of the other targets, such as the SPIKE Prime Hub, as
 explained [here](../../CONTRIBUTING.md). Make sure that `pybricksdev` is
 installed.
 
-Install the following additional tools:
-
-```
-sudo apt install u-boot-tools
-```
-
 Unlike most other alternative EV3 firmware solutions, Pybricks does not require
 using a microSD card. Instead, Pybricks is installed as a firmware update.
 


### PR DESCRIPTION
Replace creating a uImage with using the .elf file directly for the EV3 firmware. This simplifies the build process and avoids the need for u-boot-tools. U-Boot already knows how to load the .elf file, so we can use it directly by using `bootelf` instead of `bootm` (this change was made in the pybricks/v2.0.0 release of u-boot).

In order to keep the size of the .elf file small, we do not enable `-ffunction-sections` and `-fdata-sections` for the EV3 firmware. This avoids the large tables of section names that are generated by these flags, which would otherwise increase the size of the .elf file by nearly 200 kB. The .elf file is still a bit larger than the uImage because of a bit more overhead, but only by less than 4kB.