### PR TITLE
pbio/drv/battery/battery_ev3: implement EV3 battery type

### DIFF
--- a/lib/pbio/drv/battery/battery_ev3.c
+++ b/lib/pbio/drv/battery/battery_ev3.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 The Pybricks Authors
+// Copyright (c) 2024-2025 The Pybricks Authors
 
 #include <pbdrv/config.h>
 
@@ -9,28 +9,42 @@
 
 #include <pbdrv/battery.h>
 #include <pbio/error.h>
+#include <pbdrv/gpio.h>
+#include "../gpio/gpio_ev3.h"
+
+#include <tiam1808/hw/hw_syscfg0_AM1808.h>
+
+static const pbdrv_gpio_t battery_type_gpio = PBDRV_GPIO_EV3_PIN(19, 7, 4, 8, 8);
 
 void pbdrv_battery_init(void) {
+    pbdrv_gpio_alt(&battery_type_gpio, SYSCFG_PINMUX19_PINMUX19_7_4_GPIO8_8);
 }
 
 pbio_error_t pbdrv_battery_get_voltage_now(uint16_t *value) {
-    // TODO. Return nominal value for now so we don't trigger low battery shutdown.
+    // TODO. Calculate battery voltage based on ADC channel 4.
+    // For now, return nominal value for now so we don't trigger low battery shutdown.
     *value = 7200;
     return PBIO_SUCCESS;
 }
 
 pbio_error_t pbdrv_battery_get_current_now(uint16_t *value) {
+    // TODO. Calculate battery current based on ADC channel 3.
     *value = 0;
     return PBIO_ERROR_NOT_IMPLEMENTED;
 }
 
 pbio_error_t pbdrv_battery_get_type(pbdrv_battery_type_t *value) {
-    // TODO
-    *value = PBDRV_BATTERY_TYPE_UNKNOWN;
-    return PBIO_ERROR_NOT_IMPLEMENTED;
+    if (pbdrv_gpio_input(&battery_type_gpio)) {
+        *value = PBDRV_BATTERY_TYPE_ALKALINE;
+    } else {
+        *value = PBDRV_BATTERY_TYPE_LIION;
+    }
+
+    return PBIO_SUCCESS;
 }
 
 pbio_error_t pbdrv_battery_get_temperature(uint32_t *value) {
+    // EV3 does not have a way to read the battery temperature.
     *value = 0;
     return PBIO_ERROR_NOT_SUPPORTED;
 }


### PR DESCRIPTION
Implement reading the EV3 battery type from the GP8_8 pin.

Also make the remaining TODOs a bit more clear the the next person who works on this.