### PR TITLE
pbio/drv/usb: extend USB transmit timeout

### DIFF
--- a/lib/pbio/drv/usb/usb_ev3.c
+++ b/lib/pbio/drv/usb/usb_ev3.c
@@ -984,7 +984,7 @@ static pbio_error_t pbdrv_usb_ev3_process_thread(pbio_os_state_t *state, void *c
                 prev_status_flags = ~0;
             }
         } else if (!was_transmitting && is_transmitting) {
-            pbio_os_timer_set(&tx_timeout_timer, 5);
+            pbio_os_timer_set(&tx_timeout_timer, 50);
         }
         was_transmitting = is_transmitting;
 

--- a/lib/pbio/drv/usb/usb_stm32.c
+++ b/lib/pbio/drv/usb/usb_stm32.c
@@ -515,7 +515,7 @@ PROCESS_THREAD(pbdrv_usb_process, ev, data) {
         if (transmitting) {
             // If the FIFO isn't emptied quickly, then there probably isn't an
             // app anymore. This timer is used to detect such a condition.
-            etimer_set(&transmit_timer, 5);
+            etimer_set(&transmit_timer, 50);
         }
     }
 


### PR DESCRIPTION
Extend the USB transmit timeout from 5 ms to 50 ms. We are getting spurious unsubscribes due to the timeout while still being connected, so 5 ms is not long enough. Let's increase by 1 order of magnitude and see how it goes.