### PR TITLE
[EV3] Minimum-viable speaker driver

### DIFF
--- a/bricks/_common/sources.mk
+++ b/bricks/_common/sources.mk
@@ -175,6 +175,7 @@ PBIO_SRC_C = $(addprefix lib/pbio/,\
 	drv/reset/reset_stm32.c \
 	drv/reset/reset_ev3.c \
 	drv/resistor_ladder/resistor_ladder.c \
+	drv/sound/sound_ev3.c \
 	drv/sound/sound_nxt.c \
 	drv/sound/sound_stm32_hal_dac.c \
 	drv/stack/stack_embedded.c \

--- a/lib/pbio/drv/sound/sound_ev3.c
+++ b/lib/pbio/drv/sound/sound_ev3.c
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 The Pybricks Authors
+
+#include <pbdrv/config.h>
+
+#if PBDRV_CONFIG_SOUND_EV3
+
+#include <stdint.h>
+
+void pbdrv_sound_stop() {
+
+}
+
+void pbdrv_sound_start(const uint16_t *data, uint32_t length, uint32_t sample_rate) {
+
+}
+
+void pbdrv_sound_init() {
+
+}
+
+#endif // PBDRV_CONFIG_SOUND_EV3

--- a/lib/pbio/drv/sound/sound_ev3.c
+++ b/lib/pbio/drv/sound/sound_ev3.c
@@ -7,8 +7,48 @@
 
 #include <stdint.h>
 
-void pbdrv_sound_stop() {
+#include <tiam1808/armv5/am1808/interrupt.h>
+#include <tiam1808/ehrpwm.h>
+#include <tiam1808/hw/soc_AM1808.h>
+#include <tiam1808/hw/hw_syscfg0_AM1808.h>
+#include <tiam1808/psc.h>
 
+#include "../drv/gpio/gpio_ev3.h"
+
+// Audio amplifier enable
+static const pbdrv_gpio_t pin_sound_en = PBDRV_GPIO_EV3_PIN(13, 3, 0, 6, 15);
+// Audio output pin
+#define SYSCFG_PINMUX3_PINMUX3_7_4_GPIO0_0 0
+static const pbdrv_gpio_t pin_audio = PBDRV_GPIO_EV3_PIN(3, 7, 4, 0, 0);
+
+// This hardware is not capable of producing 16 bits per sample
+// at an acceptable sampling rate. As a trade-off, use 12 bits per sample
+// giving a sampling rate of 150 MHz / 2**12 ~= 36 ksps
+//
+// Unlike other audio drivers, this one runs at a fixed sample rate.
+// This is because the AM1808 has relatively few possible clock division ratios,
+// and we do not want the usable bit depth to vary as the sample rate changes.
+static const unsigned N_BITS_PER_SAMPLE = 12;
+
+static void sound_isr() {
+    EHRPWMETIntClear(SOC_EHRPWM_0_REGS);
+    IntSystemStatusClear(SYS_INT_EHRPWM0);
+
+    // TODO: Load samples
+}
+
+void pbdrv_sound_stop() {
+    // Turn speaker amplifier off
+    pbdrv_gpio_out_low(&pin_sound_en);
+    // Clean up counter
+    HWREGH(SOC_EHRPWM_0_REGS + EHRPWM_TBCTL) |= EHRPWM_TBCTL_CTRMODE_STOPFREEZE;
+    EHRPWMWriteTBCount(SOC_EHRPWM_0_REGS, 0);
+    EHRPWMETIntDisable(SOC_EHRPWM_0_REGS);
+    EHRPWMETIntClear(SOC_EHRPWM_0_REGS);
+    // Disable shadowing and set the count to 0
+    EHRPWMLoadCMPB(SOC_EHRPWM_0_REGS, 0, true, 0, true);
+    // Re-enable shadowing
+    EHRPWMLoadCMPB(SOC_EHRPWM_0_REGS, 0, false, EHRPWM_CMPCTL_LOADBMODE_TBCTRPRD, true);
 }
 
 void pbdrv_sound_start(const uint16_t *data, uint32_t length, uint32_t sample_rate) {
@@ -16,7 +56,44 @@ void pbdrv_sound_start(const uint16_t *data, uint32_t length, uint32_t sample_ra
 }
 
 void pbdrv_sound_init() {
+    // Turn on EPWM
+    PSCModuleControl(SOC_PSC_1_REGS, HW_PSC_EHRPWM, PSC_POWERDOMAIN_ALWAYS_ON, PSC_MDCTL_NEXT_ENABLE);
 
+    // The stop function performs various initializations
+    pbdrv_sound_stop();
+
+    // Set up settings which will stay consistent throughout
+    EHRPWMTimebaseClkConfig(SOC_EHRPWM_0_REGS, SOC_EHRPWM_0_MODULE_FREQ, SOC_EHRPWM_0_MODULE_FREQ);
+    // Set the period to go up to max of nbits
+    HWREGH(SOC_EHRPWM_0_REGS + EHRPWM_TBCTL) |= EHRPWM_TBCTL_PRDLD;
+    HWREGH(SOC_EHRPWM_0_REGS + EHRPWM_TBPRD) = (1 << N_BITS_PER_SAMPLE) - 1;
+    // Pulse goes high @ t=0
+    // Pulse goes low  @ t=CMPB
+    EHRPWMConfigureAQActionOnB(
+        SOC_EHRPWM_0_REGS,
+        EHRPWM_AQCTLB_ZRO_EPWMXBHIGH,
+        EHRPWM_AQCTLB_PRD_DONOTHING,
+        EHRPWM_AQCTLB_CAU_DONOTHING,
+        EHRPWM_AQCTLB_CAD_DONOTHING,
+        EHRPWM_AQCTLB_CBU_EPWMXBLOW,
+        EHRPWM_AQCTLB_CBD_DONOTHING,
+        EHRPWM_AQSFRC_ACTSFB_DONOTHING
+        );
+    // Disable unused features
+    EHRPWMDBOutput(SOC_EHRPWM_0_REGS, EHRPWM_DBCTL_OUT_MODE_BYPASS);
+    EHRPWMChopperDisable(SOC_EHRPWM_0_REGS);
+    EHRPWMTZTripEventDisable(SOC_EHRPWM_0_REGS, false);
+    EHRPWMTZTripEventDisable(SOC_EHRPWM_0_REGS, true);
+
+    // Interrupts
+    IntRegister(SYS_INT_EHRPWM0, sound_isr);
+    IntChannelSet(SYS_INT_EHRPWM0, 1);
+    IntSystemEnable(SYS_INT_EHRPWM0);
+    EHRPWMETIntSourceSelect(SOC_EHRPWM_0_REGS, EHRPWM_ETSEL_INTSEL_TBCTREQUPRD);
+    EHRPWMETIntPrescale(SOC_EHRPWM_0_REGS, EHRPWM_ETPS_INTPRD_FIRSTEVENT);
+
+    // Configure IO pin mode
+    pbdrv_gpio_alt(&pin_audio, SYSCFG_PINMUX3_PINMUX3_7_4_EPWM0B);
 }
 
 #endif // PBDRV_CONFIG_SOUND_EV3

--- a/lib/pbio/platform/ev3/pbdrvconfig.h
+++ b/lib/pbio/platform/ev3/pbdrvconfig.h
@@ -71,6 +71,9 @@
 #define PBDRV_CONFIG_RESET                          (1)
 #define PBDRV_CONFIG_RESET_EV3                      (1)
 
+#define PBDRV_CONFIG_SOUND                          (1)
+#define PBDRV_CONFIG_SOUND_EV3                      (1)
+
 #define PBDRV_CONFIG_UART                           (1)
 #define PBDRV_CONFIG_UART_DEBUG_FIRST_PORT          (1)
 #define PBDRV_CONFIG_UART_EV3                       (1)

--- a/pybricks/hubs/pb_type_ev3brick.c
+++ b/pybricks/hubs/pb_type_ev3brick.c
@@ -20,6 +20,7 @@ typedef struct _hubs_EV3Brick_obj_t {
     mp_obj_t buttons;
     mp_obj_t light;
     mp_obj_t screen;
+    mp_obj_t speaker;
     mp_obj_t system;
 } hubs_EV3Brick_obj_t;
 
@@ -53,6 +54,7 @@ static mp_obj_t hubs_EV3Brick_make_new(const mp_obj_type_t *type, size_t n_args,
     self->buttons = pb_type_Keypad_obj_new(pb_type_ev3brick_button_pressed);
     self->light = common_ColorLight_internal_obj_new(pbsys_status_light_main);
     self->screen = pb_type_Image_display_obj_new();
+    self->speaker = mp_call_function_0(MP_OBJ_FROM_PTR(&pb_type_Speaker));
     self->system = MP_OBJ_FROM_PTR(&pb_type_System);
 
     return MP_OBJ_FROM_PTR(self);
@@ -63,6 +65,7 @@ static const pb_attr_dict_entry_t hubs_EV3Brick_attr_dict[] = {
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_buttons, hubs_EV3Brick_obj_t, buttons),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_light, hubs_EV3Brick_obj_t, light),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_screen, hubs_EV3Brick_obj_t, screen),
+    PB_DEFINE_CONST_ATTR_RO(MP_QSTR_speaker, hubs_EV3Brick_obj_t, speaker),
     PB_DEFINE_CONST_ATTR_RO(MP_QSTR_system, hubs_EV3Brick_obj_t, system),
     PB_ATTR_DICT_SENTINEL
 };


### PR DESCRIPTION
This is a basic speaker driver for the EV3. The API surface exposed to user code is the same `Speaker` class as other hubs.

This runs the hardware PWM module at a fixed frequency using asymmetrical PWM and fetches samples using a FIQ handler on the ARM core.

This implementation struggles to play higher-frequency notes due to interactions with the way the `Speaker` class is implemented. Specifically, the `Speaker` class always generates a waveform of the same number of samples (128 samples) but keeps increasing the sampling rate. This driver always outputs samples to the hardware at a fixed rate and does not implement a proper resampler, so it ends up badly distorting the waveform. However, beeps and notes around octaves 2-4 work.