### PR TITLE
bricks/mpconfigport: remove duplicate/unused stuff

### DIFF
--- a/bricks/essentialhub/mpconfigport.h
+++ b/bricks/essentialhub/mpconfigport.h
@@ -8,7 +8,6 @@
 
 #define PYBRICKS_HUB_NAME                       "essentialhub"
 #define PYBRICKS_HUB_CLASS_NAME                 (MP_QSTR_EssentialHub)
-#undef PYBRICKS_HUB_CLASS_NAME_ALIAS
 #define PYBRICKS_HUB_ESSENTIALHUB               (1)
 
 // Pybricks modules

--- a/bricks/nxt/mpconfigport.h
+++ b/bricks/nxt/mpconfigport.h
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2023 The Pybricks Authors
 
-#include <stdint.h>
-
-#define MICROPY_BANNER_NAME_AND_VERSION         "Pybricks MicroPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE
 #define MICROPY_HW_BOARD_NAME                   "LEGO MINDSTORMS NXT Brick"
 #define MICROPY_HW_MCU_NAME                     "AT91SAM7S256"
 


### PR DESCRIPTION
Remove a few duplicate or unused definitions in the hub mpconfigport.h files.