### PR TITLE
[EV3] Remove SUART code which we will not use

### DIFF
--- a/lib/pbio/drv/uart/uart_ev3_pru_lib/pru.c
+++ b/lib/pbio/drv/uart/uart_ev3_pru_lib/pru.c
@@ -129,19 +129,6 @@ uint32_t pru_disable(arm_pru_iomap *pru_arm_iomap) {
         hPru->CONTROL = CSL_PRUCORE_CONTROL_RESETVAL;
     }
 
-    // Disable PRU1
-    hPru = (CSL_PrucoreRegsOvly)((uint32_t)pru_arm_iomap->pru_io_addr + 0x7800);        // CSL_PRUCORE_1_REGS;
-    CSL_FINST(hPru->CONTROL, PRUCORE_CONTROL_COUNTENABLE, DISABLE);
-
-    for (delay_cnt = 0x10000; delay_cnt > 0; delay_cnt--) {
-        CSL_FINST(hPru->CONTROL, PRUCORE_CONTROL_ENABLE, DISABLE);
-    }
-
-    for (delay_cnt = 0x10000; delay_cnt > 0; delay_cnt--) {
-        // Reset PRU1
-        hPru->CONTROL = CSL_PRUCORE_CONTROL_RESETVAL;
-    }
-
     return E_PASS;
 }
 

--- a/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.c
+++ b/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.c
@@ -477,15 +477,8 @@ int16_t pru_softuart_setbaud
     /* channel starts from 0 and uart instance starts from 1 */
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
 
 
 
