### PR TITLE
pybricks: modules: add conditional around MP_REGISTER_MODULE()

### DIFF
--- a/bricks/virtualhub/mpconfigvariant.mk
+++ b/bricks/virtualhub/mpconfigvariant.mk
@@ -71,10 +71,3 @@ SRC_THIRDPARTY_C += $(CONTIKI_SRC_C) $(PBIO_SRC_C)
 
 # realtime library for timer signals
 LIB += -lrt
-
-# embedded Python
-EMBEDDED_PYTHON ?= python3.10
-PYTHON_CONFIG := $(EMBEDDED_PYTHON)-config
-
-INC += $(shell $(PYTHON_CONFIG) --includes)
-LDFLAGS += -rdynamic $(shell $(PYTHON_CONFIG) --ldflags --embed)

--- a/pybricks/ev3devices/pb_module_ev3devices.c
+++ b/pybricks/ev3devices/pb_module_ev3devices.c
@@ -28,6 +28,8 @@ const mp_obj_module_t pb_module_ev3devices = {
     .globals = (mp_obj_dict_t *)&pb_module_ev3devices_globals,
 };
 
+#if !MICROPY_MODULE_BUILTIN_SUBPACKAGES
 MP_REGISTER_MODULE(MP_QSTR_pybricks_dot_ev3devices, pb_module_ev3devices);
+#endif
 
 #endif // PYBRICKS_PY_EV3DEVICES

--- a/pybricks/experimental/pb_module_experimental.c
+++ b/pybricks/experimental/pb_module_experimental.c
@@ -69,6 +69,8 @@ const mp_obj_module_t pb_module_experimental = {
     .globals = (mp_obj_dict_t *)&pb_module_experimental_globals,
 };
 
+#if !MICROPY_MODULE_BUILTIN_SUBPACKAGES
 MP_REGISTER_MODULE(MP_QSTR_pybricks_dot_experimental, pb_module_experimental);
+#endif
 
 #endif // PYBRICKS_PY_EXPERIMENTAL

--- a/pybricks/hubs/pb_module_hubs.c
+++ b/pybricks/hubs/pb_module_hubs.c
@@ -26,6 +26,8 @@ const mp_obj_module_t pb_module_hubs = {
     .globals = (mp_obj_dict_t *)&pb_module_hubs_globals,
 };
 
+#if !MICROPY_MODULE_BUILTIN_SUBPACKAGES
 MP_REGISTER_MODULE(MP_QSTR_pybricks_dot_hubs, pb_module_hubs);
+#endif
 
 #endif // PYBRICKS_PY_HUBS

--- a/pybricks/iodevices/pb_module_iodevices.c
+++ b/pybricks/iodevices/pb_module_iodevices.c
@@ -35,6 +35,8 @@ const mp_obj_module_t pb_module_iodevices = {
     .globals = (mp_obj_dict_t *)&pb_module_iodevices_globals,
 };
 
+#if !MICROPY_MODULE_BUILTIN_SUBPACKAGES
 MP_REGISTER_MODULE(MP_QSTR_pybricks_dot_iodevices, pb_module_iodevices);
+#endif
 
 #endif // PYBRICKS_PY_IODEVICES

--- a/pybricks/media/pb_module_media.c
+++ b/pybricks/media/pb_module_media.c
@@ -20,6 +20,8 @@ const mp_obj_module_t pb_module_media = {
     .globals = (mp_obj_dict_t *)&pb_module_media_globals,
 };
 
+#if !MICROPY_MODULE_BUILTIN_SUBPACKAGES
 MP_REGISTER_MODULE(MP_QSTR_pybricks_dot_media, pb_module_media);
+#endif
 
 #endif // PYBRICKS_PY_MEDIA

--- a/pybricks/nxtdevices/pb_module_nxtdevices.c
+++ b/pybricks/nxtdevices/pb_module_nxtdevices.c
@@ -30,6 +30,8 @@ const mp_obj_module_t pb_module_nxtdevices = {
     .globals = (mp_obj_dict_t *)&pb_module_nxtdevices_globals,
 };
 
+#if !MICROPY_MODULE_BUILTIN_SUBPACKAGES
 MP_REGISTER_MODULE(MP_QSTR_pybricks_dot_nxtdevices, pb_module_nxtdevices);
+#endif
 
 #endif // PYBRICKS_PY_NXTDEVICES

--- a/pybricks/parameters/pb_module_parameters.c
+++ b/pybricks/parameters/pb_module_parameters.c
@@ -30,6 +30,8 @@ const mp_obj_module_t pb_module_parameters = {
     .globals = (mp_obj_dict_t *)&pb_module_parameters_globals,
 };
 
