### PR TITLE
pbio/sys/storage_data: fix strict aliasing issues

### DIFF
--- a/lib/pbio/include/pbdrv/block_device.h
+++ b/lib/pbio/include/pbdrv/block_device.h
@@ -11,9 +11,10 @@
 
 #include <stdint.h>
 
+#include "../sys/storage_data.h"
+
 #include <pbdrv/config.h>
 #include <pbio/error.h>
-
 #include <pbio/os.h>
 
 #if PBDRV_CONFIG_BLOCK_DEVICE
@@ -28,7 +29,7 @@
  *                      ::PBIO_ERROR_IO (driver-specific error), though boot
  *                        does not proceed if this happens.
  */
-pbio_error_t pbdrv_block_device_get_data(uint8_t **data);
+pbio_error_t pbdrv_block_device_get_data(pbsys_storage_data_map_t **data);
 
 /**
  * Writes the "RAM Disk" to storage. May erase entire disk prior to writing.
@@ -57,7 +58,7 @@ uint32_t pbdrv_block_device_get_writable_size(void);
 
 #else
 
-static inline pbio_error_t pbdrv_block_device_get_data(uint8_t **data) {
+static inline pbio_error_t pbdrv_block_device_get_data(pbsys_storage_data_map_t **data) {
     return PBIO_ERROR_NOT_SUPPORTED;
 }
 

--- a/lib/pbio/platform/nxt/pbdrvconfig.h
+++ b/lib/pbio/platform/nxt/pbdrvconfig.h
@@ -11,8 +11,6 @@
 #define PBDRV_CONFIG_BLOCK_DEVICE                   (1)
 #define PBDRV_CONFIG_BLOCK_DEVICE_RAM_SIZE          (10 * 1024)
 #define PBDRV_CONFIG_BLOCK_DEVICE_TEST              (1)
-#define PBDRV_CONFIG_BLOCK_DEVICE_TEST_SIZE         (8 * 1024)
-#define PBDRV_CONFIG_BLOCK_DEVICE_TEST_SIZE_USER    (512)
 
 #define PBDRV_CONFIG_BUTTON                         (1)
 #define PBDRV_CONFIG_BUTTON_NXT                     (1)

--- a/lib/pbio/platform/nxt/pbsysconfig.h
+++ b/lib/pbio/platform/nxt/pbsysconfig.h
@@ -11,7 +11,7 @@
 #define PBSYS_CONFIG_MAIN                           (1)
 #define PBSYS_CONFIG_STORAGE                        (1)
 #define PBSYS_CONFIG_STORAGE_NUM_SLOTS              (1)
-#define PBSYS_CONFIG_STORAGE_USER_DATA_SIZE         (PBDRV_CONFIG_BLOCK_DEVICE_TEST_SIZE_USER)
+#define PBSYS_CONFIG_STORAGE_USER_DATA_SIZE         (512)
 #define PBSYS_CONFIG_STATUS_LIGHT                   (0)
 #define PBSYS_CONFIG_STATUS_LIGHT_BATTERY           (0)
 #define PBSYS_CONFIG_STATUS_LIGHT_BLUETOOTH         (0)

--- a/lib/pbio/sys/storage.c
+++ b/lib/pbio/sys/storage.c
@@ -23,60 +23,9 @@
 #include "hmi.h"
 
 /**
- * Information about one code slot.
- *
- * A size of 0 means that this slot is not used. The offset indicates where
- * the program is stored in user storage.
- *
- * Code slots are *not* stored chronologically by slot id. Instead they are
- * stored consecutively as they are received, with the newest program last.
- *
- * If a slot is already in use and a new program should be loaded into it,
- * it is deleted by mem-moving any subsequent programs into its place, and
- * appending the new program to be last again. Since a user is typically only
- * iterating code in one slot, this is therefore usually the last stored
- * program. This means memmoves happen very little, only when needed.
- *
- */
-typedef struct {
-    uint32_t offset;
-    uint32_t size;
-} pbsys_storage_slot_info_t;
-
-/**
  * Slot at which incoming program data is currently being received.
  */
 static uint8_t incoming_slot = 0;