@@ -552,15 +545,8 @@ int16_t pru_softuart_setdatabits
     /* channel starts from 0 and uart instance starts from 1 */
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
 
 
     if (txDataBits != 0) {
@@ -632,15 +618,8 @@ int16_t pru_softuart_setconfig(suart_handle hUart, suart_config *configUart) {
     /* channel starts from 0 and uart instance starts from 1 */
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
 
     /* Configuring the Transmit part of the given UART */
     if (configUart->TXSerializer != PRU_SUART_SERIALIZER_NONE) {
@@ -755,15 +734,8 @@ int16_t pru_softuart_getTxDataLen(suart_handle hUart) {
     /* channel starts from 0 and uart instance starts from 1 */
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
 
     /* Transmit channel number is (UartNum * 2) - 2  */
 
@@ -795,15 +767,8 @@ int16_t pru_softuart_getRxDataLen(suart_handle hUart) {
     /* channel starts from 0 and uart instance starts from 1 */
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
 
     chNum++;
 
@@ -843,15 +808,8 @@ int16_t pru_softuart_getconfig(suart_handle hUart, suart_config *configUart) {
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
 
     /* Configuring the Transmit part of the given UART */
     /* Configuring TX serializer  */
@@ -944,17 +902,9 @@ int16_t pru_softuart_write
     /* channel starts from 0 and uart instance starts from 1 */
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        pru_num = hUart->uartNum;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-        pru_num = hUart->uartNum;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
+    pru_num = hUart->uartNum;
 
     /* Writing data length to SUART channel register */
     offset =
@@ -1010,17 +960,9 @@ int16_t pru_softuart_read
     /* channel starts from 0 and uart instance starts from 1 */
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        pru_num = hUart->uartNum;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-        pru_num = hUart->uartNum;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
+    pru_num = hUart->uartNum;
     chNum++;
 
     /* Writing data length to SUART channel register */
@@ -1088,15 +1030,8 @@ int16_t pru_softuart_read_data(
     /* channel starts from 0 and uart instance starts from 1 */
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     chNum++;
 
     /* Get the data pointer from channel RX data pointer */
@@ -1201,15 +1136,8 @@ int16_t pru_softuart_stopReceive(suart_handle hUart) {
     /* channel starts from 0 and uart instance starts from 1 */
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     chNum++;
 
     /* read the existing value of status flag */
@@ -1253,15 +1181,8 @@ int16_t pru_softuart_getTxStatus(suart_handle hUart) {
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
 
     offset =
         pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
@@ -1285,15 +1206,8 @@ int16_t pru_softuart_clrTxStatus(suart_handle hUart) {
     /* channel starts from 0 and uart instance starts from 1 */
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
 
     offset =
         pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
@@ -1322,15 +1236,8 @@ int16_t pru_softuart_getRxStatus(suart_handle hUart) {
     /* channel starts from 0 and uart instance starts from 1 */
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     chNum++;
 
     offset =
@@ -1359,15 +1266,8 @@ int16_t pru_softuart_clrRxFifo(suart_handle hUart) {
     /* channel starts from 0 and uart instance starts from 1 */
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     chNum++;
 
     /* Reset the number of bytes read into the FIFO */
@@ -1414,15 +1314,8 @@ int16_t pru_softuart_clrRxStatus(suart_handle hUart) {
     /* channel starts from 0 and uart instance starts from 1 */
     chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (hUart->uartNum <= 4) {
-        /* PRU0 */
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chNum -= 8;
-    }
+    /* PRU0 */
+    pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     chNum++;
 
     offset =
@@ -1503,15 +1396,8 @@ int32_t pru_intr_clr_isrstatus(uint16_t uartNum, uint32_t txrxmode) {
     /* channel starts from 0 and uart instance starts from 1 */
     chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-    if (uartNum <= 4) {
-        /* PRU0 */
-        offset = PRU_SUART_PRU0_ISR_OFFSET + 1;
-    } else {
-        /* PRU1 */
-        offset = PRU_SUART_PRU1_ISR_OFFSET + 1;
-        /* First 8 channel corresponds to PRU0 */
-        chnNum -= 8;
-    }
+    /* PRU0 */
+    offset = PRU_SUART_PRU0_ISR_OFFSET + 1;
 
     if (2 == txrxmode) {
         chnNum++;
@@ -1532,9 +1418,6 @@ int16_t suart_arm_to_pru_intr(uint16_t uartNum) {
     if ((uartNum > 0) && (uartNum <= 4)) {
         /* PRU0 SYS_EVT32 */
         u32value = 0x20;
-    } else if ((uartNum > 4) && (uartNum <= 8)) {
-        /* PRU1 SYS_EVT33 */
-        u32value = 0x21;
     } else {
         return SUART_INVALID_UART_NUM;
     }
@@ -1830,12 +1713,6 @@ int32_t suart_intr_setmask(uint16_t uartNum,
 
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
         offset = PRU_SUART_PRU0_IMR_OFFSET;
-    } else if ((uartNum > 4) && (uartNum <= 8)) {
-        /* PRU1 */
-        offset = PRU_SUART_PRU1_IMR_OFFSET;
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chnNum -= 8;
     } else {
         return SUART_INVALID_UART_NUM;
     }
@@ -1940,12 +1817,6 @@ int32_t suart_intr_clrmask(uint16_t uartNum,
 
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
         offset = PRU_SUART_PRU0_IMR_OFFSET;
-    } else if ((uartNum > 4) && (uartNum <= 8)) {
-        /* PRU1 */
-        offset = PRU_SUART_PRU1_IMR_OFFSET;
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chnNum -= 8;
     } else {
         return SUART_INVALID_UART_NUM;
     }
@@ -2042,11 +1913,6 @@ int32_t suart_intr_getmask(uint16_t uartNum,
     if ((uartNum > 0) && (uartNum <= 4)) {
 
         offset = PRU_SUART_PRU0_IMR_OFFSET;
-    } else if ((uartNum > 4) && (uartNum <= 8)) {
-        /* PRU1 */
-        offset = PRU_SUART_PRU1_IMR_OFFSET;
-        /* First 8 channel corresponds to PRU0 */
-        chnNum -= 8;
     } else {
         return SUART_INVALID_UART_NUM;
     }
@@ -2079,8 +1945,6 @@ static int32_t suart_set_pru_id(uint32_t pru_no) {
 
     if (0 == pru_no) {
         offset = PRU_SUART_PRU0_ID_ADDR;
-    } else if (1 == pru_no) {
-        offset = PRU_SUART_PRU1_ID_ADDR;
     } else {
         return PRU_SUART_FAILURE;
     }

--- a/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.c
+++ b/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.c
@@ -239,7 +239,6 @@ int16_t pru_softuart_init(uint32_t txBaudValue,
 
     omapl_addr = (uint32_t)arm_iomap_pru->pru_io_addr;
 
-//	for (u32loop = 0; u32loop < 512; u32loop++)
     for (u32loop = 0; u32loop < 512; u32loop += 4)   // Fixed the alignment fault -- ertl-liyixiao
     {
         *(uint32_t *)(omapl_addr | u32loop) = 0x0;
@@ -1556,18 +1555,7 @@ int16_t arm_to_pru_intr_init(void) {
     uint32_t u32value;
     uint32_t intOffset;
     int16_t s16retval = -1;
-    #if 0
-    /* Set the MCASP Event to PRU0 as Edge Triggered */
-    u32offset =
-        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_TYPE0 &
-            0xFFFF);
-    u32value = 0x80000000;
-    s16retval =
-        pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
-    if (s16retval == -1) {
-        return -1;
-    }
-    #endif
+
     /* Clear all the host interrupts */
     for (intOffset = 0; intOffset <= PRU_INTC_HOSTINTLVL_MAX; intOffset++)
     {

--- a/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.c
+++ b/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.c
@@ -232,8 +232,7 @@ int16_t pru_softuart_init(uint32_t txBaudValue,
 
     omapl_addr = (uint32_t)arm_iomap_pru->mcasp_io_addr;
     /* Configure McASP0  */
-    suart_mcasp_config(omapl_addr, txBaudValue, rxBaudValue, oversampling,
-        arm_iomap_pru);
+    suart_mcasp_config(omapl_addr, txBaudValue, rxBaudValue, oversampling, arm_iomap_pru);
 
     pru_enable(0, arm_iomap_pru);
 
@@ -244,8 +243,7 @@ int16_t pru_softuart_init(uint32_t txBaudValue,
         *(uint32_t *)(omapl_addr | u32loop) = 0x0;
     }
 
-    pru_load(PRU_NUM0, (uint32_t *)pru_suart_emu_code,
-        (fw_size / sizeof(uint32_t)), arm_iomap_pru);
+    pru_load(PRU_NUM0, (uint32_t *)pru_suart_emu_code, (fw_size / sizeof(uint32_t)), arm_iomap_pru);
 
     retval = arm_to_pru_intr_init();
     if (-1 == retval) {
@@ -270,7 +268,6 @@ int16_t pru_softuart_init(uint32_t txBaudValue,
 }
 
 static void pru_set_rx_tx_mode(uint32_t pru_mode, uint32_t pruNum) {
-
     uint32_t pruOffset;
 
     if (pruNum == PRU_NUM0) {
@@ -281,14 +278,12 @@ static void pru_set_rx_tx_mode(uint32_t pru_mode, uint32_t pruNum) {
     }
 
     pru_ram_write_data(pruOffset, (uint8_t *)&pru_mode, 1, &pru_arm_iomap);
-
 }
 
 
 void pru_set_fifo_timeout(uint32_t timeout) {
     /* PRU 0 */
-    pru_ram_write_data(PRU_SUART_PRU0_IDLE_TIMEOUT_OFFSET,
-        (uint8_t *)&timeout, 2, &pru_arm_iomap);
+    pru_ram_write_data(PRU_SUART_PRU0_IDLE_TIMEOUT_OFFSET, (uint8_t *)&timeout, 2, &pru_arm_iomap);
 }
 
 /* Not needed as PRU Soft Uart Firmware is implemented as Mcasp Event Based */
@@ -304,9 +299,7 @@ static void pru_set_delay_count(uint32_t pru_freq) {
     }
 
     /* PRU 0 */
-    pru_ram_write_data(PRU_SUART_PRU0_DELAY_OFFSET,
-        (uint8_t *)&u32delay_cnt, 1, &pru_arm_iomap);
-
+    pru_ram_write_data(PRU_SUART_PRU0_DELAY_OFFSET, (uint8_t *)&u32delay_cnt, 1, &pru_arm_iomap);
 }
 
 void pru_mcasp_deinit(void) {
@@ -487,12 +480,10 @@ int16_t pru_softuart_setbaud
         offset =
             pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG1_OFFSET;
-        pru_ram_read_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
         regval &= (~0x3FF);
         regval |= txClkDivisor;
-        pru_ram_write_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
     }
 
     chNum++;
@@ -502,12 +493,10 @@ int16_t pru_softuart_setbaud
         offset =
             pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG1_OFFSET;
-        pru_ram_read_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
         regval &= (~0x3FF);
         regval |= txClkDivisor;
-        pru_ram_write_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
     }
     return status;
 }
@@ -553,13 +542,11 @@ int16_t pru_softuart_setdatabits
         offset =
             pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG2_OFFSET;
-        pru_ram_read_data(offset, (uint8_t *)&reg_val, 1,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&reg_val, 1, &pru_arm_iomap);
 
         reg_val &= ~(0xF);
         reg_val |= txDataBits;
-        pru_ram_write_data(offset, (uint8_t *)&reg_val, 1,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&reg_val, 1, &pru_arm_iomap);
     }
 
     chNum++;
@@ -569,14 +556,12 @@ int16_t pru_softuart_setdatabits
             pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG2_OFFSET;
 
-        pru_ram_read_data(offset, (uint8_t *)&reg_val, 1,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&reg_val, 1, &pru_arm_iomap);
 
         reg_val &= ~(0xF);
         reg_val |= rxDataBits;
 
-        pru_ram_write_data(offset, (uint8_t *)&rxDataBits, 1,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&rxDataBits, 1, &pru_arm_iomap);
     }
 
     return status;
@@ -638,37 +623,29 @@ int16_t pru_softuart_setconfig(suart_handle hUart, suart_config *configUart) {
         offset =
             pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CTRL_OFFSET;
-        pru_ram_read_data(offset, (uint8_t *)&regVal, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regVal, 2, &pru_arm_iomap);
 
-        regVal = (configUart->TXSerializer <<
-                PRU_SUART_CH_CTRL_SR_SHIFT);
-
-        pru_ram_write_data(offset, (uint8_t *)&regVal, 2,
-            &pru_arm_iomap);
+        regVal = (configUart->TXSerializer << PRU_SUART_CH_CTRL_SR_SHIFT);
+        pru_ram_write_data(offset, (uint8_t *)&regVal, 2, &pru_arm_iomap);
         /* Configuring the Transmit part of the given UART */
         /* Configuring TX prescalar value */
         offset =
             pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG1_OFFSET;
-        pru_ram_read_data(offset, (uint8_t *)&regVal, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regVal, 2, &pru_arm_iomap);
         regVal =
             regVal | (configUart->txClkDivisor <<
                     PRU_SUART_CH_CONFIG1_DIVISOR_SHIFT);
-        pru_ram_write_data(offset, (uint8_t *)&regVal, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regVal, 2, &pru_arm_iomap);
         /* Configuring TX bits per character value */
         offset =
             pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG2_OFFSET;
-        pru_ram_read_data(offset, (uint8_t *)&regVal, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regVal, 2, &pru_arm_iomap);
         regVal =
             regVal | (configUart->txBitsPerChar <<
                     PRU_SUART_CH_CONFIG2_BITPERCHAR_SHIFT);
-        pru_ram_write_data(offset, (uint8_t *)&regVal, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regVal, 2, &pru_arm_iomap);
     }
 
     chNum++;
@@ -679,39 +656,32 @@ int16_t pru_softuart_setconfig(suart_handle hUart, suart_config *configUart) {
         offset =
             pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CTRL_OFFSET;
-        pru_ram_read_data(offset, (uint8_t *)&regVal, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regVal, 2, &pru_arm_iomap);
 
-        regVal = (configUart->RXSerializer <<
-                PRU_SUART_CH_CTRL_SR_SHIFT);
-        pru_ram_write_data(offset, (uint8_t *)&regVal, 2,
-            &pru_arm_iomap);
+        regVal = (configUart->RXSerializer << PRU_SUART_CH_CTRL_SR_SHIFT);
+        pru_ram_write_data(offset, (uint8_t *)&regVal, 2, &pru_arm_iomap);
 
         /* Configuring RX prescalar value and Oversampling */
         offset =
             pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG1_OFFSET;
-        pru_ram_read_data(offset, (uint8_t *)&regVal, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regVal, 2, &pru_arm_iomap);
         regVal =
             regVal | (configUart->rxClkDivisor <<
                     PRU_SUART_CH_CONFIG1_DIVISOR_SHIFT) |
             (configUart->Oversampling <<
                     PRU_SUART_CH_CONFIG1_OVS_SHIFT);
-        pru_ram_write_data(offset, (uint8_t *)&regVal, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regVal, 2, &pru_arm_iomap);
 
         /* Configuring RX bits per character value */
         offset =
             pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG2_OFFSET;
-        pru_ram_read_data(offset, (uint8_t *)&regVal, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regVal, 2, &pru_arm_iomap);
         regVal =
             regVal | (configUart->rxBitsPerChar <<
                     PRU_SUART_CH_CONFIG1_DIVISOR_SHIFT);
-        pru_ram_write_data(offset, (uint8_t *)&regVal, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regVal, 2, &pru_arm_iomap);
     }
     return status;
 }
@@ -1346,8 +1316,7 @@ int16_t pru_softuart_get_isrstatus(uint16_t uartNum, uint16_t *txrxFlag) {
     /* initialize the status & Flag to known value */
     *txrxFlag = 0;
 
-    u32StatInxClrRegoffset = (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_STATIDXCLR &
-        0xFFFF);
+    u32StatInxClrRegoffset = (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_STATIDXCLR & 0xFFFF);
 
     /* Read PRU Interrupt Status Register from PRU */
     u32IntcOffset =
@@ -1454,8 +1423,7 @@ int16_t arm_to_pru_intr_init(void) {
     }
 
     /* Enable the global interrupt */
-    u32offset = (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_GLBLEN &
-        0xFFFF);
+    u32offset = (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_GLBLEN & 0xFFFF);
     u32value = 0x1;
     s16retval = pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
     if (s16retval == -1) {
@@ -1465,8 +1433,7 @@ int16_t arm_to_pru_intr_init(void) {
     /* Enable the Host interrupts for all host channels */
     for (intOffset = 0; intOffset <= PRU_INTC_HOSTINTLVL_MAX; intOffset++)
     {
-        u32offset = (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_HSTINTENIDXSET &
-            0xFFFF);
+        u32offset = (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_HSTINTENIDXSET & 0xFFFF);
         u32value = intOffset;
         s16retval = pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
         if (s16retval == -1) {
@@ -1476,8 +1443,7 @@ int16_t arm_to_pru_intr_init(void) {
 
     /* host to channel mapping : Setting the host interrupt for channels 0,1,2,3 */
     u32offset =
-        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_HOSTMAP0 &
-            0xFFFF);
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_HOSTMAP0 & 0xFFFF);
     u32value = 0x03020100;
     s16retval =
         pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
@@ -1487,8 +1453,7 @@ int16_t arm_to_pru_intr_init(void) {
 
     /* host to channel mapping : Setting the host interrupt for channels 4,5,6,7 */
     u32offset =
-        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_HOSTMAP1 &
-            0xFFFF);
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_HOSTMAP1 & 0xFFFF);
     u32value = 0x07060504;
     s16retval =
         pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
@@ -1498,8 +1463,7 @@ int16_t arm_to_pru_intr_init(void) {
 
     /* host to channel mapping : Setting the host interrupt for channels 8,9 */
     u32offset =
-        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_HOSTMAP2 &
-            0xFFFF);
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_HOSTMAP2 & 0xFFFF);
     u32value = 0x00000908;
     s16retval =
         pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
@@ -1511,8 +1475,7 @@ int16_t arm_to_pru_intr_init(void) {
         * MAP Channel 0 to SYS_EVT31
         */
     u32offset =
-        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP7 &
-            0xFFFF);
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP7 & 0xFFFF);
     u32value = 0x0000000000;
     s16retval =
         pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
@@ -1527,8 +1490,7 @@ int16_t arm_to_pru_intr_init(void) {
     * MAP channel 2 to SYS_EVT35  SUART0-Rx
     */
     u32offset =
-        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP8 &
-            0xFFFF);
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP8 & 0xFFFF);
     u32value = 0x02020100;
     s16retval =
         pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
@@ -1537,14 +1499,13 @@ int16_t arm_to_pru_intr_init(void) {
     }
 
     /* Sets the channel for the system interrupt
-    * MAP channel 3 to SYS_EVT36	SUART1-Tx
+    * MAP channel 3 to SYS_EVT36    SUART1-Tx
     * MAP channel 3 to SYS_EVT37    SUART1-Rx
     * MAP channel 4 to SYS_EVT38    SUART2-Tx
     * MAP channel 4 to SYS_EVT39    SUART2-Rx
     */
     u32offset =
-        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP9 &
-            0xFFFF);
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP9 & 0xFFFF);
     u32value = 0x04040303;
     s16retval =
         pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
@@ -1553,14 +1514,13 @@ int16_t arm_to_pru_intr_init(void) {
     }
 
     /* Sets the channel for the system interrupt
-    * MAP channel 5 to SYS_EVT40	SUART3-Tx
+    * MAP channel 5 to SYS_EVT40    SUART3-Tx
     * MAP channel 5 to SYS_EVT41    SUART3-Rx
     * MAP channel 6 to SYS_EVT42    SUART4-Tx
     * MAP channel 6 to SYS_EVT43    SUART4-Rx
     */
     u32offset =
-        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP10 &
-            0xFFFF);
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP10 & 0xFFFF);
     u32value = 0x06060505;
     s16retval =
         pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
@@ -1569,14 +1529,13 @@ int16_t arm_to_pru_intr_init(void) {
     }
 
     /* Sets the channel for the system interrupt
-    * MAP channel 7 to SYS_EVT44	SUART5-Tx
+    * MAP channel 7 to SYS_EVT44    SUART5-Tx
     * MAP channel 7 to SYS_EVT45    SUART5-Rx
     * MAP channel 8 to SYS_EVT46    SUART6-Tx
     * MAP channel 8 to SYS_EVT47    SUART6-Rx
     */
     u32offset =
-        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP11 &
-            0xFFFF);
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP11 & 0xFFFF);
     u32value = 0x08080707;
     s16retval =
         pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
@@ -1585,13 +1544,12 @@ int16_t arm_to_pru_intr_init(void) {
     }
 
     /* Sets the channel for the system interrupt
-    * MAP channel 9 to SYS_EVT48	SUART7-Tx
+    * MAP channel 9 to SYS_EVT48    SUART7-Tx
     * MAP channel 9 to SYS_EVT49    SUART7-Rx
     * MAP Channel 1 to SYS_EVT50
     */
     u32offset =
-        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP12 &
-            0xFFFF);
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP12 & 0xFFFF);
     u32value = 0x00010909;
     s16retval =
         pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
@@ -1639,8 +1597,7 @@ int16_t arm_to_pru_intr_init(void) {
     }
 
     /* Enable the global interrupt */
-    u32offset = (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_GLBLEN &
-        0xFFFF);
+    u32offset = (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_GLBLEN & 0xFFFF);
     u32value = 0x1;
     s16retval = pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
     if (s16retval == -1) {
@@ -1650,8 +1607,7 @@ int16_t arm_to_pru_intr_init(void) {
     /* Enable the Host interrupts for all host channels */
     for (intOffset = 0; intOffset <= PRU_INTC_HOSTINTLVL_MAX; intOffset++)
     {
-        u32offset = (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_HSTINTENIDXSET &
-            0xFFFF);
+        u32offset = (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_HSTINTENIDXSET & 0xFFFF);
         u32value = intOffset;
         s16retval = pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
         if (s16retval == -1) {
@@ -1710,7 +1666,6 @@ int32_t suart_intr_setmask(uint16_t uartNum,
     chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
     if ((uartNum > 0) && (uartNum <= 4)) {
-
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
         offset = PRU_SUART_PRU0_IMR_OFFSET;
     } else {
@@ -1725,22 +1680,18 @@ int32_t suart_intr_setmask(uint16_t uartNum,
     regval = 1 << chnNum;
 
     if (CHN_TXRX_IE_MASK_CMPLT == (intrmask & CHN_TXRX_IE_MASK_CMPLT)) {
-        pru_ram_read_data(offset, (uint8_t *)&txrxFlag, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&txrxFlag, 2, &pru_arm_iomap);
         txrxFlag &= ~(regval);
         txrxFlag |= regval;
-        pru_ram_write_data(offset, (uint8_t *)&txrxFlag, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&txrxFlag, 2, &pru_arm_iomap);
     }
 
     if ((intrmask & SUART_GBL_INTR_ERR_MASK) == SUART_GBL_INTR_ERR_MASK) {
         regval = 0;
-        pru_ram_read_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
         regval &= ~(SUART_GBL_INTR_ERR_MASK);
         regval |= (SUART_GBL_INTR_ERR_MASK);
-        pru_ram_write_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
 
     }
     /* Break Indicator Interrupt Masked */
@@ -1749,12 +1700,10 @@ int32_t suart_intr_setmask(uint16_t uartNum,
         offset =
             pruOffset + (chnNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG1_OFFSET;
-        pru_ram_read_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
         regval &= ~(CHN_TXRX_IE_MASK_FE);
         regval |= CHN_TXRX_IE_MASK_FE;
-        pru_ram_write_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
     }
     /* Framing Error Interrupt Masked */
     if (CHN_TXRX_IE_MASK_BI == (intrmask & CHN_TXRX_IE_MASK_BI)) {
@@ -1763,12 +1712,10 @@ int32_t suart_intr_setmask(uint16_t uartNum,
             pruOffset + (chnNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG1_OFFSET;
 
-        pru_ram_read_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
         regval &= ~(CHN_TXRX_IE_MASK_BI);
         regval |= CHN_TXRX_IE_MASK_BI;
-        pru_ram_write_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
     }
     /* Timeout error Interrupt Masked */
     if (CHN_TXRX_IE_MASK_TIMEOUT == (intrmask & CHN_TXRX_IE_MASK_TIMEOUT)) {
@@ -1777,12 +1724,10 @@ int32_t suart_intr_setmask(uint16_t uartNum,
             pruOffset + (chnNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG1_OFFSET;
 
-        pru_ram_read_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
         regval &= ~(CHN_TXRX_IE_MASK_TIMEOUT);
         regval |= CHN_TXRX_IE_MASK_TIMEOUT;
-        pru_ram_write_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
     }
     /* Overrun error Interrupt Masked */
     if (CHN_RX_IE_MASK_OVRN == (intrmask & CHN_RX_IE_MASK_OVRN)) {
@@ -1791,12 +1736,10 @@ int32_t suart_intr_setmask(uint16_t uartNum,
             pruOffset + (chnNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG1_OFFSET;
 
-        pru_ram_read_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
         regval &= ~(CHN_RX_IE_MASK_OVRN);
         regval |= CHN_RX_IE_MASK_OVRN;
-        pru_ram_write_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
     }
     return 0;
 }
@@ -1814,7 +1757,6 @@ int32_t suart_intr_clrmask(uint16_t uartNum,
     chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
     if ((uartNum > 0) && (uartNum <= 4)) {
-
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
         offset = PRU_SUART_PRU0_IMR_OFFSET;
     } else {
@@ -1828,20 +1770,16 @@ int32_t suart_intr_clrmask(uint16_t uartNum,
     regval = 1 << chnNum;
 
     if (CHN_TXRX_IE_MASK_CMPLT == (intrmask & CHN_TXRX_IE_MASK_CMPLT)) {
-        pru_ram_read_data(offset, (uint8_t *)&txrxFlag, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&txrxFlag, 2, &pru_arm_iomap);
         txrxFlag &= ~(regval);
-        pru_ram_write_data(offset, (uint8_t *)&txrxFlag, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&txrxFlag, 2, &pru_arm_iomap);
     }
 
     if ((intrmask & SUART_GBL_INTR_ERR_MASK) == SUART_GBL_INTR_ERR_MASK) {
         regval = 0;
-        pru_ram_read_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
         regval &= ~(SUART_GBL_INTR_ERR_MASK);
-        pru_ram_write_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
 
     }
     /* Break Indicator Interrupt Masked */
@@ -1850,11 +1788,9 @@ int32_t suart_intr_clrmask(uint16_t uartNum,
         offset =
             pruOffset + (chnNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG1_OFFSET;
-        pru_ram_read_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
         regval &= ~(CHN_TXRX_IE_MASK_FE);
-        pru_ram_write_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
     }
     /* Framing Error Interrupt Masked */
     if (CHN_TXRX_IE_MASK_BI == (intrmask & CHN_TXRX_IE_MASK_BI)) {
@@ -1863,11 +1799,9 @@ int32_t suart_intr_clrmask(uint16_t uartNum,
             pruOffset + (chnNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG1_OFFSET;
 
-        pru_ram_read_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
         regval &= ~(CHN_TXRX_IE_MASK_BI);
-        pru_ram_write_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
     }
 
     /* Timeout error Interrupt Masked */
@@ -1877,11 +1811,9 @@ int32_t suart_intr_clrmask(uint16_t uartNum,
             pruOffset + (chnNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG1_OFFSET;
 
-        pru_ram_read_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
         regval &= ~(CHN_TXRX_IE_MASK_TIMEOUT);
-        pru_ram_write_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
     }
     /* Overrun error Interrupt Masked */
     if (CHN_RX_IE_MASK_OVRN == (intrmask & CHN_RX_IE_MASK_OVRN)) {
@@ -1890,11 +1822,9 @@ int32_t suart_intr_clrmask(uint16_t uartNum,
             pruOffset + (chnNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
             PRU_SUART_CH_CONFIG1_OFFSET;
 
-        pru_ram_read_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_read_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
         regval &= ~(CHN_RX_IE_MASK_OVRN);
-        pru_ram_write_data(offset, (uint8_t *)&regval, 2,
-            &pru_arm_iomap);
+        pru_ram_write_data(offset, (uint8_t *)&regval, 2, &pru_arm_iomap);
     }
     return 0;
 }
@@ -1911,7 +1841,6 @@ int32_t suart_intr_getmask(uint16_t uartNum,
     chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
     if ((uartNum > 0) && (uartNum <= 4)) {
-
         offset = PRU_SUART_PRU0_IMR_OFFSET;
     } else {
         return SUART_INVALID_UART_NUM;

--- a/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.c
+++ b/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.c
@@ -256,7 +256,7 @@ int16_t pru_softuart_init(uint32_t txBaudValue,
 
     suart_set_pru_id(0);
 
-    pru_set_rx_tx_mode(PRU0_MODE, PRU_NUM0);
+    pru_set_rx_tx_mode(PRU_MODE_RX_TX_BOTH, PRU_NUM0);
 
     pru_set_ram_data(arm_iomap_pru);
 
@@ -475,23 +475,17 @@ int16_t pru_softuart_setbaud
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-        }
-    } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
     }
 
 
@@ -509,13 +503,7 @@ int16_t pru_softuart_setbaud
             &pru_arm_iomap);
     }
 
-    if (PRU0_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        chNum++;
-    } else {
-        return PRU_MODE_INVALID;
-    }
+    chNum++;
 
     regval = 0;
     if (rxClkDivisor != 0) {
@@ -562,23 +550,17 @@ int16_t pru_softuart_setdatabits
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-        }
-    } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
     }
 
 
@@ -595,13 +577,7 @@ int16_t pru_softuart_setdatabits
             &pru_arm_iomap);
     }
 
-    if (PRU0_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        chNum++;
-    } else {
-        return PRU_MODE_INVALID;
-    }
+    chNum++;
 
     if (rxDataBits != 0) {
         offset =
@@ -654,24 +630,17 @@ int16_t pru_softuart_setconfig(suart_handle hUart, suart_config *configUart) {
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
-
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-        }
-    } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
     }
 
     /* Configuring the Transmit part of the given UART */
@@ -724,13 +693,7 @@ int16_t pru_softuart_setconfig(suart_handle hUart, suart_config *configUart) {
             &pru_arm_iomap);
     }
 
-    if (PRU0_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        chNum++;
-    } else {
-        return PRU_MODE_INVALID;
-    }
+    chNum++;
 
     /* Configuring the Transmit part of the given UART */
     if (configUart->RXSerializer != PRU_SUART_SERIALIZER_NONE) {
@@ -790,23 +753,17 @@ int16_t pru_softuart_getTxDataLen(suart_handle hUart) {
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-        }
-    } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
     }
 
     /* Transmit channel number is (UartNum * 2) - 2  */
@@ -836,26 +793,20 @@ int16_t pru_softuart_getRxDataLen(suart_handle hUart) {
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-        }
-
-        chNum++;
-    } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
     }
+
+    chNum++;
 
     offset =
         pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
@@ -889,24 +840,18 @@ int16_t pru_softuart_getconfig(suart_handle hUart, suart_config *configUart) {
      */
 
     chNum = hUart->uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
 
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-        }
-    } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
     }
 
     /* Configuring the Transmit part of the given UART */
@@ -937,13 +882,7 @@ int16_t pru_softuart_getconfig(suart_handle hUart, suart_config *configUart) {
         ((regVal & PRU_SUART_CH_CONFIG1_DIVISOR_MASK) >>
             PRU_SUART_CH_CONFIG1_DIVISOR_SHIFT);
 
-    if (PRU0_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        chNum++;
-    } else {
-        return PRU_MODE_INVALID;
-    }
+    chNum++;
 
     /* Configuring the Transmit part of the given UART */
     /* Configuring RX serializer  */
@@ -981,25 +920,6 @@ int16_t pru_softuart_getconfig(suart_handle hUart, suart_config *configUart) {
 
 
 int32_t pru_softuart_pending_tx_request(void) {
-    uint32_t offset = 0;
-    uint32_t u32ISRValue = 0;
-
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        return SUART_SUCCESS;
-    } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
-        /* Read PRU Interrupt Status Register from PRU */
-        offset =
-            (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_STATCLRINT1 &
-                0xFFFF);
-        pru_ram_read_data_4byte(offset, (uint32_t *)&u32ISRValue, 1);
-
-        if ((u32ISRValue & 0x1) == 0x1) {
-            return PRU_SUART_FAILURE;
-        }
-    } else {
-        return PRU_MODE_INVALID;
-    }
-
     return SUART_SUCCESS;
 }
 
@@ -1022,27 +942,19 @@ int16_t pru_softuart_write
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
-
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-            pru_num = hUart->uartNum;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-            pru_num = hUart->uartNum;
-        }
-    } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        pru_num = 0;
+        pru_num = hUart->uartNum;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
+        pru_num = hUart->uartNum;
     }
 
     /* Writing data length to SUART channel register */
@@ -1096,28 +1008,21 @@ int16_t pru_softuart_read
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-            pru_num = hUart->uartNum;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-            pru_num = hUart->uartNum;
-        }
-        chNum++;
-    } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        pru_num = 0;
+        pru_num = hUart->uartNum;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
+        pru_num = hUart->uartNum;
     }
+    chNum++;
 
     /* Writing data length to SUART channel register */
     offset =
@@ -1181,25 +1086,19 @@ int16_t pru_softuart_read_data(
     }
 
     chNum = hUart->uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-        }
-        chNum++;
-    } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
     }
+    chNum++;
 
     /* Get the data pointer from channel RX data pointer */
     offset =
@@ -1300,26 +1199,19 @@ int16_t pru_softuart_stopReceive(suart_handle hUart) {
     }
 
     chNum = hUart->uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
-
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-        }
-        chNum++;
-    } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
     }
+    chNum++;
 
     /* read the existing value of status flag */
     offset = pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
@@ -1358,24 +1250,18 @@ int16_t pru_softuart_getTxStatus(suart_handle hUart) {
     }
 
     chNum = hUart->uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
 
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-        }
-    } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
     }
 
     offset =
@@ -1397,24 +1283,17 @@ int16_t pru_softuart_clrTxStatus(suart_handle hUart) {
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
-
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-        }
-    } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
     }
 
     offset =
@@ -1441,25 +1320,19 @@ int16_t pru_softuart_getRxStatus(suart_handle hUart) {
     }
 
     chNum = hUart->uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-        }
