### PR TITLE
pbio/drv/sound/sound_ev3: Fix playing a frequency of 0

### DIFF
--- a/lib/pbio/drv/sound/sound_ev3.c
+++ b/lib/pbio/drv/sound/sound_ev3.c
@@ -43,6 +43,12 @@ void pbdrv_sound_stop() {
 }
 
 void pbdrv_beep_start(uint32_t frequency, uint16_t sample_attenuator) {
+    // A frequency of 0 is equivalent to turning the sound off
+    if (frequency == 0) {
+        pbdrv_sound_stop();
+        return;
+    }
+
     // Clamp the frequency into the supported range
     if (frequency < 64) {
         frequency = 64;


### PR DESCRIPTION
A frequency of 0 turns the sound off. It would previously play a minimum-frequency 64 Hz sound instead.

Fixes issue reported by @BertLindeman [here](https://github.com/pybricks/pybricks-micropython/pull/342#issuecomment-3092244006). Thanks for testing!