### PR TITLE
[EV3] Four misc fixups

### DIFF
--- a/bricks/_common/micropython.c
+++ b/bricks/_common/micropython.c
@@ -240,7 +240,7 @@ static uint8_t *mpy_data_get_buf(mpy_info_t *info) {
 static mpy_info_t *mpy_data_find(qstr name) {
     const char *name_str = qstr_str(name);
 
-    for (mpy_info_t *info = mpy_first; info < mpy_end;
+    for (mpy_info_t *info = mpy_first; (uintptr_t)info + sizeof(uint32_t) < (uintptr_t)mpy_end;
          info = (mpy_info_t *)(mpy_data_get_buf(info) + pbio_get_uint32_le(info->mpy_size))) {
         if (strcmp(info->mpy_name, name_str) == 0) {
             return info;

--- a/bricks/_common/sources.mk
+++ b/bricks/_common/sources.mk
@@ -135,6 +135,7 @@ PBIO_SRC_C = $(addprefix lib/pbio/,\
 	drv/button/button_nxt.c \
 	drv/button/button_resistor_ladder.c \
 	drv/button/button_test.c \
+	drv/cache/cache_ev3.c \
 	drv/charger/charger_mp2639a.c \
 	drv/clock/clock_ev3.c \
 	drv/clock/clock_linux.c \

--- a/lib/pbio/drv/cache/cache_ev3.c
+++ b/lib/pbio/drv/cache/cache_ev3.c
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 The Pybricks Authors
+
+#include <pbdrv/config.h>
+
+#if PBDRV_CONFIG_CACHE_EV3
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <tiam1808/armv5/cp15.h>
+
+#include <pbdrv/compiler.h>
+
+void pbdrv_cache_prepare_before_dma(const void *buf, size_t sz) {
+    // Make sure all data is written by the compiler...
+    pbdrv_compiler_memory_barrier();
+    // and then make sure it's written out of the cache...
+    CP15DCacheCleanBuff((uint32_t)buf, sz);
+    // and also the write buffer, in case the cache missed.
+    CP15DrainWriteBuffer();
+}
+
+void pbdrv_cache_prepare_after_dma(const void *buf, size_t sz) {
+    // Invalidate stale data in the cache...
+    CP15DCacheFlushBuff((uint32_t)buf, sz);
+    // and then make sure _subsequent_ reads cannot be reordered earlier.
+    pbdrv_compiler_memory_barrier();
+}
+
+#endif // PBDRV_CONFIG_CACHE_EV3

--- a/lib/pbio/drv/sound/sound_ev3.c
+++ b/lib/pbio/drv/sound/sound_ev3.c
@@ -49,6 +49,11 @@ void pbdrv_beep_start(uint32_t frequency, uint16_t sample_attenuator) {
         return;
     }
 
+    // Turn speaker amplifier on
+    // We turn the amplifier on and leave it turned on, because otherwise
+    // it will generate a popping sound each time it is enabled.
+    pbdrv_gpio_out_high(&pin_sound_en);
+
     // Clamp the frequency into the supported range
     if (frequency < 64) {
         frequency = 64;
@@ -132,10 +137,6 @@ void pbdrv_sound_init() {
 
     // Configure IO pin mode
     pbdrv_gpio_alt(&pin_audio, SYSCFG_PINMUX3_PINMUX3_7_4_EPWM0B);
-    // Turn speaker amplifier on
-    // We turn the amplifier on and leave it turned on, because otherwise
-    // it will generate a popping sound whenever it is enabled.
-    pbdrv_gpio_out_high(&pin_sound_en);
 }
 
 #endif // PBDRV_CONFIG_SOUND_EV3

--- a/lib/pbio/include/pbdrv/cache.h
+++ b/lib/pbio/include/pbdrv/cache.h
@@ -3,6 +3,10 @@
 
 #ifndef _PBDRV_CACHE_H_
 
+#include <pbdrv/config.h>
+
+#if PBDRV_CONFIG_CACHE
+
 #include <stddef.h>
 
 // Gets data ready so that the data that we (the CPU) have written
@@ -15,15 +19,17 @@ void pbdrv_cache_prepare_before_dma(const void *buf, size_t sz);
 void pbdrv_cache_prepare_after_dma(const void *buf, size_t sz);
 
 // Accesses a variable via the uncached memory alias
-#define PBDRV_UNCACHED(x)           (*(volatile __typeof__(x) *)((uint32_t)(&(x)) + 0x10000000))
+#define PBDRV_UNCACHED(x)           (*(volatile __typeof__(x) *)((uintptr_t)(&(x)) + PBDRV_CONFIG_CACHE_UNCACHED_OFFSET))
 
 // Gets the address of the uncached memory alias of a variable
-#define PBDRV_UNCACHED_ADDR(x)      ((__typeof__(x) *)((uint32_t)(&(x)) + 0x10000000))
+#define PBDRV_UNCACHED_ADDR(x)      ((__typeof__(x) *)((uintptr_t)(&(x)) + PBDRV_CONFIG_CACHE_UNCACHED_OFFSET))
 
 // Cache line size
 #define PBDRV_CACHE_LINE_SZ         32
 
 // Align data to a cache line, which is needed for clean RX DMA
 #define PBDRV_DMA_BUF               __attribute__((aligned(PBDRV_CACHE_LINE_SZ), section(".dma")))
+
+#endif // PBDRV_CONFIG_CACHE
 
 #endif

--- a/lib/pbio/platform/ev3/pbdrvconfig.h
+++ b/lib/pbio/platform/ev3/pbdrvconfig.h
@@ -7,6 +7,18 @@
 #define PBDRV_CONFIG_ADC_EV3                        (1)
 #define PBDRV_CONFIG_ADC_EV3_ADC_NUM_CHANNELS       (16)
 
+#define PBDRV_CONFIG_CACHE                          (1)
+#define PBDRV_CONFIG_CACHE_EV3                      (1)
+// The EV3 MMU is configured to additionally map
+// VA 0xDxxxxxxx onto PA 0xCxxxxxxx, covering the DDR RAM region.
+// The 0xD alias is mapped as non-cacheable and non-bufferable
+// and can be used when data needs to be shared with bus-mastering
+// hardware peripherals. The 0xD region is unused in the physical
+// address map and lies at a convenient offset from the 0xC region.
+// The 0xC region, which is the region typically used to access RAM,
+// is cacheable and bufferable.
+#define PBDRV_CONFIG_CACHE_UNCACHED_OFFSET          (0x10000000)
+
 #define PBDRV_CONFIG_CLOCK                          (1)
 #define PBDRV_CONFIG_CLOCK_TIAM1808                 (1)
 

--- a/lib/pbio/platform/ev3/platform.ld
+++ b/lib/pbio/platform/ev3/platform.ld
@@ -60,7 +60,7 @@ SECTIONS
         *(.data.*)
     } > DDR
 
-    .bss :
+    .bss (NOLOAD) :
     {
         . = ALIGN(4);
         _bss_start = .;


### PR DESCRIPTION
* Enable EV3 speaker only upon first sound, as suggested [here](https://github.com/pybricks/support/issues/2155#issuecomment-3149603656)
* Rename EV3 caching macros, as suggested [here](https://github.com/pybricks/pybricks-micropython/pull/364#discussion_r2254707369)
* Fix MicroPython crash mentioned [here](https://github.com/pybricks/support/issues/2301)
* Mark `.dma` buffers as NOBITS