### PR TITLE
EV3 USB fixes.

### DIFF
--- a/lib/pbio/drv/usb/usb_common_desc.c
+++ b/lib/pbio/drv/usb/usb_common_desc.c
@@ -8,6 +8,8 @@
 
 #if PBDRV_CONFIG_USB
 
+#include <pbio/version.h>
+
 #include "usb_common_desc.h"
 
 #if PBIO_VERSION_LEVEL_HEX == 0xA

--- a/lib/pbio/drv/usb/usb_ev3.c
+++ b/lib/pbio/drv/usb/usb_ev3.c
@@ -819,7 +819,7 @@ void pbdrv_usb_init(void) {
 
     // Power on and reset the controller
     PSCModuleControl(SOC_PSC_1_REGS, HW_PSC_USB0, PSC_POWERDOMAIN_ALWAYS_ON, PSC_MDCTL_NEXT_ENABLE);
-    USBReset(USB0_BASE);
+    USBReset(USB_0_OTGBASE);
 
     // Reset the PHY
     HWREG(CFGCHIP2_USBPHYCTRL) |= CFGCHIP2_RESET;

--- a/lib/pbio/drv/usb/usb_ev3.c
+++ b/lib/pbio/drv/usb/usb_ev3.c
@@ -813,13 +813,16 @@ static pbio_error_t pbdrv_usb_ev3_process_thread(pbio_os_state_t *state, void *c
 }
 
 void pbdrv_usb_init(void) {
+    // If we came straight from a firmware update, we need to send a disconnect
+    // to the host, then reset the USB controller.
+    USBDevDisconnect(USB0_BASE);
+
+    PSCModuleControl(SOC_PSC_1_REGS, HW_PSC_USB0, PSC_POWERDOMAIN_ALWAYS_ON, PSC_MDCTL_NEXT_SWRSTDISABLE);
+    PSCModuleControl(SOC_PSC_1_REGS, HW_PSC_USB0, PSC_POWERDOMAIN_ALWAYS_ON, PSC_MDCTL_NEXT_ENABLE);
+
     // This reset sequence is from Example 34-1 in the AM1808 TRM (spruh82c.pdf)
     // Because PHYs and clocking are... as they tend to be, use the precise sequence
     // of operations specified.
-
-    // Power on and reset the controller
-    PSCModuleControl(SOC_PSC_1_REGS, HW_PSC_USB0, PSC_POWERDOMAIN_ALWAYS_ON, PSC_MDCTL_NEXT_ENABLE);
-    USBReset(USB_0_OTGBASE);
 
     // Reset the PHY
     HWREG(CFGCHIP2_USBPHYCTRL) |= CFGCHIP2_RESET;

--- a/lib/pbio/include/pbio/version.h
+++ b/lib/pbio/include/pbio/version.h
@@ -14,16 +14,16 @@
 #include <pbio/util.h>
 
 /** The current major version. */
-#define PBIO_VERSION_MAJOR 3
+#define PBIO_VERSION_MAJOR 4
 
 /** The current minor version. */
-#define PBIO_VERSION_MINOR 6
+#define PBIO_VERSION_MINOR 0
 
 /** The current patch version. */
-#define PBIO_VERSION_MICRO 1
+#define PBIO_VERSION_MICRO 0
 
 /** The current prerelease level as a hex digit. */
-#define PBIO_VERSION_LEVEL_HEX 0xF
+#define PBIO_VERSION_LEVEL_HEX 0xA
 
 /** The current prerelease serial. */
 #define PBIO_VERSION_SERIAL 0

--- a/lib/tiam1808/drivers/usb.c
+++ b/lib/tiam1808/drivers/usb.c
@@ -3151,7 +3151,7 @@ void USBEnableOtgIntr(unsigned int ulBase)
 	unsigned int reg;
 
 	reg = HWREG(ulBase + USB_0_CTRL);
-	reg &= 0xFFFFFFF7;
+	reg &= ~USBOTG_CTRL_UINT;
 	HWREG(ulBase + USB_0_CTRL) = reg;
 
 	/* This API  enables the USB Interrupts through subsystem specific wrapper
@@ -3171,14 +3171,13 @@ void USBReset(unsigned int ulBase)
 	unsigned int reg;
 
 	reg = HWREG(ulBase + USB_0_CTRL);
-	reg |= 1;
+	reg |= USBOTG_CTRL_RESET;
 
 	/* Set the Reset Bit */
 	HWREG(ulBase + USB_0_CTRL) = reg;
 
 	/* Wait till Reset bit is cleared */
-	while(((HWREG(ulBase + USB_0_CTRL)) & 0x1 )== 1);
-
+	while(((HWREG(ulBase + USB_0_CTRL)) & USBOTG_CTRL_RESET) == USBOTG_CTRL_RESET);
 }
 
 void USBClearOtgIntr(unsigned int ulBase)


### PR DESCRIPTION
Fixing https://github.com/pybricks/support/issues/2295 plus bumping the firmware version so that the WebUSB descriptors point to `labs.pybricks.com` instead of `code.pybricks.com`.