### PR TITLE
micropython: Bring back running program from storage RAM.

### DIFF
--- a/bricks/_common/mpconfigport.h
+++ b/bricks/_common/mpconfigport.h
@@ -116,7 +116,8 @@
 #define MICROPY_PERSISTENT_CODE_LOAD            (1)
 #define MICROPY_ENABLE_EXTERNAL_IMPORT          (0)
 #define MICROPY_HAS_FILE_READER                 (0)
-#define MICROPY_VFS_MAP_MINIMAL                 (1)
+#define MICROPY_VFS_ROM                         (1)
+#define MICROPY_VFS_ROM_IOCTL                   (0)
 #if PYBRICKS_OPT_CUSTOM_IMPORT
 #define mp_builtin___import__ pb_builtin_import
 #endif


### PR DESCRIPTION
This was missed in 65d519679ed2327abaf2d1669e521c3857819d30 when upgrading MicroPython. This would lead to programs being copied to RAM before running. How it was found: If all slots were full, then the program would not run as there would not be enough heap to load yet another program.

Also, MicroPython has a hardcoded test for mp_reader_mem_readbyte in mp_reader_try_read_rom, so it would ignore our reader even with MICROPY_VFS_ROM enabled.

Fixes https://github.com/pybricks/support/issues/2382