### PR TITLE
pbio/drv/block_device_ev3: Fix RX DMA channel.

### DIFF
--- a/lib/pbio/drv/block_device/block_device_ev3.c
+++ b/lib/pbio/drv/block_device/block_device_ev3.c
@@ -243,7 +243,7 @@ static void spi_bus_init(void) {
 
     // Request DMA channels. This only needs to be done for the initial events (and not for linked parameter sets)
     EDMA3RequestChannel(SOC_EDMA30CC_0_REGS, EDMA3_CHANNEL_TYPE_DMA, EDMA3_CHA_SPI0_TX, EDMA3_CHA_SPI0_TX, 0);
-    EDMA3RequestChannel(SOC_EDMA30CC_0_REGS, EDMA3_CHANNEL_TYPE_DMA, EDMA3_CHA_SPI1_RX, EDMA3_CHA_SPI1_RX, 0);
+    EDMA3RequestChannel(SOC_EDMA30CC_0_REGS, EDMA3_CHANNEL_TYPE_DMA, EDMA3_CHA_SPI0_RX, EDMA3_CHA_SPI0_RX, 0);
 
     // Enable!
     SPIEnable(SOC_SPI_0_REGS);


### PR DESCRIPTION
Fix a typo where the RX channel for the wrong SPI peripheral was requested. Likely we didn't notice this because everything should already be set up correctly by the bootloader since it also uses this SPI for flash memory.