### PR TITLE
bricks/_common/arm_none_eabi.mk: Switch to C11 standard

### DIFF
--- a/bricks/_common/arm_none_eabi.mk
+++ b/bricks/_common/arm_none_eabi.mk
@@ -176,7 +176,7 @@ endif
 endif
 
 CFLAGS_WARN = -Wall -Werror -Wextra -Wno-unused-parameter -Wno-maybe-uninitialized
-CFLAGS = $(INC) -std=c99 -nostdlib -fshort-enums $(CFLAGS_MCU) $(CFLAGS_WARN) $(COPT) $(CFLAGS_EXTRA)
+CFLAGS = $(INC) -std=c11 -nostdlib -fshort-enums $(CFLAGS_MCU) $(CFLAGS_WARN) $(COPT) $(CFLAGS_EXTRA)
 $(BUILD)/lib/libm/%.o: CFLAGS += -Wno-sign-compare
 
 # linker scripts


### PR DESCRIPTION
This codebase already uses a number of C11 features. Enabling C11 globally will allow for UTF-16 string literals which are useful for USB.