### PR TITLE
pybricks/ev3devices: Enable remaining device support

### DIFF
--- a/pybricks/ev3devices.h
+++ b/pybricks/ev3devices.h
@@ -12,15 +12,10 @@
 
 extern const mp_obj_type_t pb_type_ev3devices_TouchSensor;
 extern const mp_obj_type_t pb_type_ev3devices_ColorSensor;
+extern const mp_obj_type_t pb_type_ev3devices_InfraredSensor;
+extern const mp_obj_type_t pb_type_ev3devices_UltrasonicSensor;
+extern const mp_obj_type_t pb_type_ev3devices_GyroSensor;
 
 #endif // PYBRICKS_PY_EV3DEVICES
-
-#if PYBRICKS_PY_EV3DEVDEVICES
-
-extern const mp_obj_type_t pb_type_ev3devices_InfraredSensor;
-extern const mp_obj_type_t pb_type_ev3devices_GyroSensor;
-extern const mp_obj_type_t pb_type_ev3devices_UltrasonicSensor;
-
-#endif // PYBRICKS_PY_EV3DEVDEVICES
 
 #endif // PYBRICKS_INCLUDED_PYBRICKS_EV3DEVICES_H

--- a/pybricks/ev3devices/pb_module_ev3devices.c
+++ b/pybricks/ev3devices/pb_module_ev3devices.c
@@ -15,11 +15,9 @@ static const mp_rom_map_elem_t ev3devices_globals_table[] = {
     #endif
     { MP_ROM_QSTR(MP_QSTR_TouchSensor),      MP_ROM_PTR(&pb_type_ev3devices_TouchSensor)     },
     { MP_ROM_QSTR(MP_QSTR_ColorSensor),      MP_ROM_PTR(&pb_type_ev3devices_ColorSensor)     },
-    #if PYBRICKS_PY_EV3DEVDEVICES
     { MP_ROM_QSTR(MP_QSTR_InfraredSensor),   MP_ROM_PTR(&pb_type_ev3devices_InfraredSensor)  },
     { MP_ROM_QSTR(MP_QSTR_UltrasonicSensor), MP_ROM_PTR(&pb_type_ev3devices_UltrasonicSensor)},
     { MP_ROM_QSTR(MP_QSTR_GyroSensor),       MP_ROM_PTR(&pb_type_ev3devices_GyroSensor)      },
-    #endif
 };
 static MP_DEFINE_CONST_DICT(pb_module_ev3devices_globals, ev3devices_globals_table);
 

--- a/pybricks/ev3devices/pb_type_ev3devices_gyrosensor.c
+++ b/pybricks/ev3devices/pb_type_ev3devices_gyrosensor.c
@@ -3,7 +3,7 @@
 
 #include "py/mpconfig.h"
 
-#if PYBRICKS_PY_EV3DEVDEVICES
+#if PYBRICKS_PY_EV3DEVICES
 
 #include <pybricks/common.h>
 #include <pybricks/ev3devices.h>
@@ -103,4 +103,4 @@ MP_DEFINE_CONST_OBJ_TYPE(pb_type_ev3devices_GyroSensor,
     make_new, ev3devices_GyroSensor_make_new,
     locals_dict, &ev3devices_GyroSensor_locals_dict);
 
-#endif // PYBRICKS_PY_EV3DEVDEVICES
+#endif // PYBRICKS_PY_EV3DEVICES

--- a/pybricks/ev3devices/pb_type_ev3devices_infraredsensor.c
+++ b/pybricks/ev3devices/pb_type_ev3devices_infraredsensor.c
@@ -3,7 +3,7 @@
 
 #include "py/mpconfig.h"
 
-#if PYBRICKS_PY_EV3DEVDEVICES
+#if PYBRICKS_PY_EV3DEVICES
 
 #include <pybricks/common.h>
 #include <pybricks/ev3devices.h>
@@ -181,4 +181,4 @@ MP_DEFINE_CONST_OBJ_TYPE(pb_type_ev3devices_InfraredSensor,
     make_new, ev3devices_InfraredSensor_make_new,
     locals_dict, &ev3devices_InfraredSensor_locals_dict);
 
-#endif // PYBRICKS_PY_EV3DEVDEVICES
+#endif // PYBRICKS_PY_EV3DEVICES

--- a/pybricks/ev3devices/pb_type_ev3devices_ultrasonicsensor.c
+++ b/pybricks/ev3devices/pb_type_ev3devices_ultrasonicsensor.c
@@ -3,7 +3,7 @@
 
 #include "py/mpconfig.h"
 
-#if PYBRICKS_PY_EV3DEVDEVICES
+#if PYBRICKS_PY_EV3DEVICES
 
 #include <pybricks/common.h>
 #include <pybricks/ev3devices.h>
@@ -63,4 +63,4 @@ MP_DEFINE_CONST_OBJ_TYPE(pb_type_ev3devices_UltrasonicSensor,
     make_new, ev3devices_UltrasonicSensor_make_new,
     locals_dict, &ev3devices_UltrasonicSensor_locals_dict);
 
-#endif // PYBRICKS_PY_EV3DEVDEVICES
+#endif // PYBRICKS_PY_EV3DEVICES


### PR DESCRIPTION
As mentioned on the call earlier today, I decided to test if this module was already working or not. It would appear that it is, at least for basic distance measurements. I don't have a remote or any way to test the other functionality,