-        chNum++;
-    } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
     }
+    chNum++;
 
     offset =
         pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
@@ -1484,27 +1357,19 @@ int16_t pru_softuart_clrRxFifo(suart_handle hUart) {
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
-
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-        }
-        chNum++;
-    } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        uartNum = 0;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
     }
+    chNum++;
 
     /* Reset the number of bytes read into the FIFO */
     offset = pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
@@ -1547,26 +1412,19 @@ int16_t pru_softuart_clrRxStatus(suart_handle hUart) {
     }
 
     chNum = hUart->uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
-
-        if (hUart->uartNum <= 4) {
-            /* PRU0 */
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-        } else {
-            /* PRU1 */
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chNum -= 8;
-        }
-        chNum++;
-    } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
+    if (hUart->uartNum <= 4) {
+        /* PRU0 */
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chNum -= 8;
     }
+    chNum++;
 
     offset =
         pruOffset + (chNum * SUART_NUM_OF_BYTES_PER_CHANNEL) +
@@ -1606,59 +1464,32 @@ int16_t pru_softuart_get_isrstatus(uint16_t uartNum, uint16_t *txrxFlag) {
 
     pru_ram_read_data_4byte(u32IntcOffset, (uint32_t *)&u32ISRValue, 1);
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chNum = uartNum * 2 - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chNum = uartNum * 2 - 2;
 
-        /* Check if the interrupt occured for Tx */
-        u32RegVal = PRU_SUART0_TX_EVT_BIT << ((uartNum - 1) * 2);
-        if (u32ISRValue & u32RegVal) {
-            /* interupt occured for TX */
-            *txrxFlag |= PRU_TX_INTR;
+    /* Check if the interrupt occured for Tx */
+    u32RegVal = PRU_SUART0_TX_EVT_BIT << ((uartNum - 1) * 2);
+    if (u32ISRValue & u32RegVal) {
+        /* interupt occured for TX */
+        *txrxFlag |= PRU_TX_INTR;
 
-            /* acknowledge the TX interrupt  */
-            u32AckRegVal = chNum + PRU_SUART0_TX_EVT;
-            pru_ram_write_data_4byte(u32StatInxClrRegoffset, (uint32_t *)&u32AckRegVal, 1);
+        /* acknowledge the TX interrupt  */
+        u32AckRegVal = chNum + PRU_SUART0_TX_EVT;
+        pru_ram_write_data_4byte(u32StatInxClrRegoffset, (uint32_t *)&u32AckRegVal, 1);
 
-        }
+    }
 
-        /* Check if the interrupt occured for Rx */
-        u32RegVal = PRU_SUART0_RX_EVT_BIT << ((uartNum - 1) * 2);
-        pru_ram_read_data_4byte(u32IntcOffset, (uint32_t *)&u32ISRValue, 1);
-        if (u32ISRValue & u32RegVal) {
-            /* interupt occured for RX */
-            *txrxFlag |= PRU_RX_INTR;
-            chNum += 1;
+    /* Check if the interrupt occured for Rx */
+    u32RegVal = PRU_SUART0_RX_EVT_BIT << ((uartNum - 1) * 2);
+    pru_ram_read_data_4byte(u32IntcOffset, (uint32_t *)&u32ISRValue, 1);
+    if (u32ISRValue & u32RegVal) {
+        /* interupt occured for RX */
+        *txrxFlag |= PRU_RX_INTR;
+        chNum += 1;
 
-            /* acknowledge the RX interrupt  */
-            u32AckRegVal = chNum + PRU_SUART0_TX_EVT;
-            pru_ram_write_data_4byte(u32StatInxClrRegoffset, (uint32_t *)&u32AckRegVal, 1);
-        }
-    } else {
-        chNum = uartNum - 1;
-        if ((u32ISRValue & 0x03FC) != 0) {
-            /* PRU0 */
-            u32RegVal = 1 << (uartNum + 1);
-            if (u32ISRValue & u32RegVal) {
-                /* acknowledge the interrupt  */
-                u32AckRegVal = chNum + PRU_SUART0_TX_EVT;
-                pru_ram_write_data_4byte(u32StatInxClrRegoffset, (uint32_t *)&u32AckRegVal, 1);
-                *txrxFlag |= PRU_RX_INTR;
-            }
-        }
-
-        pru_ram_read_data_4byte(u32IntcOffset, (uint32_t *)&u32ISRValue, 1);
-        if (u32ISRValue & 0x3FC00) {
-            /* PRU1 */
-            u32RegVal = 1 << (uartNum + 9);
-            if (u32ISRValue & u32RegVal) {
-                /* acknowledge the interrupt  */
-                u32AckRegVal = chNum + PRU_SUART4_TX_EVT;
-                pru_ram_write_data_4byte(u32StatInxClrRegoffset, (uint32_t *)&u32AckRegVal, 1);
-                *txrxFlag |= PRU_TX_INTR;
-            }
-        }
-
+        /* acknowledge the RX interrupt  */
+        u32AckRegVal = chNum + PRU_SUART0_TX_EVT;
+        pru_ram_write_data_4byte(u32StatInxClrRegoffset, (uint32_t *)&u32AckRegVal, 1);
     }
 
     return regVal;
@@ -1670,27 +1501,21 @@ int32_t pru_intr_clr_isrstatus(uint16_t uartNum, uint32_t txrxmode) {
     uint16_t chnNum;
 
     chnNum = uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        if (uartNum <= 4) {
-            /* PRU0 */
-            offset = PRU_SUART_PRU0_ISR_OFFSET + 1;
-        } else {
-            /* PRU1 */
-            offset = PRU_SUART_PRU1_ISR_OFFSET + 1;
-            /* First 8 channel corresponds to PRU0 */
-            chnNum -= 8;
-        }
-
-        if (2 == txrxmode) {
-            chnNum++;
-        }
-    } else if (PRU0_MODE == txrxmode) {
+    if (uartNum <= 4) {
+        /* PRU0 */
         offset = PRU_SUART_PRU0_ISR_OFFSET + 1;
     } else {
-        return PRU_MODE_INVALID;
+        /* PRU1 */
+        offset = PRU_SUART_PRU1_ISR_OFFSET + 1;
+        /* First 8 channel corresponds to PRU0 */
+        chnNum -= 8;
+    }
+
+    if (2 == txrxmode) {
+        chnNum++;
     }
 
     pru_ram_read_data(offset, (uint8_t *)&txrxFlag, 1, &pru_arm_iomap);
@@ -1705,29 +1530,14 @@ int16_t suart_arm_to_pru_intr(uint16_t uartNum) {
     uint32_t u32value;
     int16_t s16retval;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        if ((uartNum > 0) && (uartNum <= 4)) {
-            /* PRU0 SYS_EVT32 */
-            u32value = 0x20;
-        } else if ((uartNum > 4) && (uartNum <= 8)) {
-            /* PRU1 SYS_EVT33 */
-            u32value = 0x21;
-        } else {
-            return SUART_INVALID_UART_NUM;
-        }
-    }
-
-    if ((PRU0_MODE == PRU_MODE_RX_ONLY) ||
-        (PRU0_MODE == PRU_MODE_TX_ONLY)) {
-        if (uartNum == PRU_NUM0) {
-            /* PRU0 SYS_EVT32 */
-            u32value = 0x20;
-        }
-
-        if (uartNum == PRU_NUM1) {
-            /* PRU0 SYS_EVT33 */
-            u32value = 0x21;
-        }
+    if ((uartNum > 0) && (uartNum <= 4)) {
+        /* PRU0 SYS_EVT32 */
+        u32value = 0x20;
+    } else if ((uartNum > 4) && (uartNum <= 8)) {
+        /* PRU1 SYS_EVT33 */
+        u32value = 0x21;
+    } else {
+        return SUART_INVALID_UART_NUM;
     }
 
     u32offset =
@@ -1839,168 +1649,83 @@ int16_t arm_to_pru_intr_init(void) {
         return -1;
     }
 
-
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* Sets the channel for the system interrupt
-        * MAP channel 0 to SYS_EVT32
-        * MAP channel 1 to SYS_EVT33
-        * MAP channel 2 to SYS_EVT34  SUART0-Tx
-        * MAP channel 2 to SYS_EVT35  SUART0-Rx
-        */
-        u32offset =
-            (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP8 &
-                0xFFFF);
-        u32value = 0x02020100;
-        s16retval =
-            pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
-        if (-1 == s16retval) {
-            return -1;
-        }
-
-        /* Sets the channel for the system interrupt
-        * MAP channel 3 to SYS_EVT36	SUART1-Tx
-        * MAP channel 3 to SYS_EVT37    SUART1-Rx
-        * MAP channel 4 to SYS_EVT38    SUART2-Tx
-        * MAP channel 4 to SYS_EVT39    SUART2-Rx
-        */
-        u32offset =
-            (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP9 &
-                0xFFFF);
-        u32value = 0x04040303;
-        s16retval =
-            pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
-        if (-1 == s16retval) {
-            return -1;
-        }
-
-        /* Sets the channel for the system interrupt
-        * MAP channel 5 to SYS_EVT40	SUART3-Tx
-        * MAP channel 5 to SYS_EVT41    SUART3-Rx
-        * MAP channel 6 to SYS_EVT42    SUART4-Tx
-        * MAP channel 6 to SYS_EVT43    SUART4-Rx
-        */
-        u32offset =
-            (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP10 &
-                0xFFFF);
-        u32value = 0x06060505;
-        s16retval =
-            pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
-        if (-1 == s16retval) {
-            return -1;
-        }
-
-        /* Sets the channel for the system interrupt
-        * MAP channel 7 to SYS_EVT44	SUART5-Tx
-        * MAP channel 7 to SYS_EVT45    SUART5-Rx
-        * MAP channel 8 to SYS_EVT46    SUART6-Tx
-        * MAP channel 8 to SYS_EVT47    SUART6-Rx
-        */
-        u32offset =
-            (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP11 &
-                0xFFFF);
-        u32value = 0x08080707;
-        s16retval =
-            pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
-        if (-1 == s16retval) {
-            return -1;
-        }
-
-        /* Sets the channel for the system interrupt
-        * MAP channel 9 to SYS_EVT48	SUART7-Tx
-        * MAP channel 9 to SYS_EVT49    SUART7-Rx
-        * MAP Channel 1 to SYS_EVT50
-        */
-        u32offset =
-            (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP12 &
-                0xFFFF);
-        u32value = 0x00010909;
-        s16retval =
-            pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
-        if (-1 == s16retval) {
-            return -1;
-        }
+    /* Sets the channel for the system interrupt
+    * MAP channel 0 to SYS_EVT32
+    * MAP channel 1 to SYS_EVT33
+    * MAP channel 2 to SYS_EVT34  SUART0-Tx
+    * MAP channel 2 to SYS_EVT35  SUART0-Rx
+    */
+    u32offset =
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP8 &
+            0xFFFF);
+    u32value = 0x02020100;
+    s16retval =
+        pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
+    if (-1 == s16retval) {
+        return -1;
     }
 
-    if ((PRU0_MODE == PRU_MODE_RX_ONLY) ||
-        (PRU0_MODE == PRU_MODE_TX_ONLY)) {
-        /* Sets the channel for the system interrupt
-        * MAP channel 0 to SYS_EVT32
-        * MAP channel 1 to SYS_EVT33
-        * MAP channel 2 to SYS_EVT34  SUART0
-        * MAP channel 3 to SYS_EVT35  SUART1
-        */
-        u32offset =
-            (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP8 &
-                0xFFFF);
-        u32value = 0x03020100;
-        s16retval =
-            pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
-        if (-1 == s16retval) {
-            return -1;
-        }
+    /* Sets the channel for the system interrupt
+    * MAP channel 3 to SYS_EVT36	SUART1-Tx
+    * MAP channel 3 to SYS_EVT37    SUART1-Rx
+    * MAP channel 4 to SYS_EVT38    SUART2-Tx
+    * MAP channel 4 to SYS_EVT39    SUART2-Rx
+    */
+    u32offset =
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP9 &
+            0xFFFF);
+    u32value = 0x04040303;
+    s16retval =
+        pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
+    if (-1 == s16retval) {
+        return -1;
+    }
 
-        /* Sets the channel for the system interrupt
-        * MAP channel 4 to SYS_EVT36	SUART2
-        * MAP channel 5 to SYS_EVT37    SUART3
-        * MAP channel 6 to SYS_EVT38    SUART4
-        * MAP channel 7 to SYS_EVT39    SUART5
-        */
-        u32offset =
-            (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP9 &
-                0xFFFF);
-        u32value = 0x07060504;
-        s16retval =
-            pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
-        if (-1 == s16retval) {
-            return -1;
-        }
+    /* Sets the channel for the system interrupt
+    * MAP channel 5 to SYS_EVT40	SUART3-Tx
+    * MAP channel 5 to SYS_EVT41    SUART3-Rx
+    * MAP channel 6 to SYS_EVT42    SUART4-Tx
+    * MAP channel 6 to SYS_EVT43    SUART4-Rx
+    */
+    u32offset =
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP10 &
+            0xFFFF);
+    u32value = 0x06060505;
+    s16retval =
+        pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
+    if (-1 == s16retval) {
+        return -1;
+    }
 
-        /* Sets the channel for the system interrupt
-        * MAP channel 8 to SYS_EVT40	SUART6
-        * MAP channel 9 to SYS_EVT41    SUART7
-        * MAP channel 2 to SYS_EVT42    SUART0
-        * MAP channel 3 to SYS_EVT43    SUART1
-        */
-        u32offset =
-            (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP10 &
-                0xFFFF);
-        u32value = 0x03020908;
-        s16retval =
-            pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
-        if (-1 == s16retval) {
-            return -1;
-        }
+    /* Sets the channel for the system interrupt
+    * MAP channel 7 to SYS_EVT44	SUART5-Tx
+    * MAP channel 7 to SYS_EVT45    SUART5-Rx
+    * MAP channel 8 to SYS_EVT46    SUART6-Tx
+    * MAP channel 8 to SYS_EVT47    SUART6-Rx
+    */
+    u32offset =
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP11 &
+            0xFFFF);
+    u32value = 0x08080707;
+    s16retval =
+        pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
+    if (-1 == s16retval) {
+        return -1;
+    }
 
