### PR TITLE
USB stdio v2

### DIFF
--- a/bricks/_common_stm32/mphalport.c
+++ b/bricks/_common_stm32/mphalport.c
@@ -38,7 +38,7 @@ void mp_hal_delay_ms(mp_uint_t Delay) {
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
 
-    if ((poll_flags & MP_STREAM_POLL_RD) && pbsys_host_rx_get_available()) {
+    if ((poll_flags & MP_STREAM_POLL_RD) && pbsys_host_stdin_get_available()) {
         ret |= MP_STREAM_POLL_RD;
     }
 
@@ -51,7 +51,7 @@ int mp_hal_stdin_rx_chr(void) {
     uint8_t c;
 
     // wait for rx interrupt
-    while (size = 1, pbsys_host_rx(&c, &size) != PBIO_SUCCESS) {
+    while (size = 1, pbsys_host_stdin_read(&c, &size) != PBIO_SUCCESS) {
         MICROPY_EVENT_POLL_HOOK
     }
 

--- a/lib/pbio/drv/usb/usb_stm32.c
+++ b/lib/pbio/drv/usb/usb_stm32.c
@@ -145,8 +145,8 @@ void pbdrv_usb_stm32_handle_vbus_irq(bool active) {
  * @param data  [in]        The data to be sent.
  * @param size  [in, out]   The size of @p data in bytes. After return, @p size
  *                          contains the number of bytes actually written.
- * @return                  ::PBIO_SUCCESS if all @p data was queued, ::PBIO_ERROR_AGAIN
- *                          if not all @p data could not be queued at this time (e.g. buffer
+ * @return                  ::PBIO_SUCCESS if some @p data was queued, ::PBIO_ERROR_AGAIN
+ *                          if no @p data could not be queued at this time (e.g. buffer
  *                          is full), ::PBIO_ERROR_INVALID_OP if there is not an
  *                          active USB connection or ::PBIO_ERROR_NOT_SUPPORTED
  *                          if this platform does not support USB.
@@ -158,7 +158,6 @@ pbio_error_t pbdrv_usb_stdout_tx(const uint8_t *data, uint32_t *size) {
 
     uint8_t *ptr = usb_stdout_buf;
     uint32_t ptr_len = sizeof(usb_stdout_buf);
-    uint32_t full_size = *size;
 
     // TODO: return PBIO_ERROR_INVALID_OP if app flag is not set. Also need a
     // timeout in case the app crashes and doesn't clear the flag on exit.
@@ -174,14 +173,24 @@ pbio_error_t pbdrv_usb_stdout_tx(const uint8_t *data, uint32_t *size) {
     *ptr++ = PBIO_PYBRICKS_EVENT_WRITE_STDOUT;
     ptr_len--;
 
-    *size = MIN(full_size, ptr_len);
+    *size = MIN(*size, ptr_len);
     memcpy(ptr, data, *size);
 
     usb_stdout_sz = 1 + 1 + *size;
 
     process_poll(&pbdrv_usb_process);
 
-    return *size == full_size ? PBIO_SUCCESS : PBIO_ERROR_AGAIN;
+    return PBIO_SUCCESS;
+}
+
+uint32_t pbdrv_usb_stdout_tx_available(void) {
+    // TODO: return UINT32_MAX if app flag is not set.
+
+    if (usb_stdout_sz) {
+        return 0;
+    }
+
+    return sizeof(usb_stdout_buf) - 2; // 2 bytes for header
 }
 
 /**

--- a/lib/pbio/drv/usb/usb_stm32.c
+++ b/lib/pbio/drv/usb/usb_stm32.c
@@ -39,6 +39,7 @@ static volatile uint32_t usb_response_sz;
 static volatile uint32_t usb_status_sz;
 static volatile uint32_t usb_stdout_sz;
 static volatile bool transmitting;
+static volatile bool pbdrv_usb_stm32_is_events_subscribed;
 
 static USBD_HandleTypeDef husbd;
 static PCD_HandleTypeDef hpcd;
@@ -156,11 +157,13 @@ pbio_error_t pbdrv_usb_stdout_tx(const uint8_t *data, uint32_t *size) {
     return PBIO_ERROR_NOT_IMPLEMENTED;
     #endif
 
+    if (!pbdrv_usb_stm32_is_events_subscribed) {
+        // If the app hasn't subscribed to events, we can't send stdout.
+        return PBIO_ERROR_INVALID_OP;
+    }
+
     uint8_t *ptr = usb_stdout_buf;
     uint32_t ptr_len = sizeof(usb_stdout_buf);
-
-    // TODO: return PBIO_ERROR_INVALID_OP if app flag is not set. Also need a
-    // timeout in case the app crashes and doesn't clear the flag on exit.
 
     if (usb_stdout_sz) {
         *size = 0;
@@ -184,7 +187,9 @@ pbio_error_t pbdrv_usb_stdout_tx(const uint8_t *data, uint32_t *size) {
 }
 
 uint32_t pbdrv_usb_stdout_tx_available(void) {
-    // TODO: return UINT32_MAX if app flag is not set.
+    if (!pbdrv_usb_stm32_is_events_subscribed) {
+        return UINT32_MAX;
+    }
 
     if (usb_stdout_sz) {
         return 0;
@@ -201,6 +206,14 @@ bool pbdrv_usb_stdout_tx_is_idle(void) {
     return usb_stdout_sz == 0;
 }
 
+static void pbdrv_usb_stm32_reset_tx_state(void) {
+    usb_response_sz = 0;
+    usb_status_sz = 0;
+    usb_stdout_sz = 0;
+    transmitting = false;
+    pbdrv_usb_stm32_is_events_subscribed = false;
+}
+
 /**
   * @brief  Pybricks_Itf_Init
   *         Initializes the Pybricks media low layer
@@ -210,10 +223,7 @@ bool pbdrv_usb_stdout_tx_is_idle(void) {
 static USBD_StatusTypeDef Pybricks_Itf_Init(void) {
     USBD_Pybricks_SetRxBuffer(&husbd, usb_in_buf);
     usb_in_sz = 0;
-    usb_response_sz = 0;
-    usb_status_sz = 0;
-    usb_stdout_sz = 0;
-    transmitting = false;
+    pbdrv_usb_stm32_reset_tx_state();
 
     return USBD_OK;
 }
@@ -225,6 +235,7 @@ static USBD_StatusTypeDef Pybricks_Itf_Init(void) {
   * @retval Result of the operation: USBD_OK if all operations are OK else USBD_FAIL
   */
 static USBD_StatusTypeDef Pybricks_Itf_DeInit(void) {
+    pbdrv_usb_stm32_reset_tx_state();
     return USBD_OK;
 }
 
@@ -316,7 +327,8 @@ PROCESS_THREAD(pbdrv_usb_process, ev, data) {
     static PBIO_ONESHOT(pwrdn_oneshot);
     static bool bcd_busy;
     static pbio_pybricks_error_t result;
-    static struct etimer timer;
+    static struct etimer status_timer;
+    static struct etimer transmit_timer;
     static uint32_t prev_status_flags = ~0;
     static uint32_t new_status_flags;
 
@@ -337,7 +349,7 @@ PROCESS_THREAD(pbdrv_usb_process, ev, data) {
 
     PROCESS_BEGIN();
 
-    etimer_set(&timer, 500);
+    etimer_set(&status_timer, 500);
 
     for (;;) {
         PROCESS_WAIT_EVENT();
@@ -369,6 +381,12 @@ PROCESS_THREAD(pbdrv_usb_process, ev, data) {
 
         if (usb_in_sz) {
             switch (usb_in_buf[0]) {
+                case USBD_PYBRICKS_OUT_EP_MSG_SUBSCRIBE:
+                    pbdrv_usb_stm32_is_events_subscribed = usb_in_buf[1];
+                    usb_response_buf[0] = USBD_PYBRICKS_IN_EP_MSG_RESPONSE;
+                    pbio_set_uint32_le(&usb_response_buf[1], PBIO_PYBRICKS_ERROR_OK);
+                    usb_response_sz = sizeof(usb_response_buf);
+                    break;
                 case USBD_PYBRICKS_OUT_EP_MSG_COMMAND:
                     if (usb_response_sz == 0) {
                         result = pbsys_command(usb_in_buf + 1, usb_in_sz - 1);
@@ -385,6 +403,13 @@ PROCESS_THREAD(pbdrv_usb_process, ev, data) {
         }
 
         if (transmitting) {
+            if (etimer_expired(&transmit_timer)) {
+                // Transmission has taken too long, so reset the state to allow
+                // new transmissions. This can happen if the host stops reading
+                // data for some reason.
+                pbdrv_usb_stm32_reset_tx_state();
+            }
+
             continue;
         }
 
@@ -394,20 +419,32 @@ PROCESS_THREAD(pbdrv_usb_process, ev, data) {
         if (usb_response_sz) {
             transmitting = true;
             USBD_Pybricks_TransmitPacket(&husbd, usb_response_buf, usb_response_sz);
-        } else if ((new_status_flags != prev_status_flags) || etimer_expired(&timer)) {
-            usb_status_buf[0] = USBD_PYBRICKS_IN_EP_MSG_EVENT;
-            _Static_assert(sizeof(usb_status_buf) + 1 >= PBIO_PYBRICKS_EVENT_STATUS_REPORT_SIZE,
-                "size of status report does not match size of event");
-            usb_status_sz = 1 + pbsys_status_get_status_report(&usb_status_buf[1]);
+        } else if (pbdrv_usb_stm32_is_events_subscribed) {
+            if ((new_status_flags != prev_status_flags) || etimer_expired(&status_timer)) {
+                usb_status_buf[0] = USBD_PYBRICKS_IN_EP_MSG_EVENT;
+                _Static_assert(sizeof(usb_status_buf) + 1 >= PBIO_PYBRICKS_EVENT_STATUS_REPORT_SIZE,
+                    "size of status report does not match size of event");
+                usb_status_sz = 1 + pbsys_status_get_status_report(&usb_status_buf[1]);
 
-            etimer_restart(&timer);
-            prev_status_flags = new_status_flags;
+                // REVISIT: we really shouldn't need a status timer on USB since
+                // it's not a lossy transport. We just need to make sure we send
+                // status updates when they change and send the current status
+                // immediately after subscribing to events.
+                etimer_restart(&status_timer);
+                prev_status_flags = new_status_flags;
 
-            transmitting = true;
-            USBD_Pybricks_TransmitPacket(&husbd, usb_status_buf, usb_status_sz);
-        } else if (usb_stdout_sz) {
-            transmitting = true;
-            USBD_Pybricks_TransmitPacket(&husbd, usb_stdout_buf, usb_stdout_sz);
+                transmitting = true;
+                USBD_Pybricks_TransmitPacket(&husbd, usb_status_buf, usb_status_sz);
+            } else if (usb_stdout_sz) {
+                transmitting = true;
+                USBD_Pybricks_TransmitPacket(&husbd, usb_stdout_buf, usb_stdout_sz);
+            }
+        }
+
+        if (transmitting) {
+            // If the FIFO isn't emptied quickly, then there probably isn't an
+            // app anymore. This timer is used to detect such a condition.
+            etimer_set(&transmit_timer, 5);
         }
     }
 

--- a/lib/pbio/include/pbdrv/usb.h
+++ b/lib/pbio/include/pbdrv/usb.h
@@ -47,6 +47,16 @@ pbdrv_usb_bcd_t pbdrv_usb_get_bcd(void);
 pbio_error_t pbdrv_usb_stdout_tx(const uint8_t *data, uint32_t *size);
 
 /**
+ * Gets the number of bytes that can be queued for sending stdout via USB.
+ *
+ * Returns UINT32_MAX if there is no USB connection or no app is subscribed to
+ * stdout.
+ *
+ * @return              The number of bytes that can be queued.
+ */
+uint32_t pbdrv_usb_stdout_tx_available(void);
+
+/**
  * Indicates if the USB stdout stream is idle.
  * @return              true if the USB stdout stream is idle.
 */
@@ -60,6 +70,10 @@ static inline pbdrv_usb_bcd_t pbdrv_usb_get_bcd(void) {
 
 static inline pbio_error_t pbdrv_usb_stdout_tx(const uint8_t *data, uint32_t *size) {
     return PBIO_SUCCESS;
+}
+
+static inline uint32_t pbdrv_usb_stdout_tx_available(void) {
+    return UINT32_MAX;
 }
 
 static inline bool pbdrv_usb_stdout_tx_is_idle(void) {

--- a/lib/pbio/include/pbsys/host.h
+++ b/lib/pbio/include/pbsys/host.h
@@ -26,33 +26,26 @@ typedef bool (*pbsys_host_stdin_event_callback_t)(uint8_t c);
 #if PBSYS_CONFIG_HOST
 
 void pbsys_host_init(void);
-void pbsys_host_rx_set_callback(pbsys_host_stdin_event_callback_t callback);
-void pbsys_host_rx_flush(void);
-uint32_t pbsys_host_rx_get_available(void);
-uint32_t pbsys_host_rx_get_free(void);
-void pbsys_host_rx_write(const uint8_t *data, uint32_t size);
-pbio_error_t pbsys_host_rx(uint8_t *data, uint32_t *size);
+uint32_t pbsys_host_stdin_get_free(void);
+void pbsys_host_stdin_write(const uint8_t *data, uint32_t size);
+void pbsys_host_stdin_set_callback(pbsys_host_stdin_event_callback_t callback);
+void pbsys_host_stdin_flush(void);
+uint32_t pbsys_host_stdin_get_available(void);
+pbio_error_t pbsys_host_stdin_read(uint8_t *data, uint32_t *size);
 pbio_error_t pbsys_host_tx(const uint8_t *data, uint32_t size);
 bool pbsys_host_tx_is_idle(void);
 
 #else // PBSYS_CONFIG_HOST
 
 #define pbsys_host_init()
-#define pbsys_host_rx_set_callback(callback)
-#define pbsys_host_rx_flush()
-#define pbsys_host_rx_get_available() 0
-#define pbsys_host_rx_get_free() 0
-#define pbsys_host_rx_write(data, size)
-
-static inline pbio_error_t pbsys_host_rx(uint8_t *data, uint32_t *size) {
-    return PBIO_ERROR_NOT_SUPPORTED;
-}
-static inline pbio_error_t pbsys_host_tx(const uint8_t *data, uint32_t size) {
-    return PBIO_ERROR_NOT_SUPPORTED;
-}
-static inline bool pbsys_host_tx_is_idle(void) {
-    return false;
-}
+#define pbsys_host_stdin_get_free() 0
+#define pbsys_host_stdin_write(data, size) { (void)(data); (void)(size); }
+#define pbsys_host_stdin_set_callback(callback) { (void)(callback); }
+#define pbsys_host_stdin_flush()
+#define pbsys_host_stdin_get_available() 0
+#define pbsys_host_stdin_read(data, size) PBIO_ERROR_NOT_SUPPORTED
+#define pbsys_host_tx(data, size) { (void)(data); (void)(size); PBIO_ERROR_NOT_SUPPORTED; }
+#define pbsys_host_tx_is_idle() false
 
 #endif // PBSYS_CONFIG_HOST
 

--- a/lib/pbio/include/pbsys/host.h
+++ b/lib/pbio/include/pbsys/host.h
@@ -32,7 +32,7 @@ void pbsys_host_stdin_set_callback(pbsys_host_stdin_event_callback_t callback);
 void pbsys_host_stdin_flush(void);
 uint32_t pbsys_host_stdin_get_available(void);
 pbio_error_t pbsys_host_stdin_read(uint8_t *data, uint32_t *size);
-pbio_error_t pbsys_host_tx(const uint8_t *data, uint32_t size);
+pbio_error_t pbsys_host_stdout_write(const uint8_t *data, uint32_t *size);
 bool pbsys_host_tx_is_idle(void);
 
 #else // PBSYS_CONFIG_HOST
@@ -44,7 +44,7 @@ bool pbsys_host_tx_is_idle(void);
 #define pbsys_host_stdin_flush()
 #define pbsys_host_stdin_get_available() 0
 #define pbsys_host_stdin_read(data, size) PBIO_ERROR_NOT_SUPPORTED
-#define pbsys_host_tx(data, size) { (void)(data); (void)(size); PBIO_ERROR_NOT_SUPPORTED; }
+#define pbsys_host_stdout_write(data, size) { (void)(data); (void)(size); PBIO_ERROR_NOT_SUPPORTED; }
 #define pbsys_host_tx_is_idle() false
 
 #endif // PBSYS_CONFIG_HOST

--- a/lib/pbio/platform/city_hub/pbsysconfig.h
+++ b/lib/pbio/platform/city_hub/pbsysconfig.h
@@ -13,6 +13,7 @@
 #define PBSYS_CONFIG_HMI_NUM_SLOTS                  (0)
 #define PBSYS_CONFIG_HUB_LIGHT_MATRIX               (0)
 #define PBSYS_CONFIG_HOST                           (1)
+#define PBSYS_CONFIG_HOST_STDIN_BUF_SIZE            (21)
 #define PBSYS_CONFIG_MAIN                           (1)
 #define PBSYS_CONFIG_STORAGE                        (1)
 #define PBSYS_CONFIG_STORAGE_NUM_SLOTS              (1)

--- a/lib/pbio/platform/essential_hub/pbdrvconfig.h
+++ b/lib/pbio/platform/essential_hub/pbdrvconfig.h
@@ -103,7 +103,7 @@
 #define PBDRV_CONFIG_USB_MFG_STR                    LEGO_USB_MFG_STR
 #define PBDRV_CONFIG_USB_PROD_STR                   LEGO_USB_PROD_STR_TECHNIC_SMALL_HUB " + Pybricks"
 #define PBDRV_CONFIG_USB_STM32F4                    (1)
-#define PBDRV_CONFIG_USB_CHARGE_ONLY                (1)
+#define PBDRV_CONFIG_USB_CHARGE_ONLY                (0)
 
 #define PBDRV_CONFIG_STACK                          (1)
 #define PBDRV_CONFIG_STACK_EMBEDDED                 (1)

--- a/lib/pbio/platform/essential_hub/pbsysconfig.h
+++ b/lib/pbio/platform/essential_hub/pbsysconfig.h
@@ -11,6 +11,7 @@
 #define PBSYS_CONFIG_HMI_NUM_SLOTS                  (0)
 #define PBSYS_CONFIG_HUB_LIGHT_MATRIX               (0)
 #define PBSYS_CONFIG_HOST                           (1)
+#define PBSYS_CONFIG_HOST_STDIN_BUF_SIZE            (64)
 #define PBSYS_CONFIG_MAIN                           (1)
 #define PBSYS_CONFIG_STORAGE                        (1)
 #define PBSYS_CONFIG_STORAGE_NUM_SLOTS              (1)

--- a/lib/pbio/platform/ev3/pbsysconfig.h
+++ b/lib/pbio/platform/ev3/pbsysconfig.h
@@ -7,6 +7,7 @@
 #define PBSYS_CONFIG_FEATURE_PROGRAM_FORMAT_MULTI_MPY_V6           (1)
 #define PBSYS_CONFIG_FEATURE_PROGRAM_FORMAT_MULTI_MPY_V6_3_NATIVE  (0)
 #define PBSYS_CONFIG_HOST                           (1)
+#define PBSYS_CONFIG_HOST_STDIN_BUF_SIZE            (21)
 #define PBSYS_CONFIG_MAIN                           (1)
 #define PBSYS_CONFIG_STORAGE                        (1)
 #define PBSYS_CONFIG_STORAGE_NUM_SLOTS              (1)

--- a/lib/pbio/platform/move_hub/pbsysconfig.h
+++ b/lib/pbio/platform/move_hub/pbsysconfig.h
@@ -13,6 +13,7 @@
 #define PBSYS_CONFIG_HMI_NUM_SLOTS                  (0)
 #define PBSYS_CONFIG_HUB_LIGHT_MATRIX               (0)
 #define PBSYS_CONFIG_HOST                           (1)
+#define PBSYS_CONFIG_HOST_STDIN_BUF_SIZE            (21)
 #define PBSYS_CONFIG_MAIN                           (1)
 #define PBSYS_CONFIG_STORAGE                        (1)
 #define PBSYS_CONFIG_STORAGE_NUM_SLOTS              (1)

--- a/lib/pbio/platform/nxt/pbsysconfig.h
+++ b/lib/pbio/platform/nxt/pbsysconfig.h
@@ -7,6 +7,7 @@
 #define PBSYS_CONFIG_FEATURE_PROGRAM_FORMAT_MULTI_MPY_V6           (1)
 #define PBSYS_CONFIG_FEATURE_PROGRAM_FORMAT_MULTI_MPY_V6_3_NATIVE  (0)
 #define PBSYS_CONFIG_HOST                           (1)
+#define PBSYS_CONFIG_HOST_STDIN_BUF_SIZE            (64)
 #define PBSYS_CONFIG_MAIN                           (1)
 #define PBSYS_CONFIG_STORAGE                        (1)
 #define PBSYS_CONFIG_STORAGE_NUM_SLOTS              (1)

--- a/lib/pbio/platform/prime_hub/pbdrvconfig.h
+++ b/lib/pbio/platform/prime_hub/pbdrvconfig.h
@@ -123,7 +123,7 @@
 #define PBDRV_CONFIG_USB_PROD_STR                   LEGO_USB_PROD_STR_TECHNIC_LARGE_HUB " + Pybricks"
 #define PBDRV_CONFIG_USB_STM32F4                    (1)
 #define PBDRV_CONFIG_USB_STM32F4_HUB_VARIANT_ADDR   0x08007d80
-#define PBDRV_CONFIG_USB_CHARGE_ONLY                (1)
+#define PBDRV_CONFIG_USB_CHARGE_ONLY                (0)
 
 #define PBDRV_CONFIG_STACK                          (1)
 #define PBDRV_CONFIG_STACK_EMBEDDED                 (1)

--- a/lib/pbio/platform/prime_hub/pbsysconfig.h
+++ b/lib/pbio/platform/prime_hub/pbsysconfig.h
@@ -13,6 +13,7 @@
 #define PBSYS_CONFIG_HMI_NUM_SLOTS                  (5)
 #define PBSYS_CONFIG_HUB_LIGHT_MATRIX               (1)
 #define PBSYS_CONFIG_HOST                           (1)
+#define PBSYS_CONFIG_HOST_STDIN_BUF_SIZE            (64)
 #define PBSYS_CONFIG_MAIN                           (1)
 #define PBSYS_CONFIG_STORAGE                        (1)
 #define PBSYS_CONFIG_STORAGE_NUM_SLOTS              (5)

--- a/lib/pbio/platform/technic_hub/pbsysconfig.h
+++ b/lib/pbio/platform/technic_hub/pbsysconfig.h
@@ -13,6 +13,7 @@
 #define PBSYS_CONFIG_HMI_NUM_SLOTS                  (0)
 #define PBSYS_CONFIG_HUB_LIGHT_MATRIX               (0)
 #define PBSYS_CONFIG_HOST                           (1)
+#define PBSYS_CONFIG_HOST_STDIN_BUF_SIZE            (21)
 #define PBSYS_CONFIG_MAIN                           (1)
 #define PBSYS_CONFIG_STORAGE                        (1)
 #define PBSYS_CONFIG_STORAGE_NUM_SLOTS              (1)

--- a/lib/pbio/platform/test/pbsysconfig.h
+++ b/lib/pbio/platform/test/pbsysconfig.h
@@ -8,6 +8,7 @@
 #define PBSYS_CONFIG_FEATURE_PROGRAM_FORMAT_MULTI_MPY_V6_3_NATIVE  (0)
 #define PBSYS_CONFIG_BLUETOOTH                      (1)
 #define PBSYS_CONFIG_HOST                           (1)
+#define PBSYS_CONFIG_HOST_STDIN_BUF_SIZE            (64)
 #define PBSYS_CONFIG_HMI_NUM_SLOTS                  (0)
 #define PBSYS_CONFIG_HUB_LIGHT_MATRIX               (0)
 #define PBSYS_CONFIG_MAIN                           (0)

--- a/lib/pbio/sys/bluetooth.h
+++ b/lib/pbio/sys/bluetooth.h
@@ -10,30 +10,18 @@
 #include <pbio/error.h>
 #include <pbsys/host.h>
 
-uint32_t pbsys_bluetooth_rx_get_free(void);
-void pbsys_bluetooth_rx_write(const uint8_t *data, uint32_t size);
 void pbsys_bluetooth_process_poll(void);
 
 #if PBSYS_CONFIG_BLUETOOTH
 
 void pbsys_bluetooth_init(void);
-void pbsys_bluetooth_rx_set_callback(pbsys_host_stdin_event_callback_t callback);
-void pbsys_bluetooth_rx_flush(void);
-uint32_t pbsys_bluetooth_rx_get_available(void);
-pbio_error_t pbsys_bluetooth_rx(uint8_t *data, uint32_t *size);
 pbio_error_t pbsys_bluetooth_tx(const uint8_t *data, uint32_t *size);
 bool pbsys_bluetooth_tx_is_idle(void);
 
 #else // PBSYS_CONFIG_BLUETOOTH
 
 #define pbsys_bluetooth_init()
-#define pbsys_bluetooth_rx_set_callback(callback)
-#define pbsys_bluetooth_rx_flush()
-#define pbsys_bluetooth_rx_get_available() 0
 
-static inline pbio_error_t pbsys_bluetooth_rx(uint8_t *data, uint32_t *size) {
-    return PBIO_ERROR_NOT_SUPPORTED;
-}
 static inline pbio_error_t pbsys_bluetooth_tx(const uint8_t *data, uint32_t *size) {
     return PBIO_ERROR_NOT_SUPPORTED;
 }

--- a/lib/pbio/sys/bluetooth.h
+++ b/lib/pbio/sys/bluetooth.h
@@ -16,6 +16,7 @@ void pbsys_bluetooth_process_poll(void);
 
 void pbsys_bluetooth_init(void);
 pbio_error_t pbsys_bluetooth_tx(const uint8_t *data, uint32_t *size);
+uint32_t pbsys_bluetooth_tx_available(void);
 bool pbsys_bluetooth_tx_is_idle(void);
 
 #else // PBSYS_CONFIG_BLUETOOTH
@@ -24,6 +25,9 @@ bool pbsys_bluetooth_tx_is_idle(void);
 
 static inline pbio_error_t pbsys_bluetooth_tx(const uint8_t *data, uint32_t *size) {
     return PBIO_ERROR_NOT_SUPPORTED;
+}
+static inline uint32_t pbsys_bluetooth_tx_available(void) {
+    return UINT32_MAX;
 }
 static inline bool pbsys_bluetooth_tx_is_idle(void) {
     return false;

--- a/lib/pbio/sys/command.c
+++ b/lib/pbio/sys/command.c
@@ -73,10 +73,10 @@ pbio_pybricks_error_t pbsys_command(const uint8_t *data, uint32_t size) {
 
         case PBIO_PYBRICKS_COMMAND_WRITE_STDIN:
             #if PBSYS_CONFIG_HOST
-            if (pbsys_host_rx_get_free() < size - 1) {
+            if (pbsys_host_stdin_get_free() < size - 1) {
                 return PBIO_PYBRICKS_ERROR_BUSY;
             }
-            pbsys_host_rx_write(&data[1], size - 1);
+            pbsys_host_stdin_write(&data[1], size - 1);
             #endif
             // If no consumers are configured, goes to "/dev/null" without error
             return PBIO_PYBRICKS_ERROR_OK;

--- a/lib/pbio/sys/host.c
+++ b/lib/pbio/sys/host.c
@@ -155,8 +155,23 @@ pbio_error_t pbsys_host_stdout_write(const uint8_t *data, uint32_t *size) {
     #endif
 }
 
+/**
+ * Checks if all data has been transmitted.
+ *
+ * This is used to implement, e.g. a flush() function that blocks until all
+ * data has been sent.
+ *
+ * @return              true if all data has been transmitted or no one is
+ *                      listening, false if there is still data queued to be sent.
+ */
 bool pbsys_host_tx_is_idle(void) {
+    #if PBDRV_CONFIG_USB && !PBDRV_CONFIG_USB_CHARGE_ONLY
+    // The USB part is a bit of a hack since it depends on the USB driver not
+    // buffering more than one packet at a time to actually be accurate.
+    return pbsys_bluetooth_tx_is_idle() && pbdrv_usb_stdout_tx_available();
+    #else
     return pbsys_bluetooth_tx_is_idle();
+    #endif
 }
 
 #endif // PBSYS_CONFIG_HOST

--- a/lib/pbio/sys/main.c
+++ b/lib/pbio/sys/main.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
         // Prepare pbsys for running the program.
         pbsys_status_set_program_id(program.id);
         pbsys_status_set(PBIO_PYBRICKS_STATUS_USER_PROGRAM_RUNNING);
-        pbsys_host_rx_set_callback(pbsys_main_stdin_event);
+        pbsys_host_stdin_set_callback(pbsys_main_stdin_event);
         pbsys_hub_light_matrix_handle_user_program_start(true);
 
         // Handle pending events triggered by the status change, such as
@@ -113,12 +113,15 @@ int main(int argc, char **argv) {
         while (pbio_os_run_processes_once()) {
         }
 
+        // Make sure we are starting with an empty stdin buffer.
+        pbsys_host_stdin_flush();
+
         // Run the main application.
         pbsys_main_run_program(&program);
 
         // Get system back in idle state.
         pbsys_status_clear(PBIO_PYBRICKS_STATUS_USER_PROGRAM_RUNNING);
-        pbsys_host_rx_set_callback(NULL);
+        pbsys_host_stdin_set_callback(NULL);
         pbsys_program_stop_set_buttons(PBIO_BUTTON_CENTER);
         pbsys_hub_light_matrix_handle_user_program_start(false);
         pbio_stop_all(true);

--- a/lib/pbio/test/sys/test_bluetooth.c
+++ b/lib/pbio/test/sys/test_bluetooth.c
@@ -10,6 +10,7 @@
 #include <tinytest.h>
 
 #include <pbio/util.h>
+#include <pbsys/host.h>
 #include <pbsys/main.h>
 #include <pbsys/status.h>
 #include <test-pbio.h>
@@ -20,7 +21,7 @@
 static PT_THREAD(test_bluetooth(struct pt *pt)) {
     PT_BEGIN(pt);
 
-    pbsys_bluetooth_init();
+    pbsys_host_init();
 
     // power should be initialized to off
     tt_want_uint_op(pbio_test_bluetooth_get_control_state(), ==, PBIO_TEST_BLUETOOTH_STATE_OFF);
@@ -84,7 +85,7 @@ static PT_THREAD(test_bluetooth(struct pt *pt)) {
     PT_WAIT_UNTIL(pt, ({
         pbio_test_clock_tick(1);
         size = PBIO_ARRAY_SIZE(rx_data);
-        pbsys_bluetooth_rx(rx_data, &size) == PBIO_SUCCESS;
+        pbsys_host_stdin_read(rx_data, &size) == PBIO_SUCCESS;
     }));
 
     tt_want_uint_op(size, ==, strlen("test3\n"));


### PR DESCRIPTION
The less ambitious alternative to https://github.com/pybricks/pybricks-micropython/pull/332.

This time, instead of duplicating a bunch of stuff, we finish the TODO to move the stdin buffer out of pbsys_bluetooth and into pbsys_host. Then we can hook up the USB stdin to this as well.