### PR TITLE
pbio/platform/ev3/exceptionhandler.S: Fix bug in panic handler

### DIFF
--- a/lib/pbio/platform/ev3/exceptionhandler.S
+++ b/lib/pbio/platform/ev3/exceptionhandler.S
@@ -68,7 +68,7 @@ CommonPanicHandler:
         @ NOTE: Assumes we never use User mode
         and     r0, #MASK_SR_MODE
         mrs     r1, cpsr
-        and     r2, r1, #MASK_SR_MODE
+        bic     r2, r1, #MASK_SR_MODE
         orr     r2, r0
         msr     cpsr, r2
         mov     r3, r13


### PR DESCRIPTION
The bic opcode was supposed to be used here in order to *clear* the mode bits, rather than keep them.

This bug did not surface because we've mostly been hitting panics in System mode, which has a mode bits value of all 1s.