-        /* Sets the channel for the system interrupt
-        * MAP channel 4 to SYS_EVT44	SUART2
-        * MAP channel 5 to SYS_EVT45    SUART3
-        * MAP channel 6 to SYS_EVT46    SUART4
-        * MAP channel 7 to SYS_EVT47    SUART5
-        */
-        u32offset =
-            (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP11 &
-                0xFFFF);
-        u32value = 0x07060504;
-        s16retval =
-            pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
-        if (-1 == s16retval) {
-            return -1;
-        }
-
-        /* Sets the channel for the system interrupt
-        * MAP channel 8 to SYS_EVT48	SUART6
-        * MAP channel 9 to SYS_EVT49    SUART7
-        * MAP Channel 1 to SYS_EVT50    PRU to PRU Intr
-        */
-        u32offset =
-            (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP12 &
-                0xFFFF);
-        u32value = 0x00010908;
-        s16retval =
-            pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
-        if (-1 == s16retval) {
-            return -1;
-        }
+    /* Sets the channel for the system interrupt
+    * MAP channel 9 to SYS_EVT48	SUART7-Tx
+    * MAP channel 9 to SYS_EVT49    SUART7-Rx
+    * MAP Channel 1 to SYS_EVT50
+    */
+    u32offset =
+        (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_CHANMAP12 &
+            0xFFFF);
+    u32value = 0x00010909;
+    s16retval =
+        pru_ram_write_data_4byte(u32offset, (uint32_t *)&u32value, 1);
+    if (-1 == s16retval) {
+        return -1;
     }
 
     /* Clear required set of system events and enable them using indexed register */
