### PR TITLE
pbio/drv/bluetooth: Add way to forcefully exit.

### DIFF
--- a/lib/pbio/drv/bluetooth/bluetooth.h
+++ b/lib/pbio/drv/bluetooth/bluetooth.h
@@ -24,6 +24,7 @@
 #define PBDRV_BLUETOOTH_MAX_ADV_SIZE 31
 
 void pbdrv_bluetooth_init_hci(void);
+void pbdrv_bluetooth_controller_reset_hard(void);
 pbio_error_t pbdrv_bluetooth_controller_reset(pbio_os_state_t *state, pbio_os_timer_t *timer);
 pbio_error_t pbdrv_bluetooth_controller_initialize(pbio_os_state_t *state, pbio_os_timer_t *timer);
 

--- a/lib/pbio/drv/bluetooth/bluetooth_btstack.c
+++ b/lib/pbio/drv/bluetooth/bluetooth_btstack.c
@@ -848,6 +848,10 @@ const char *pbdrv_bluetooth_get_fw_version(void) {
     return "v1.4";
 }
 
+void pbdrv_bluetooth_controller_reset_hard(void) {
+    hci_power_control(HCI_POWER_OFF);
+}
+
 pbio_error_t pbdrv_bluetooth_controller_reset(pbio_os_state_t *state, pbio_os_timer_t *timer) {
 
     // The event handler also pushes the bluetooth process along, but shouldn't
@@ -864,7 +868,7 @@ pbio_error_t pbdrv_bluetooth_controller_reset(pbio_os_state_t *state, pbio_os_ti
         PBIO_OS_AWAIT_UNTIL(state, le_con_handle == HCI_CON_HANDLE_INVALID);
     }
 
-    hci_power_control(HCI_POWER_OFF);
+    pbdrv_bluetooth_controller_reset_hard();
     PBIO_OS_AWAIT_UNTIL(state, hci_get_state() == HCI_STATE_OFF);
 
     PBIO_OS_ASYNC_END(PBIO_SUCCESS);

--- a/lib/pbio/drv/bluetooth/bluetooth_stm32_bluenrg.c
+++ b/lib/pbio/drv/bluetooth/bluetooth_stm32_bluenrg.c
@@ -1237,6 +1237,13 @@ static pbio_error_t init_uart_service(pbio_os_state_t *state, void *context) {
     PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
+void pbdrv_bluetooth_controller_reset_hard(void) {
+    pybricks_notify_en = uart_tx_notify_en = false;
+    conn_handle = peripheral_singleton.con_handle = 0;
+    spi_disable_cs();
+    bluetooth_reset(true);
+}
+
 pbio_error_t pbdrv_bluetooth_controller_reset(pbio_os_state_t *state, pbio_os_timer_t *timer) {
     PBIO_OS_ASYNC_BEGIN(state);
 
@@ -1249,11 +1256,8 @@ pbio_error_t pbdrv_bluetooth_controller_reset(pbio_os_state_t *state, pbio_os_ti
         PBIO_OS_AWAIT_UNTIL(state, conn_handle == 0);
     }
 
-    pybricks_notify_en = uart_tx_notify_en = false;
-    conn_handle = peripheral_singleton.con_handle = 0;
+    pbdrv_bluetooth_controller_reset_hard();
 
-    spi_disable_cs();
-    bluetooth_reset(true);
     PBIO_OS_AWAIT_MS(state, timer, 50);
 
     PBIO_OS_ASYNC_END(PBIO_SUCCESS);

--- a/lib/pbio/drv/bluetooth/bluetooth_stm32_cc2640.c
+++ b/lib/pbio/drv/bluetooth/bluetooth_stm32_cc2640.c
@@ -1837,6 +1837,14 @@ static pbio_error_t init_uart_service(pbio_os_state_t *state, void *context) {
     PBIO_OS_ASYNC_END(PBIO_SUCCESS);
 }
 
+void pbdrv_bluetooth_controller_reset_hard(void) {
+    pybricks_notify_en = uart_tx_notify_en = false;
+    conn_handle = peripheral_singleton.con_handle = NO_CONNECTION;
+
+    spi_set_mrdy(false);
+    bluetooth_reset(RESET_STATE_OUT_LOW);
+}
+
 pbio_error_t pbdrv_bluetooth_controller_reset(pbio_os_state_t *state, pbio_os_timer_t *timer) {
     PBIO_OS_ASYNC_BEGIN(state);
 
@@ -1847,11 +1855,8 @@ pbio_error_t pbdrv_bluetooth_controller_reset(pbio_os_state_t *state, pbio_os_ti
         PBIO_OS_AWAIT_UNTIL(state, conn_handle == NO_CONNECTION);
     }
 
-    pybricks_notify_en = uart_tx_notify_en = false;
-    conn_handle = peripheral_singleton.con_handle = NO_CONNECTION;
+    pbdrv_bluetooth_controller_reset_hard();
 
-    spi_set_mrdy(false);
-    bluetooth_reset(RESET_STATE_OUT_LOW);
     PBIO_OS_AWAIT_MS(state, timer, 150);
 
     PBIO_OS_ASYNC_END(PBIO_SUCCESS);

--- a/lib/pbio/include/pbdrv/bluetooth.h
+++ b/lib/pbio/include/pbdrv/bluetooth.h
@@ -503,6 +503,19 @@ void pbdrv_bluetooth_restart_observing_request(void);
  */
 pbio_error_t pbdrv_bluetooth_await_advertise_or_scan_command(pbio_os_state_t *state, void *context);
 
+/**
+ * Awaits user activity to complete, usually called during cleanup after running
+ * a user program. This will disconnect from the peripheral and stop scanning
+ * and advertising.
+ *
+ * @param [in]  state          Protothread state.
+ * @param [in]  timer          Timer used to give up if this takes too long.
+ * @return                     ::PBIO_SUCCESS on completion.
+ *                             ::PBIO_ERROR_AGAIN while awaiting.
+ *                             ::PBIO_ERROR_TIMEDOUT if the timer expired.
+ */
+pbio_error_t pbdrv_bluetooth_close_user_tasks(pbio_os_state_t *state, pbio_os_timer_t *timer);
+
 #else // PBDRV_CONFIG_BLUETOOTH
 
 static inline void pbdrv_bluetooth_init(void) {
@@ -601,6 +614,11 @@ static inline pbio_error_t pbdrv_bluetooth_start_observing(
 static inline pbio_error_t pbdrv_bluetooth_await_advertise_or_scan_command(pbio_os_state_t *state, void *context) {
     return PBIO_ERROR_NOT_SUPPORTED;
 }
+
+static inline pbio_error_t pbdrv_bluetooth_close_user_tasks(pbio_os_state_t *state, pbio_os_timer_t *timer) {
+    return PBIO_ERROR_NOT_SUPPORTED;
+}
+
 
 #endif // PBDRV_CONFIG_BLUETOOTH
 

--- a/lib/pbio/include/pbio/main.h
+++ b/lib/pbio/include/pbio/main.h
@@ -8,9 +8,11 @@
 
 #include "pbio/config.h"
 
+#include <pbio/error.h>
+
 void pbio_init(bool start_processes);
 void pbio_deinit(void);
-void pbio_main_stop_application_resources();
+pbio_error_t pbio_main_stop_application_resources(void);
 void pbio_main_soft_stop(void);
 
 #endif // _PBIO_MAIN_H_

--- a/lib/pbio/sys/main.c
+++ b/lib/pbio/sys/main.c
@@ -114,7 +114,12 @@ int main(int argc, char **argv) {
         pbsys_main_run_program(&program);
 
         // Stop motors, user animations, user bluetooth activity, etc.
-        pbio_main_stop_application_resources();
+        err = pbio_main_stop_application_resources();
+        if (err != PBIO_SUCCESS) {
+            // If we couldn't get the system back in a normal state, proceed
+            // towards shutdown.
+            break;
+        }
 
         // Get system back in idle state.
         pbsys_status_clear(PBIO_PYBRICKS_STATUS_USER_PROGRAM_RUNNING);


### PR DESCRIPTION
Adds a generic way to forcefully stop trying to run Bluetooth functions when the Bluetooth drivers get stuck. Such as mechanism had not yet been implemented after overhauling the Bluetooth drivers. 

Before, we used to try to disconnect and stop observing/scanning in the MicroPython deinit, and stop waiting in case of a shutdown request. Now we do it as part of the pbio cleanup, and enforce shutdown if it fails since this is not a recoverable state.

In practice, this was mostly happening on Technic Hub. This was when it would be stuck in a blinking state if an advertising function got stuck.

This commit was tested by adding the following intentional obstacle in one of the Bluetooth functions.

```diff
 pbio_error_t pbdrv_bluetooth_peripheral_disconnect_func(pbio_os_state_t *state, void *context) {
 
+    static pbio_os_timer_t timer;
+
     PBIO_OS_ASYNC_BEGIN(state);
 
+    while (true) {
+        PBIO_OS_AWAIT_MS(state, &timer, 1000);
+    }
```

This would cause the de-initialization to never complete if a peripheral is connected. With this commit, it will exit the task and proceed to normal shutdown.

It will still save the user program and data, etc.