### PR TITLE
[EV3] Fix more USB corner cases and minor bugs

### DIFF
--- a/lib/pbio/drv/usb/usb_ev3.c
+++ b/lib/pbio/drv/usb/usb_ev3.c
@@ -493,7 +493,7 @@ static void usb_device_intr(void) {
         pbdrv_usb_setup_data_to_send = 0;
         pbdrv_usb_addr_needs_setting = false;
 
-        if (HWREGH(USB0_BASE + USB_O_POWER) & USB_POWER_HSMODE) {
+        if (HWREGB(USB0_BASE + USB_O_POWER) & USB_POWER_HSMODE) {
             pbdrv_usb_is_usb_hs = true;
         } else {
             pbdrv_usb_is_usb_hs = false;

--- a/lib/pbio/drv/usb/usb_ev3.c
+++ b/lib/pbio/drv/usb/usb_ev3.c
@@ -634,11 +634,12 @@ static void usb_device_intr(void) {
 
                                 case CLEAR_FEATURE:
                                     if (setup_pkt.s.wValue == 0) {
+                                        // Clear the endpoint halt, which also resets the data toggle value
                                         if (setup_pkt.s.wIndex == 1) {
-                                            HWREGB(USB0_BASE + USB_O_RXCSRL1) &= ~USB_RXCSRL1_STALL;
+                                            HWREGB(USB0_BASE + USB_O_RXCSRL1) = (HWREGB(USB0_BASE + USB_O_RXCSRL1) & ~USB_RXCSRL1_STALL) | USB_RXCSRL1_CLRDT;
                                             handled = true;
                                         } else if (setup_pkt.s.wIndex == 0x81) {
-                                            HWREGB(USB0_BASE + USB_O_TXCSRL1) &= ~USB_TXCSRL1_STALL;
+                                            HWREGB(USB0_BASE + USB_O_TXCSRL1) = (HWREGB(USB0_BASE + USB_O_TXCSRL1) & ~USB_TXCSRL1_STALL) | USB_TXCSRL1_CLRDT;
                                             handled = true;
                                         }
                                     }


### PR DESCRIPTION
There is no guarantee that these events can only happen one at a time. If we happen to miss an event, it may cause the USB control transfer state machine to fall out of sync, which can cause enumeration failures.

This might fix https://github.com/pybricks/support/issues/2297

Note that the bulk of the diff is indentation changes.