@@ -2079,19 +1804,11 @@ int32_t suart_pru_to_host_intr_enable(uint16_t uartNum,
     }
 
     chnNum = uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        chnNum = (uartNum * 2) - 2;
-        if (2 == txrxmode) {            /* Rx mode */
-            chnNum++;
-        }
-        u32value = 34 + chnNum;
-    } else if ((PRU_MODE_RX_ONLY == txrxmode) && (PRU0_MODE == PRU_MODE_RX_ONLY)) {
-        u32value = 34 + chnNum;
-    } else if ((PRU_MODE_TX_ONLY == txrxmode) && (PRU0_MODE == PRU_MODE_TX_ONLY)) {
-        u32value = 34 + chnNum;
-    } else {
-        return -1;
+    chnNum = (uartNum * 2) - 2;
+    if (2 == txrxmode) {            /* Rx mode */
+        chnNum++;
     }
+    u32value = 34 + chnNum;
 
     if (true == s32Flag) {
         u32offset = (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_ENIDXSET & 0xFFFF);
@@ -2118,32 +1835,25 @@ int32_t suart_intr_setmask(uint16_t uartNum,
     uint32_t chnNum;
 
     chnNum = uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        if ((uartNum > 0) && (uartNum <= 4)) {
+    if ((uartNum > 0) && (uartNum <= 4)) {
 
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-            offset = PRU_SUART_PRU0_IMR_OFFSET;
-        } else if ((uartNum > 4) && (uartNum <= 8)) {
-            /* PRU1 */
-            offset = PRU_SUART_PRU1_IMR_OFFSET;
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chnNum -= 8;
-        } else {
-            return SUART_INVALID_UART_NUM;
-        }
-
-        if (2 == txrxmode) {            /* rx mode */
-            chnNum++;
-        }
-    } else if (PRU0_MODE == txrxmode) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
         offset = PRU_SUART_PRU0_IMR_OFFSET;
+    } else if ((uartNum > 4) && (uartNum <= 8)) {
+        /* PRU1 */
+        offset = PRU_SUART_PRU1_IMR_OFFSET;
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chnNum -= 8;
     } else {
-        return PRU_MODE_INVALID;
+        return SUART_INVALID_UART_NUM;
+    }
+
+    if (2 == txrxmode) {            /* rx mode */
+        chnNum++;
     }
 
 
@@ -2235,32 +1945,25 @@ int32_t suart_intr_clrmask(uint16_t uartNum,
     uint16_t chnNum;
 
     chnNum = uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        if ((uartNum > 0) && (uartNum <= 4)) {
+    if ((uartNum > 0) && (uartNum <= 4)) {
 
-            pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-            offset = PRU_SUART_PRU0_IMR_OFFSET;
-        } else if ((uartNum > 4) && (uartNum <= 8)) {
-            /* PRU1 */
-            offset = PRU_SUART_PRU1_IMR_OFFSET;
-            pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chnNum -= 8;
-        } else {
-            return SUART_INVALID_UART_NUM;
-        }
-
-        if (2 == txrxmode) {            /* rx mode */
-            chnNum++;
-        }
-    } else if (PRU0_MODE == txrxmode) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
         offset = PRU_SUART_PRU0_IMR_OFFSET;
+    } else if ((uartNum > 4) && (uartNum <= 8)) {
+        /* PRU1 */
+        offset = PRU_SUART_PRU1_IMR_OFFSET;
+        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chnNum -= 8;
     } else {
-        return PRU_MODE_INVALID;
+        return SUART_INVALID_UART_NUM;
+    }
+
+    if (2 == txrxmode) {            /* rx mode */
+        chnNum++;
     }
 
     regval = 1 << chnNum;
@@ -2345,29 +2048,23 @@ int32_t suart_intr_getmask(uint16_t uartNum,
     uint16_t regval = 1;
 
     chnNum = uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
-        /* channel starts from 0 and uart instance starts from 1 */
-        chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
+    /* channel starts from 0 and uart instance starts from 1 */
+    chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
-        if ((uartNum > 0) && (uartNum <= 4)) {
+    if ((uartNum > 0) && (uartNum <= 4)) {
 
-            offset = PRU_SUART_PRU0_IMR_OFFSET;
-        } else if ((uartNum > 4) && (uartNum <= 8)) {
-            /* PRU1 */
-            offset = PRU_SUART_PRU1_IMR_OFFSET;
-            /* First 8 channel corresponds to PRU0 */
-            chnNum -= 8;
-        } else {
-            return SUART_INVALID_UART_NUM;
-        }
-
-        if (2 == txrxmode) {            /* rx mode */
-            chnNum++;
-        }
-    } else if (PRU0_MODE == txrxmode) {
         offset = PRU_SUART_PRU0_IMR_OFFSET;
+    } else if ((uartNum > 4) && (uartNum <= 8)) {
+        /* PRU1 */
+        offset = PRU_SUART_PRU1_IMR_OFFSET;
+        /* First 8 channel corresponds to PRU0 */
+        chnNum -= 8;
     } else {
-        return PRU_MODE_INVALID;
+        return SUART_INVALID_UART_NUM;
+    }
+
+    if (2 == txrxmode) {            /* rx mode */
+        chnNum++;
     }
 
     regval = regval << chnNum;

--- a/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.c
+++ b/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.c
@@ -39,328 +39,6 @@ static int32_t suart_set_pru_id(uint32_t pru_no);
 static void pru_set_rx_tx_mode(uint32_t pru_mode, uint32_t pruNum);
 static void pru_set_delay_count(uint32_t pru_freq);
 
-#if (PRU_ACTIVE == BOTH_PRU)
-void pru_set_ram_data(arm_pru_iomap *arm_iomap_pru) {
-
-    PRU_SUART_RegsOvly pru_suart_regs = (PRU_SUART_RegsOvly)arm_iomap_pru->pru_io_addr;
-    uint32_t *pu32SrCtlAddr = (uint32_t *)((uint32_t)
-        arm_iomap_pru->mcasp_io_addr + 0x180);
-    pru_suart_tx_cntx_priv *pru_suart_tx_priv = NULL;
-    pru_suart_rx_cntx_priv *pru_suart_rx_priv = NULL;
-    uint8_t *pu32_pru_ram_base = (uint8_t *)arm_iomap_pru->pru_io_addr;
-
-    /* ***************************** RX PRU - 0  **************************************** */
-
-    /* Chanel 0 context information */
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_RX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART1_CONFIG_RX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART1_CONFIG_DUPLEX & PRU_SUART_HALF_RX_DISABLED) == PRU_SUART_HALF_RX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART1_CONFIG_RX_SER)) = MCASP_SRCTL_RX_MODE;
-    #endif
-    /* RX is active by default, write the dummy received data at PRU RAM addr 0x1FC to avoid memory corruption */
-    pru_suart_regs->CH_TXRXData = RX_DEFAULT_DATA_DUMP_ADDR;
-    pru_suart_regs->Reserved1 = 0;
-    pru_suart_rx_priv = (pru_suart_rx_cntx_priv *)(pu32_pru_ram_base + 0x090);  /* SUART1 RX context base addr */
-    pru_suart_rx_priv->asp_rbuf_base = (uint32_t)(MCASP_RBUF_BASE_ADDR + (PRU_SUART1_CONFIG_RX_SER << 2));
-    pru_suart_rx_priv->asp_rsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART1_CONFIG_RX_SER << 2));
-
-    /* Chanel 1 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_RX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART2_CONFIG_RX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART2_CONFIG_DUPLEX & PRU_SUART_HALF_RX_DISABLED) == PRU_SUART_HALF_RX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART2_CONFIG_RX_SER)) = MCASP_SRCTL_RX_MODE;
-    #endif
-    /* RX is active by default, write the dummy received data at PRU RAM addr 0x1FC to avoid memory corruption */
-    pru_suart_regs->CH_TXRXData = RX_DEFAULT_DATA_DUMP_ADDR;
-    pru_suart_regs->Reserved1 = 0;
-    pru_suart_rx_priv = (pru_suart_rx_cntx_priv *)(pu32_pru_ram_base + 0x0B0);  /* SUART2 RX context base addr */
-    pru_suart_rx_priv->asp_rbuf_base = (uint32_t)(MCASP_RBUF_BASE_ADDR + (PRU_SUART2_CONFIG_RX_SER << 2));
-    pru_suart_rx_priv->asp_rsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART2_CONFIG_RX_SER << 2));
-
-    /* Chanel 2 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_RX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART3_CONFIG_RX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART3_CONFIG_DUPLEX & PRU_SUART_HALF_RX_DISABLED) == PRU_SUART_HALF_RX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART3_CONFIG_RX_SER)) = MCASP_SRCTL_RX_MODE;
-    #endif
-    /* RX is active by default, write the dummy received data at PRU RAM addr 0x1FC to avoid memory corruption */
-    pru_suart_regs->CH_TXRXData = RX_DEFAULT_DATA_DUMP_ADDR;
-    pru_suart_regs->Reserved1 = 0;
-    pru_suart_rx_priv = (pru_suart_rx_cntx_priv *)(pu32_pru_ram_base + 0x0D0);  /* SUART3 RX context base addr */
-    pru_suart_rx_priv->asp_rbuf_base = (uint32_t)(MCASP_RBUF_BASE_ADDR + (PRU_SUART3_CONFIG_RX_SER << 2));
-    pru_suart_rx_priv->asp_rsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART3_CONFIG_RX_SER << 2));
-
-    /* Chanel 3 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_RX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART4_CONFIG_RX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART4_CONFIG_DUPLEX & PRU_SUART_HALF_RX_DISABLED) == PRU_SUART_HALF_RX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART4_CONFIG_RX_SER)) = MCASP_SRCTL_RX_MODE;
-    #endif
-    /* RX is active by default, write the dummy received data at PRU RAM addr 0x1FC to avoid memory corruption */
-    pru_suart_regs->CH_TXRXData = RX_DEFAULT_DATA_DUMP_ADDR;
-    pru_suart_regs->Reserved1 = 0;
-    pru_suart_rx_priv = (pru_suart_rx_cntx_priv *)(pu32_pru_ram_base + 0x0F0);  /* SUART4 RX context base addr */
-    pru_suart_rx_priv->asp_rbuf_base = (uint32_t)(MCASP_RBUF_BASE_ADDR + (PRU_SUART4_CONFIG_RX_SER << 2));
-    pru_suart_rx_priv->asp_rsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART4_CONFIG_RX_SER << 2));
-
-    /* Chanel 4 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_RX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART5_CONFIG_RX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART5_CONFIG_DUPLEX & PRU_SUART_HALF_RX_DISABLED) == PRU_SUART_HALF_RX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART5_CONFIG_RX_SER)) = MCASP_SRCTL_RX_MODE;
-    #endif
-    /* RX is active by default, write the dummy received data at PRU RAM addr 0x1FC to avoid memory corruption */
-    pru_suart_regs->CH_TXRXData = RX_DEFAULT_DATA_DUMP_ADDR;
-    pru_suart_regs->Reserved1 = 0;
-    pru_suart_rx_priv = (pru_suart_rx_cntx_priv *)(pu32_pru_ram_base + 0x110);  /* SUART5 RX context base addr */
-    pru_suart_rx_priv->asp_rbuf_base = (uint32_t)(MCASP_RBUF_BASE_ADDR + (PRU_SUART5_CONFIG_RX_SER << 2));
-    pru_suart_rx_priv->asp_rsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART5_CONFIG_RX_SER << 2));
-
-    /* Chanel 5 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_RX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART6_CONFIG_RX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART6_CONFIG_DUPLEX & PRU_SUART_HALF_RX_DISABLED) == PRU_SUART_HALF_RX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART6_CONFIG_RX_SER)) = MCASP_SRCTL_RX_MODE;
-    #endif
-    /* RX is active by default, write the dummy received data at PRU RAM addr 0x1FC to avoid memory corruption */
-    pru_suart_regs->CH_TXRXData = RX_DEFAULT_DATA_DUMP_ADDR;
-    pru_suart_regs->Reserved1 = 0;
-    pru_suart_rx_priv = (pru_suart_rx_cntx_priv *)(pu32_pru_ram_base + 0x130);  /* SUART6 RX context base addr */
-    pru_suart_rx_priv->asp_rbuf_base = (uint32_t)(MCASP_RBUF_BASE_ADDR + (PRU_SUART6_CONFIG_RX_SER << 2));
-    pru_suart_rx_priv->asp_rsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART6_CONFIG_RX_SER << 2));
-
-    /* Chanel 6 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_RX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART7_CONFIG_RX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART7_CONFIG_DUPLEX & PRU_SUART_HALF_RX_DISABLED) == PRU_SUART_HALF_RX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART7_CONFIG_RX_SER)) = MCASP_SRCTL_RX_MODE;
-    #endif
-    /* RX is active by default, write the dummy received data at PRU RAM addr 0x1FC to avoid memory corruption */
-    pru_suart_regs->CH_TXRXData = RX_DEFAULT_DATA_DUMP_ADDR;
-    pru_suart_regs->Reserved1 = 0;
-    pru_suart_rx_priv = (pru_suart_rx_cntx_priv *)(pu32_pru_ram_base + 0x150);  /* SUART7 RX context base addr */
-    pru_suart_rx_priv->asp_rbuf_base = (uint32_t)(MCASP_RBUF_BASE_ADDR + (PRU_SUART7_CONFIG_RX_SER << 2));
-    pru_suart_rx_priv->asp_rsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART7_CONFIG_RX_SER << 2));
-
-    /* Chanel 7 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_RX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART8_CONFIG_RX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART8_CONFIG_DUPLEX & PRU_SUART_HALF_RX_DISABLED) == PRU_SUART_HALF_RX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART8_CONFIG_RX_SER)) = MCASP_SRCTL_RX_MODE;
-    #endif
-    /* RX is active by default, write the dummy received data at PRU RAM addr 0x1FC to avoid memory corruption */
-    pru_suart_regs->CH_TXRXData = RX_DEFAULT_DATA_DUMP_ADDR;
-    pru_suart_regs->Reserved1 = 0;
-    pru_suart_rx_priv = (pru_suart_rx_cntx_priv *)(pu32_pru_ram_base + 0x170);  /* SUART8 RX context base addr */
-    pru_suart_rx_priv->asp_rbuf_base = (uint32_t)(MCASP_RBUF_BASE_ADDR + (PRU_SUART8_CONFIG_RX_SER << 2));
-    pru_suart_rx_priv->asp_rsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART8_CONFIG_RX_SER << 2));
-
-
-    /* ****************************** PRU1 RAM BASE ADDR ******************************** */
-    pru_suart_regs = (PRU_SUART_RegsOvly)((uint32_t)
-        arm_iomap_pru->pru_io_addr + 0x2000);
-    pu32_pru_ram_base = (uint8_t *)((uint32_t)
-        arm_iomap_pru->pru_io_addr + 0x2000);
-
-    /* ***************************** TX PRU - 1  **************************************** */
-    /* Channel 0 context information */
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_TX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART1_CONFIG_TX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART1_CONFIG_DUPLEX & PRU_SUART_HALF_TX_DISABLED) == PRU_SUART_HALF_TX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART1_CONFIG_TX_SER)) = MCASP_SRCTL_TX_MODE;
-    #endif
-    pru_suart_regs->Reserved1 = 1;
-
-    pru_suart_tx_priv = (pru_suart_tx_cntx_priv *)(pu32_pru_ram_base + 0x0B0);  /* SUART1 TX context base addr */
-    pru_suart_tx_priv->asp_xsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART1_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->asp_xbuf_base = (uint32_t)(MCASP_XBUF_BASE_ADDR + (PRU_SUART1_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->buff_addr = 0x0090; /* SUART1 TX formatted data base addr */
-
-    /* Channel 1 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_TX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART2_CONFIG_TX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART2_CONFIG_DUPLEX & PRU_SUART_HALF_TX_DISABLED) == PRU_SUART_HALF_TX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART2_CONFIG_TX_SER)) = MCASP_SRCTL_TX_MODE;
-    #endif
-    pru_suart_regs->Reserved1 = 1;
-
-    pru_suart_tx_priv = (pru_suart_tx_cntx_priv *)(pu32_pru_ram_base + 0x0DC);  /* SUART2 TX context base addr */
-    pru_suart_tx_priv->asp_xsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART2_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->asp_xbuf_base = (uint32_t)(MCASP_XBUF_BASE_ADDR + (PRU_SUART2_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->buff_addr = 0x00BC; /* SUART2 TX formatted data base addr */
-
-    /* Channel 2 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_TX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART3_CONFIG_TX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART3_CONFIG_DUPLEX & PRU_SUART_HALF_TX_DISABLED) == PRU_SUART_HALF_TX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART3_CONFIG_TX_SER)) = MCASP_SRCTL_TX_MODE;
-    #endif
-    pru_suart_regs->Reserved1 = 1;
-
-    pru_suart_tx_priv = (pru_suart_tx_cntx_priv *)(pu32_pru_ram_base + 0x108);  /* SUART3 TX context base addr */
-    pru_suart_tx_priv->asp_xsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART3_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->asp_xbuf_base = (uint32_t)(MCASP_XBUF_BASE_ADDR + (PRU_SUART3_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->buff_addr = 0x00E8; /* SUART3 TX formatted data base addr */
-
-    /* Channel 3 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_TX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART4_CONFIG_TX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART4_CONFIG_DUPLEX & PRU_SUART_HALF_TX_DISABLED) == PRU_SUART_HALF_TX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART4_CONFIG_TX_SER)) = MCASP_SRCTL_TX_MODE;
-    #endif
-    pru_suart_regs->Reserved1 = 1;
-
-    pru_suart_tx_priv = (pru_suart_tx_cntx_priv *)(pu32_pru_ram_base + 0x134);  /* SUART4 TX context base addr */
-    pru_suart_tx_priv->asp_xsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART4_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->asp_xbuf_base = (uint32_t)(MCASP_XBUF_BASE_ADDR + (PRU_SUART4_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->buff_addr = 0x0114; /* SUART4 TX formatted data base addr */
-
-    /* Channel 4 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_TX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART5_CONFIG_TX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART5_CONFIG_DUPLEX & PRU_SUART_HALF_TX_DISABLED) == PRU_SUART_HALF_TX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART5_CONFIG_TX_SER)) = MCASP_SRCTL_TX_MODE;
-    #endif
-    pru_suart_regs->Reserved1 = 1;
-
-    pru_suart_tx_priv = (pru_suart_tx_cntx_priv *)(pu32_pru_ram_base + 0x160);  /* SUART5 TX context base addr */
-    pru_suart_tx_priv->asp_xsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART5_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->asp_xbuf_base = (uint32_t)(MCASP_XBUF_BASE_ADDR + (PRU_SUART5_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->buff_addr = 0x0140; /* SUART5 TX formatted data base addr */
-
-    /* Channel 5 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_TX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART6_CONFIG_TX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART6_CONFIG_DUPLEX & PRU_SUART_HALF_TX_DISABLED) == PRU_SUART_HALF_TX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART6_CONFIG_TX_SER)) = MCASP_SRCTL_TX_MODE;
-    #endif
-    pru_suart_regs->Reserved1 = 1;
-
-    pru_suart_tx_priv = (pru_suart_tx_cntx_priv *)(pu32_pru_ram_base + 0x18C);  /* SUART6 TX context base addr */
-    pru_suart_tx_priv->asp_xsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART6_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->asp_xbuf_base = (uint32_t)(MCASP_XBUF_BASE_ADDR + (PRU_SUART6_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->buff_addr = 0x016C; /* SUART6 TX formatted data base addr */
-
-    /* Channel 6 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_TX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART7_CONFIG_TX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART7_CONFIG_DUPLEX & PRU_SUART_HALF_TX_DISABLED) == PRU_SUART_HALF_TX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART7_CONFIG_TX_SER)) = MCASP_SRCTL_TX_MODE;
-    #endif
-    pru_suart_regs->Reserved1 = 1;
-
-    pru_suart_tx_priv = (pru_suart_tx_cntx_priv *)(pu32_pru_ram_base + 0x1B8);  /* SUART7 TX context base addr */
-    pru_suart_tx_priv->asp_xsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART7_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->asp_xbuf_base = (uint32_t)(MCASP_XBUF_BASE_ADDR + (PRU_SUART7_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->buff_addr = 0x0198; /* SUART7 TX formatted data base addr */
-
-    /* Channel 7 context information */
-    pru_suart_regs++;
-    pru_suart_regs->CH_Ctrl_Config1.mode = SUART_CHN_TX;
-    pru_suart_regs->CH_Ctrl_Config1.serializer_num = (0xF & PRU_SUART8_CONFIG_TX_SER);
-    pru_suart_regs->CH_Ctrl_Config1.over_sampling = SUART_DEFAULT_OVRSMPL;
-    pru_suart_regs->CH_Config2_TXRXStatus.bits_per_char = 8;
-    #if ((PRU_SUART8_CONFIG_DUPLEX & PRU_SUART_HALF_TX_DISABLED) == PRU_SUART_HALF_TX_DISABLED)
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_DISABLED;
-    #else
-    pru_suart_regs->CH_Config2_TXRXStatus.chn_state = SUART_CHN_ENABLED;
-    *((uint32_t *)(pu32SrCtlAddr + PRU_SUART8_CONFIG_TX_SER)) = MCASP_SRCTL_TX_MODE;
-    #endif
-    pru_suart_regs->Reserved1 = 1;
-    pru_suart_tx_priv = (pru_suart_tx_cntx_priv *)(pu32_pru_ram_base + 0x1E4);  /* SUART8 TX context base addr */
-    pru_suart_tx_priv->asp_xsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART8_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->asp_xbuf_base = (uint32_t)(MCASP_XBUF_BASE_ADDR + (PRU_SUART8_CONFIG_TX_SER << 2));
-    pru_suart_tx_priv->buff_addr = 0x01C4; /* SUART8  TX formatted data base addr */
-}
-#else
 void pru_set_ram_data(arm_pru_iomap *arm_iomap_pru) {
 
     PRU_SUART_RegsOvly pru_suart_regs = (PRU_SUART_RegsOvly)arm_iomap_pru->pru_io_addr;
@@ -524,8 +202,6 @@ void pru_set_ram_data(arm_pru_iomap *arm_iomap_pru) {
     pru_suart_rx_priv->asp_rsrctl_base = (uint32_t)(MCASP_SRCTL_BASE_ADDR + (PRU_SUART4_CONFIG_RX_SER << 2));
 }
 
-#endif
-
 /*
  * suart Initialization routine
  */
@@ -539,10 +215,6 @@ int16_t pru_softuart_init(uint32_t txBaudValue,
     int16_t status = PRU_SUART_SUCCESS;
     int16_t idx;
     int16_t retval;
-
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) && (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
-        return PRU_SUART_FAILURE;
-    }
 
     pru_arm_iomap.pru_io_addr = arm_iomap_pru->pru_io_addr;
     pru_arm_iomap.mcasp_io_addr = arm_iomap_pru->mcasp_io_addr;
@@ -564,9 +236,6 @@ int16_t pru_softuart_init(uint32_t txBaudValue,
         arm_iomap_pru);
 
     pru_enable(0, arm_iomap_pru);
-    #if (!(PRU1_MODE == PRU_MODE_INVALID))
-    pru_enable(1, arm_iomap_pru);
-    #endif
 
     omapl_addr = (uint32_t)arm_iomap_pru->pru_io_addr;
 
@@ -574,17 +243,10 @@ int16_t pru_softuart_init(uint32_t txBaudValue,
     for (u32loop = 0; u32loop < 512; u32loop += 4)   // Fixed the alignment fault -- ertl-liyixiao
     {
         *(uint32_t *)(omapl_addr | u32loop) = 0x0;
-        #if (!(PRU1_MODE == PRU_MODE_INVALID))
-        *(uint32_t *)(omapl_addr | u32loop | 0x2000) = 0x0;
-        #endif
     }
 
     pru_load(PRU_NUM0, (uint32_t *)pru_suart_emu_code,
         (fw_size / sizeof(uint32_t)), arm_iomap_pru);
-    #if (!(PRU1_MODE == PRU_MODE_INVALID))
-    pru_load(PRU_NUM1, (uint32_t *)pru_suart_emu_code,
-        (fw_size / sizeof(uint32_t)), arm_iomap_pru);
-    #endif
 
     retval = arm_to_pru_intr_init();
     if (-1 == retval) {
@@ -594,21 +256,11 @@ int16_t pru_softuart_init(uint32_t txBaudValue,
 
     suart_set_pru_id(0);
 
-    #if (!(PRU1_MODE == PRU_MODE_INVALID))
-    suart_set_pru_id(1);
-    #endif
-
     pru_set_rx_tx_mode(PRU0_MODE, PRU_NUM0);
-    #if (!(PRU1_MODE == PRU_MODE_INVALID))
-    pru_set_rx_tx_mode(PRU1_MODE, PRU_NUM1);
-    #endif
 
     pru_set_ram_data(arm_iomap_pru);
 
     pru_run(PRU_NUM0, arm_iomap_pru);
-    #if (!(PRU1_MODE == PRU_MODE_INVALID))
-    pru_run(PRU_NUM1, arm_iomap_pru);
-    #endif
 
     /* Initialize gUartStatuTable */
     for (idx = 0; idx < 8; idx++) {
@@ -625,9 +277,6 @@ static void pru_set_rx_tx_mode(uint32_t pru_mode, uint32_t pruNum) {
     if (pruNum == PRU_NUM0) {
         /* PRU0 */
         pruOffset = PRU_SUART_PRU0_RX_TX_MODE;
-    } else if (pruNum == PRU_NUM1) {
-        /* PRU1 */
-        pruOffset = PRU_SUART_PRU1_RX_TX_MODE;
     } else {
         return;
     }
@@ -641,11 +290,6 @@ void pru_set_fifo_timeout(uint32_t timeout) {
     /* PRU 0 */
     pru_ram_write_data(PRU_SUART_PRU0_IDLE_TIMEOUT_OFFSET,
         (uint8_t *)&timeout, 2, &pru_arm_iomap);
-    #if (!(PRU1_MODE == PRU_MODE_INVALID))
-    /* PRU 1 */
-    pru_ram_write_data(PRU_SUART_PRU1_IDLE_TIMEOUT_OFFSET,
-        (uint8_t *)&timeout, 2, &pru_arm_iomap);
-    #endif
 }
 
 /* Not needed as PRU Soft Uart Firmware is implemented as Mcasp Event Based */
@@ -663,11 +307,6 @@ static void pru_set_delay_count(uint32_t pru_freq) {
     /* PRU 0 */
     pru_ram_write_data(PRU_SUART_PRU0_DELAY_OFFSET,
         (uint8_t *)&u32delay_cnt, 1, &pru_arm_iomap);
-    #if (!(PRU1_MODE == PRU_MODE_INVALID))
-    /* PRU 1 */
-    pru_ram_write_data(PRU_SUART_PRU1_DELAY_OFFSET,
-        (uint8_t *)&u32delay_cnt, 1, &pru_arm_iomap);
-    #endif
 
 }
 
@@ -782,72 +421,6 @@ int16_t pru_softuart_open(suart_handle hSuart) {
             }
             break;
 
-        /* ************ PRU 1 ************** */
-        case PRU_SUART_UART5:
-            if (gUartStatuTable[PRU_SUART_UART5 - 1] ==
-                ePRU_SUART_UART_IN_USE) {
-                status = SUART_UART_IN_USE;
-                return status;
-            } else {
-                hSuart->uartStatus = ePRU_SUART_UART_IN_USE;
-                hSuart->uartType = PRU_SUART5_CONFIG_DUPLEX;
-                hSuart->uartTxChannel = PRU_SUART5_CONFIG_TX_SER;
-                hSuart->uartRxChannel = PRU_SUART5_CONFIG_RX_SER;
-
-                gUartStatuTable[PRU_SUART_UART5 - 1] =
-                    ePRU_SUART_UART_IN_USE;
-            }
-            break;
-
-        case PRU_SUART_UART6:
-            if (gUartStatuTable[PRU_SUART_UART6 - 1] ==
-                ePRU_SUART_UART_IN_USE) {
-                status = SUART_UART_IN_USE;
-                return status;
-            } else {
-                hSuart->uartStatus = ePRU_SUART_UART_IN_USE;
-                hSuart->uartType = PRU_SUART6_CONFIG_DUPLEX;
-                hSuart->uartTxChannel = PRU_SUART6_CONFIG_TX_SER;
-                hSuart->uartRxChannel = PRU_SUART6_CONFIG_RX_SER;
-
-                gUartStatuTable[PRU_SUART_UART6 - 1] =
-                    ePRU_SUART_UART_IN_USE;
-            }
-
-            break;
-
-        case PRU_SUART_UART7:
-            if (gUartStatuTable[PRU_SUART_UART7 - 1] ==
-                ePRU_SUART_UART_IN_USE) {
-                status = SUART_UART_IN_USE;
-                return status;
-            } else {
-                hSuart->uartStatus = ePRU_SUART_UART_IN_USE;
-                hSuart->uartType = PRU_SUART7_CONFIG_DUPLEX;
-                hSuart->uartTxChannel = PRU_SUART7_CONFIG_TX_SER;
-                hSuart->uartRxChannel = PRU_SUART7_CONFIG_RX_SER;
-
-                gUartStatuTable[PRU_SUART_UART7 - 1] =
-                    ePRU_SUART_UART_IN_USE;
-            }
-            break;
-
-        case PRU_SUART_UART8:
-            if (gUartStatuTable[PRU_SUART_UART8 - 1] ==
-                ePRU_SUART_UART_IN_USE) {
-                status = SUART_UART_IN_USE;
-                return status;
-            } else {
-                hSuart->uartStatus = ePRU_SUART_UART_IN_USE;
-                hSuart->uartType = PRU_SUART8_CONFIG_DUPLEX;
-                hSuart->uartTxChannel = PRU_SUART8_CONFIG_TX_SER;
-                hSuart->uartRxChannel = PRU_SUART8_CONFIG_RX_SER;
-
-                gUartStatuTable[PRU_SUART_UART8 - 1] =
-                    ePRU_SUART_UART_IN_USE;
-            }
-            break;
-
         default:
             /* return invalid UART */
             status = SUART_INVALID_UART_NUM;
@@ -902,7 +475,7 @@ int16_t pru_softuart_setbaud
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
@@ -917,8 +490,6 @@ int16_t pru_softuart_setbaud
         }
     } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_TX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -940,9 +511,7 @@ int16_t pru_softuart_setbaud
 
     if (PRU0_MODE == PRU_MODE_RX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-    } else if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    } else if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         chNum++;
     } else {
         return PRU_MODE_INVALID;
@@ -993,7 +562,7 @@ int16_t pru_softuart_setdatabits
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
@@ -1008,8 +577,6 @@ int16_t pru_softuart_setdatabits
         }
     } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_TX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -1030,9 +597,7 @@ int16_t pru_softuart_setdatabits
 
     if (PRU0_MODE == PRU_MODE_RX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-    } else if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    } else if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         chNum++;
     } else {
         return PRU_MODE_INVALID;
@@ -1089,7 +654,7 @@ int16_t pru_softuart_setconfig(suart_handle hUart, suart_config *configUart) {
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
 
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
@@ -1105,8 +670,6 @@ int16_t pru_softuart_setconfig(suart_handle hUart, suart_config *configUart) {
         }
     } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_TX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -1163,9 +726,7 @@ int16_t pru_softuart_setconfig(suart_handle hUart, suart_config *configUart) {
 
     if (PRU0_MODE == PRU_MODE_RX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-    } else if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    } else if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         chNum++;
     } else {
         return PRU_MODE_INVALID;
@@ -1229,7 +790,7 @@ int16_t pru_softuart_getTxDataLen(suart_handle hUart) {
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
@@ -1244,8 +805,6 @@ int16_t pru_softuart_getTxDataLen(suart_handle hUart) {
         }
     } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_TX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -1277,7 +836,7 @@ int16_t pru_softuart_getRxDataLen(suart_handle hUart) {
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
@@ -1294,8 +853,6 @@ int16_t pru_softuart_getRxDataLen(suart_handle hUart) {
         chNum++;
     } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -1332,7 +889,7 @@ int16_t pru_softuart_getconfig(suart_handle hUart, suart_config *configUart) {
      */
 
     chNum = hUart->uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
@@ -1348,8 +905,6 @@ int16_t pru_softuart_getconfig(suart_handle hUart, suart_config *configUart) {
         }
     } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_TX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -1384,9 +939,7 @@ int16_t pru_softuart_getconfig(suart_handle hUart, suart_config *configUart) {
 
     if (PRU0_MODE == PRU_MODE_RX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-    } else if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    } else if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         chNum++;
     } else {
         return PRU_MODE_INVALID;
@@ -1431,7 +984,7 @@ int32_t pru_softuart_pending_tx_request(void) {
     uint32_t offset = 0;
     uint32_t u32ISRValue = 0;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         return SUART_SUCCESS;
     } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
         /* Read PRU Interrupt Status Register from PRU */
@@ -1441,16 +994,6 @@ int32_t pru_softuart_pending_tx_request(void) {
         pru_ram_read_data_4byte(offset, (uint32_t *)&u32ISRValue, 1);
 
         if ((u32ISRValue & 0x1) == 0x1) {
-            return PRU_SUART_FAILURE;
-        }
-    } else if (PRU1_MODE == PRU_MODE_TX_ONLY) {
-        /* Read PRU Interrupt Status Register from PRU */
-        offset =
-            (uint32_t)pru_arm_iomap.pru_io_addr | (PRU_INTC_STATCLRINT1 &
-                0xFFFF);
-        pru_ram_read_data_4byte(offset, (uint32_t *)&u32ISRValue, 1);
-
-        if ((u32ISRValue & 0x2) == 0x2) {
             return PRU_SUART_FAILURE;
         }
     } else {
@@ -1479,7 +1022,7 @@ int16_t pru_softuart_write
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
 
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
@@ -1498,9 +1041,6 @@ int16_t pru_softuart_write
     } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
         pru_num = 0;
-    } else if (PRU1_MODE == PRU_MODE_TX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        pru_num = 1;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -1556,7 +1096,7 @@ int16_t pru_softuart_read
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
@@ -1575,9 +1115,6 @@ int16_t pru_softuart_read
     } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
         pru_num = 0;
-    } else if (PRU1_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        pru_num = 1;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -1644,7 +1181,7 @@ int16_t pru_softuart_read_data(
     }
 
     chNum = hUart->uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
@@ -1660,8 +1197,6 @@ int16_t pru_softuart_read_data(
         chNum++;
     } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -1765,7 +1300,7 @@ int16_t pru_softuart_stopReceive(suart_handle hUart) {
     }
 
     chNum = hUart->uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
 
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
@@ -1782,8 +1317,6 @@ int16_t pru_softuart_stopReceive(suart_handle hUart) {
         chNum++;
     } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -1825,7 +1358,7 @@ int16_t pru_softuart_getTxStatus(suart_handle hUart) {
     }
 
     chNum = hUart->uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
@@ -1841,8 +1374,6 @@ int16_t pru_softuart_getTxStatus(suart_handle hUart) {
         }
     } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_TX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -1866,7 +1397,7 @@ int16_t pru_softuart_clrTxStatus(suart_handle hUart) {
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
 
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
@@ -1882,8 +1413,6 @@ int16_t pru_softuart_clrTxStatus(suart_handle hUart) {
         }
     } else if (PRU0_MODE == PRU_MODE_TX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_TX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -1912,7 +1441,7 @@ int16_t pru_softuart_getRxStatus(suart_handle hUart) {
     }
 
     chNum = hUart->uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
@@ -1928,8 +1457,6 @@ int16_t pru_softuart_getRxStatus(suart_handle hUart) {
         chNum++;
     } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -1957,7 +1484,7 @@ int16_t pru_softuart_clrRxFifo(suart_handle hUart) {
 
     chNum = hUart->uartNum - 1;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
 
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
@@ -1975,9 +1502,6 @@ int16_t pru_softuart_clrRxFifo(suart_handle hUart) {
     } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
         uartNum = 0;
-    } else if (PRU1_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
-        uartNum = 1;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -2023,7 +1547,7 @@ int16_t pru_softuart_clrRxStatus(suart_handle hUart) {
     }
 
     chNum = hUart->uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
 
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = (hUart->uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
@@ -2040,8 +1564,6 @@ int16_t pru_softuart_clrRxStatus(suart_handle hUart) {
         chNum++;
     } else if (PRU0_MODE == PRU_MODE_RX_ONLY) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
-    } else if (PRU1_MODE == PRU_MODE_RX_ONLY) {
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -2084,7 +1606,7 @@ int16_t pru_softuart_get_isrstatus(uint16_t uartNum, uint16_t *txrxFlag) {
 
     pru_ram_read_data_4byte(u32IntcOffset, (uint32_t *)&u32ISRValue, 1);
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chNum = uartNum * 2 - 2;
 
@@ -2148,7 +1670,7 @@ int32_t pru_intr_clr_isrstatus(uint16_t uartNum, uint32_t txrxmode) {
     uint16_t chnNum;
 
     chnNum = uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
@@ -2167,8 +1689,6 @@ int32_t pru_intr_clr_isrstatus(uint16_t uartNum, uint32_t txrxmode) {
         }
     } else if (PRU0_MODE == txrxmode) {
         offset = PRU_SUART_PRU0_ISR_OFFSET + 1;
-    } else if (PRU1_MODE == txrxmode) {
-        offset = PRU_SUART_PRU1_ISR_OFFSET + 1;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -2185,7 +1705,7 @@ int16_t suart_arm_to_pru_intr(uint16_t uartNum) {
     uint32_t u32value;
     int16_t s16retval;
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         if ((uartNum > 0) && (uartNum <= 4)) {
             /* PRU0 SYS_EVT32 */
             u32value = 0x20;
@@ -2197,8 +1717,8 @@ int16_t suart_arm_to_pru_intr(uint16_t uartNum) {
         }
     }
 
-    if ((PRU0_MODE == PRU_MODE_RX_ONLY) || (PRU1_MODE == PRU_MODE_RX_ONLY) ||
-        (PRU0_MODE == PRU_MODE_TX_ONLY) || (PRU1_MODE == PRU_MODE_TX_ONLY)) {
+    if ((PRU0_MODE == PRU_MODE_RX_ONLY) ||
+        (PRU0_MODE == PRU_MODE_TX_ONLY)) {
         if (uartNum == PRU_NUM0) {
             /* PRU0 SYS_EVT32 */
             u32value = 0x20;
@@ -2320,7 +1840,7 @@ int16_t arm_to_pru_intr_init(void) {
     }
 
 
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* Sets the channel for the system interrupt
         * MAP channel 0 to SYS_EVT32
         * MAP channel 1 to SYS_EVT33
@@ -2401,8 +1921,8 @@ int16_t arm_to_pru_intr_init(void) {
         }
     }
 
-    if ((PRU0_MODE == PRU_MODE_RX_ONLY) || (PRU1_MODE == PRU_MODE_RX_ONLY) ||
-        (PRU0_MODE == PRU_MODE_TX_ONLY) || (PRU1_MODE == PRU_MODE_TX_ONLY)) {
+    if ((PRU0_MODE == PRU_MODE_RX_ONLY) ||
+        (PRU0_MODE == PRU_MODE_TX_ONLY)) {
         /* Sets the channel for the system interrupt
         * MAP channel 0 to SYS_EVT32
         * MAP channel 1 to SYS_EVT33
@@ -2559,7 +2079,7 @@ int32_t suart_pru_to_host_intr_enable(uint16_t uartNum,
     }
 
     chnNum = uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         chnNum = (uartNum * 2) - 2;
         if (2 == txrxmode) {            /* Rx mode */
             chnNum++;
@@ -2567,12 +2087,8 @@ int32_t suart_pru_to_host_intr_enable(uint16_t uartNum,
         u32value = 34 + chnNum;
     } else if ((PRU_MODE_RX_ONLY == txrxmode) && (PRU0_MODE == PRU_MODE_RX_ONLY)) {
         u32value = 34 + chnNum;
-    } else if ((PRU_MODE_RX_ONLY == txrxmode) && (PRU1_MODE == PRU_MODE_RX_ONLY)) {
-        u32value = 42 + chnNum;
     } else if ((PRU_MODE_TX_ONLY == txrxmode) && (PRU0_MODE == PRU_MODE_TX_ONLY)) {
         u32value = 34 + chnNum;
-    } else if ((PRU_MODE_TX_ONLY == txrxmode) && (PRU1_MODE == PRU_MODE_TX_ONLY)) {
-        u32value = 42 + chnNum;
     } else {
         return -1;
     }
@@ -2602,7 +2118,7 @@ int32_t suart_intr_setmask(uint16_t uartNum,
     uint32_t chnNum;
 
     chnNum = uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
@@ -2626,9 +2142,6 @@ int32_t suart_intr_setmask(uint16_t uartNum,
     } else if (PRU0_MODE == txrxmode) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
         offset = PRU_SUART_PRU0_IMR_OFFSET;
-    } else if (PRU1_MODE == txrxmode) {
-        offset = PRU_SUART_PRU1_IMR_OFFSET;
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -2722,7 +2235,7 @@ int32_t suart_intr_clrmask(uint16_t uartNum,
     uint16_t chnNum;
 
     chnNum = uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
@@ -2746,9 +2259,6 @@ int32_t suart_intr_clrmask(uint16_t uartNum,
     } else if (PRU0_MODE == txrxmode) {
         pruOffset = PRU_SUART_PRU0_CH0_OFFSET;
         offset = PRU_SUART_PRU0_IMR_OFFSET;
-    } else if (PRU1_MODE == txrxmode) {
-        offset = PRU_SUART_PRU1_IMR_OFFSET;
-        pruOffset = PRU_SUART_PRU1_CH0_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }
@@ -2835,7 +2345,7 @@ int32_t suart_intr_getmask(uint16_t uartNum,
     uint16_t regval = 1;
 
     chnNum = uartNum - 1;
-    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH) || (PRU1_MODE == PRU_MODE_RX_TX_BOTH)) {
+    if ((PRU0_MODE == PRU_MODE_RX_TX_BOTH)) {
         /* channel starts from 0 and uart instance starts from 1 */
         chnNum = (uartNum * SUART_NUM_OF_CHANNELS_PER_SUART) - 2;
 
@@ -2856,8 +2366,6 @@ int32_t suart_intr_getmask(uint16_t uartNum,
         }
     } else if (PRU0_MODE == txrxmode) {
         offset = PRU_SUART_PRU0_IMR_OFFSET;
-    } else if (PRU1_MODE == txrxmode) {
-        offset = PRU_SUART_PRU1_IMR_OFFSET;
     } else {
         return PRU_MODE_INVALID;
     }

--- a/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.h
+++ b/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.h
@@ -39,10 +39,6 @@
 #define BIT(x)                          (1 << x)
 #endif
 
-#define  SINGLE_PRU             0
-#define  BOTH_PRU               1
-#define  PRU_ACTIVE             SINGLE_PRU // BOTH_PRU
-
 #define SUART_NUM_OF_CHANNELS_PER_SUART         2
 #define SUART_NUM_OF_BYTES_PER_CHANNEL          16
 
@@ -91,16 +87,7 @@
 #define PRU_MODE_RX_ONLY        0x2
 #define PRU_MODE_RX_TX_BOTH     0x3
 
-#if (PRU_ACTIVE == BOTH_PRU)
-#define PRU0_MODE    PRU_MODE_RX_ONLY
-#define PRU1_MODE    PRU_MODE_TX_ONLY
-#elif (PRU_ACTIVE == SINGLE_PRU)
 #define PRU0_MODE    PRU_MODE_RX_TX_BOTH
-#define PRU1_MODE    PRU_MODE_INVALID
-#else
-#define PRU0_MODE    PRU_MODE_INVALID
-#define PRU1_MODE    PRU_MODE_INVALID
-#endif
 
 #if !(defined CONFIG_OMAPL_SUART_MCASP) || (CONFIG_OMAPL_SUART_MCASP == 0)
 #define MCASP_BASE_OFFSET               (0x0)

--- a/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.h
+++ b/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_api.h
@@ -87,8 +87,6 @@
 #define PRU_MODE_RX_ONLY        0x2
 #define PRU_MODE_RX_TX_BOTH     0x3
 
-#define PRU0_MODE    PRU_MODE_RX_TX_BOTH
-
 #if !(defined CONFIG_OMAPL_SUART_MCASP) || (CONFIG_OMAPL_SUART_MCASP == 0)
 #define MCASP_BASE_OFFSET               (0x0)
 #elif (CONFIG_OMAPL_SUART_MCASP == 1)

--- a/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_pru_regs.h
+++ b/lib/pbio/drv/uart/uart_ev3_pru_lib/suart_pru_regs.h
@@ -78,46 +78,6 @@
 #define PRU_SUART_PRU0_DELAY_OFFSET             (0x0086)
 #define PRU_SUART_PRU0_IDLE_TIMEOUT_OFFSET      (0x0088)
 
-/* ********* PRU 1 Macros ************* */
-#define PRU_SUART_PRU1_CH0_OFFSET               (0x2000)
-/** Channel 0 */
-
-#define PRU_SUART_PRU1_CH1_OFFSET               (0x2010)
-/** Channel 1 */
-
-#define PRU_SUART_PRU1_CH2_OFFSET               (0x2020)
-/** Channel 2 */
-
-#define PRU_SUART_PRU1_CH3_OFFSET               (0x2030)
-/** Channel 3 */
-
-#define PRU_SUART_PRU1_CH4_OFFSET               (0x2040)
-/** Channel 4 */
-
-#define PRU_SUART_PRU1_CH5_OFFSET               (0x2050)
-/** Channel 5 */
-
-#define PRU_SUART_PRU1_CH6_OFFSET               (0x2060)
-/** Channel 6 */
-
-#define PRU_SUART_PRU1_CH7_OFFSET               (0x2070)
-/** Channel 7 */
-
-#define PRU_SUART_PRU1_IMR_OFFSET               (0x2080)
-/** Interrupt Mask Register */
-
-#define PRU_SUART_PRU1_ISR_OFFSET               (0x2082)
-/** Interrupt Status Register */
-
-#define PRU_SUART_PRU1_ID_ADDR                  (0x2084)
-/** PRU ID Register */
-
-#define PRU_SUART_PRU1_RX_TX_MODE               (0x2085)
-
-#define PRU_SUART_PRU1_DELAY_OFFSET             (0x2086)
-
-#define PRU_SUART_PRU1_IDLE_TIMEOUT_OFFSET      (0x2088)
-
 
 /* SUART Channel Control Register bit descriptions */
 #define PRU_SUART_CH_CTRL_MODE_SHIFT            0x0000


### PR DESCRIPTION
Because we are already using PRU1, we cannot use dual-PRU mode for the SUART library. Remove support for this mode so that the code is easier to maintain and understand.