-
-/**
- * Map of loaded data. All data types are little-endian.
- */
-typedef struct {
-    /**
-     * End-user read-write accessible data. Everything after this is also
-     * user-readable but not writable.
-     */
-    uint8_t user_data[PBSYS_CONFIG_STORAGE_USER_DATA_SIZE];
-    /**
-     * First 8 symbols of the git hash of the firmware version used to create
-     * this data map. If this does not match the version of the running
-     * firmware, user data will be reset to 0.
-     */
-    char stored_firmware_hash[8];
-    /**
-     * System settings. Settings will be reset to defaults when the firmware
-     * version changes due to an update.
-     */
-    pbsys_storage_settings_t settings;
-    /**
-     * Size and offset info for each slot.
-     */
-    pbsys_storage_slot_info_t slot_info[PBSYS_CONFIG_STORAGE_NUM_SLOTS];
-    /**
-     * Data of the application program (code + heap).
-     */
-    uint8_t program_data[] __attribute__((aligned(sizeof(void *))));
-} pbsys_storage_data_map_t;
 
 /**
  * Map of loaded data. This is kept in memory between successive runs of the
@@ -399,7 +348,7 @@ static pbio_error_t pbsys_storage_deinit_process_thread(pbio_os_state_t *state, 
  */
 void pbsys_storage_init(void) {
 
-    pbio_error_t err = pbdrv_block_device_get_data((uint8_t **)&map);
+    pbio_error_t err = pbdrv_block_device_get_data(&map);
 
     // Test that storage successfully loaded and matches current firmware,
     // otherwise reset storage.

--- a/lib/pbio/sys/storage_data.h
+++ b/lib/pbio/sys/storage_data.h
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 The Pybricks Authors
+
+// Data structures for non-volatile storage.
+
+// NB: Normally, pbsys code isn't referenced by drivers, however this is a
+// special case where the block device driver needs to have the actual struct
+// definition in order to ensure correct memory layout and alignment.
+
+#ifndef _PBSYS_SYS_STORAGE_DATA_H_
+#define _PBSYS_SYS_STORAGE_DATA_H_
+
+#include <stdint.h>
+
+#include <pbsys/config.h>
+#include <pbsys/storage_settings.h>
+
+/**
+ * Information about one code slot.
+ *
+ * A size of 0 means that this slot is not used. The offset indicates where
+ * the program is stored in user storage.
+ *
+ * Code slots are *not* stored chronologically by slot id. Instead they are
+ * stored consecutively as they are received, with the newest program last.
+ *
+ * If a slot is already in use and a new program should be loaded into it,
+ * it is deleted by mem-moving any subsequent programs into its place, and
+ * appending the new program to be last again. Since a user is typically only
+ * iterating code in one slot, this is therefore usually the last stored
+ * program. This means memmoves happen very little, only when needed.
+ *
+ */
+typedef struct {
+    uint32_t offset;
+    uint32_t size;
+} pbsys_storage_slot_info_t;
+
+/**
+ * Map of loaded data. All data types are little-endian.
+ */
+typedef struct {
+    /**
+     * End-user read-write accessible data. Everything after this is also
+     * user-readable but not writable.
+     */
+    uint8_t user_data[PBSYS_CONFIG_STORAGE_USER_DATA_SIZE];
+    /**
+     * First 8 symbols of the git hash of the firmware version used to create
+     * this data map. If this does not match the version of the running
+     * firmware, user data will be reset to 0.
+     */
+    char stored_firmware_hash[8];
+    /**
+     * System settings. Settings will be reset to defaults when the firmware
+     * version changes due to an update.
+     */
+    pbsys_storage_settings_t settings;
+    /**
+     * Size and offset info for each slot.
+     */
+    pbsys_storage_slot_info_t slot_info[PBSYS_CONFIG_STORAGE_NUM_SLOTS];
+    /**
+     * Data of the application program (code + heap).
+     */
+    uint8_t program_data[] __attribute__((aligned(sizeof(void *))));
+} pbsys_storage_data_map_t;
+
+#endif // _PBSYS_SYS_STORAGE_DATA_H_


### PR DESCRIPTION
Fix strict aliasing issues between block drivers and pbsys storage.

Casting a uint8_t* to a struct pointer violates strict aliasing rules, which can lead to hard-to-find bugs. We need to ensure that the memory being pointed to has the same alignment, etc. as the struct it is being cast to. The usual way to do this is to use a union of the struct and the other type we want to use (in this case, uint8_t array).

To do this, we need to move the storage data struct definition to a header file that can be included by both pbdrv/block_device and pbsys/storage.

Additionally, in block_device_test, the size of the ramdisk block was wrong and was causing the NXT to crash sometime after starting the REPL. It also incorrectly had the .noinit section attribute, but depends on being initialized to zero, so that is removed.

Fixes: https://github.com/pybricks/support/issues/2272
Fixes: ce4253aec ("pbio/sys: Move block device read to driver level.")