### PR TITLE
pbio/platform/ev3/exceptionhandler.S: Remove SWI handler

### DIFF
--- a/lib/pbio/platform/ev3/exceptionhandler.S
+++ b/lib/pbio/platform/ev3/exceptionhandler.S
@@ -11,8 +11,7 @@
         .set  MODE_SYS, 0x1F            
   
 
-        .equ I_F_BIT, 0xC0 
-        .equ MASK_SWI_NUM, 0xFF000000
+        .equ I_F_BIT, 0xC0
         .equ MASK_SR_MODE, 0x1F
 
         @ This will be placed at 0xffff0000 by the linker script
@@ -52,6 +51,12 @@ UnknownExceptionHandler:
         @ Save r0-r12, lr
         stmfd   sp!, {r0-r12, lr}
         mov     r7, #EV3_PANIC_UNKNOWN
+        b       CommonPanicHandler
+
+SWIHandler:
+        @ Save r0-r12, lr
+        stmfd   sp!, {r0-r12, lr}
+        mov     r7, #EV3_PANIC_SWI
         @ b       CommonPanicHandler
         @ fall through
 
@@ -87,25 +92,7 @@ FIQHandler:
         MOV      lr, pc
         LDR      pc, [r0]
         LDMFD    r13!, {r0-r7, lr}
-        SUBS     pc, lr, #0x4 
-        
-@******************************************************************************
-@*                  Function Definition of SWI Handler
-@******************************************************************************    
-@
-@ The SWI Handler switches to system mode if the SWI number is 458752. If the
-@ SWI number is different, no mode switching will be done. No other SWI are 
-@ handled here
-@
-SWIHandler:
-        STMFD    r13!, {r0-r1, r14}       @ Save context in SVC stack
-        LDR      r0, [r14, #-4]           @ R0 points to SWI instruction
-        BIC      r0, r0, #MASK_SWI_NUM    @ Get the SWI number
-        CMP      r0, #458752
-        MRSEQ    r1, spsr                 @ Copy SPSR  
-        ORREQ    r1, r1, #0x1F            @ Change the mode to System
-        MSREQ    spsr_cf, r1              @ Restore SPSR
-        LDMFD    r13!, {r0-r1, pc}^       @ Restore registers from IRQ stack
+        SUBS     pc, lr, #0x4
 
 @******************************************************************************
 @*                  Function Definition of IRQ Handler

--- a/lib/pbio/platform/ev3/exceptionhandler.h
+++ b/lib/pbio/platform/ev3/exceptionhandler.h
@@ -5,5 +5,6 @@
 #define EV3_PANIC_UNDEFINED_INSTR   1
 #define EV3_PANIC_PREFETCH_ABORT    2
 #define EV3_PANIC_DATA_ABORT        3
+#define EV3_PANIC_SWI               4
 
 #endif // PBIO_EV3_EXCEPTIONHANDLER_H_

--- a/lib/pbio/platform/ev3/platform.c
+++ b/lib/pbio/platform/ev3/platform.c
@@ -419,6 +419,7 @@ static const char *const panic_types[] = {
     "Undefined Instruction",
     "Prefetch Abort",
     "Data Abort",
+    "SWI opcode"
 };
 
 typedef struct {


### PR DESCRIPTION
This handler was copied from an existing project template. We do not use SWI opcodes in this firmware, so replace it with a panic handler.