+#if !MICROPY_MODULE_BUILTIN_SUBPACKAGES
 MP_REGISTER_MODULE(MP_QSTR_pybricks_dot_parameters, pb_module_parameters);
+#endif
 
 #endif // PYBRICKS_PY_PARAMETERS

--- a/pybricks/pupdevices/pb_module_pupdevices.c
+++ b/pybricks/pupdevices/pb_module_pupdevices.c
@@ -35,6 +35,8 @@ const mp_obj_module_t pb_module_pupdevices = {
     .globals = (mp_obj_dict_t *)&pb_module_pupdevices_globals,
 };
 
+#if !MICROPY_MODULE_BUILTIN_SUBPACKAGES
 MP_REGISTER_MODULE(MP_QSTR_pybricks_dot_pupdevices, pb_module_pupdevices);
+#endif
 
 #endif // PYBRICKS_PY_PUPDEVICES

--- a/pybricks/pybricks.c
+++ b/pybricks/pybricks.c
@@ -47,6 +47,39 @@ void pb_package_pybricks_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 }
 #endif
 
+#if MICROPY_MODULE_BUILTIN_SUBPACKAGES
+#if PYBRICKS_PY_EXPERIMENTAL
+extern const mp_obj_module_t pb_module_experimental;
+#endif
+#if PYBRICKS_PY_HUBS
+extern const mp_obj_module_t pb_module_hubs;
+#endif
+#if PYBRICKS_PY_NXTDEVICES
+extern const mp_obj_module_t pb_module_nxtdevices;
+#endif
+#if PYBRICKS_PY_EV3DEVICES
+extern const mp_obj_module_t pb_module_ev3devices;
+#endif
+#if PYBRICKS_PY_PUPDEVICES
+extern const mp_obj_module_t pb_module_pupdevices;
+#endif
+#if PYBRICKS_PY_IODEVICES
+extern const mp_obj_module_t pb_module_iodevices;
+#endif
+#if PYBRICKS_PY_MEDIA
+extern const mp_obj_module_t pb_module_media;
+#endif
+#if PYBRICKS_PY_PARAMETERS
+extern const mp_obj_module_t pb_module_parameters;
+#endif
+#if PYBRICKS_PY_TOOLS
+extern const mp_obj_module_t pb_module_tools;
+#endif
+#if PYBRICKS_PY_ROBOTICS
+extern const mp_obj_module_t pb_module_robotics;
+#endif
+#endif
+
 static const mp_rom_map_elem_t pybricks_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),            MP_ROM_QSTR(MP_QSTR_pybricks) },
     { MP_ROM_QSTR(MP_QSTR_version),             MP_ROM_PTR(&pybricks_info_obj)},

--- a/pybricks/robotics/pb_module_robotics.c
+++ b/pybricks/robotics/pb_module_robotics.c
@@ -28,6 +28,8 @@ const mp_obj_module_t pb_module_robotics = {
     .globals = (mp_obj_dict_t *)&pb_module_robotics_globals,
 };
 
+#if !MICROPY_MODULE_BUILTIN_SUBPACKAGES
 MP_REGISTER_MODULE(MP_QSTR_pybricks_dot_robotics, pb_module_robotics);
+#endif
 
 #endif // PYBRICKS_PY_ROBOTICS

--- a/pybricks/tools/pb_module_tools.c
+++ b/pybricks/tools/pb_module_tools.c
@@ -382,11 +382,15 @@ const mp_obj_module_t pb_module_tools = {
     .globals = (mp_obj_dict_t *)&pb_module_tools_globals,
 };
 
+#if !MICROPY_MODULE_BUILTIN_SUBPACKAGES
+
 MP_REGISTER_MODULE(MP_QSTR_pybricks_dot_tools, pb_module_tools);
 
 // backwards compatibility for pybricks.geometry
 #if MICROPY_PY_BUILTINS_FLOAT
 MP_REGISTER_MODULE(MP_QSTR_pybricks_dot_geometry, pb_module_tools);
 #endif // MICROPY_PY_BUILTINS_FLOAT
+
+#endif // !MICROPY_MODULE_BUILTIN_SUBPACKAGES
 
 #endif // PYBRICKS_PY_TOOLS


### PR DESCRIPTION
Add a conditional compilation check around `MP_REGISTER_MODULE()` that checks `MICROPY_MODULE_BUILTIN_SUBPACKAGES`. If this option is enabled, we don't need to register subpackages as they are already handled by the parent package.

This corresponds to the alternate way of registering submodules at https://github.com/pybricks/pybricks-micropython/blob/343793b9a75f9460fd718b5aeb3a9f0e8e694ec9/pybricks/pybricks.c#L53-L84

But that requires enabling `MICROPY_ENABLE_EXTERNAL_IMPORT` which is pretty huge, so we'll stick with our method for now.