### PR TITLE
added keyword argument to UARTDevice to set power on one of the power…

### DIFF
--- a/pybricks/iodevices/pb_type_uart_device.c
+++ b/pybricks/iodevices/pb_type_uart_device.c
@@ -53,8 +53,9 @@ static mp_obj_t pb_type_uart_device_make_new(const mp_obj_type_t *type, size_t n
     PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
         PB_ARG_REQUIRED(port),
         PB_ARG_DEFAULT_INT(baudrate, 115200),
-        PB_ARG_DEFAULT_NONE(timeout));
-
+        PB_ARG_DEFAULT_NONE(timeout),
+        PB_ARG_DEFAULT_INT(power_pin, 0)
+        );
     // Get device, which inits UART port
     pb_type_uart_device_obj_t *self = mp_obj_malloc(pb_type_uart_device_obj_t, type);
 
@@ -74,6 +75,14 @@ static mp_obj_t pb_type_uart_device_make_new(const mp_obj_type_t *type, size_t n
     pbio_port_id_t port_id = pb_type_enum_get_value(port_in, &pb_enum_type_Port);
     pb_assert(pbio_port_get_port(port_id, &self->port));
     pbio_port_set_mode(self->port, PBIO_PORT_MODE_UART);
+
+    if (mp_obj_get_int(power_pin_in) == 1) {
+       pbio_port_p1p2_set_power(self->port, PBIO_PORT_POWER_REQUIREMENTS_BATTERY_VOLTAGE_P1_POS);
+    } else if (mp_obj_get_int(power_pin_in) == 2) {
+       pbio_port_p1p2_set_power(self->port, PBIO_PORT_POWER_REQUIREMENTS_BATTERY_VOLTAGE_P2_POS);
+    } else
+       pbio_port_p1p2_set_power(self->port, PBIO_PORT_POWER_REQUIREMENTS_NONE);
+
     pb_assert(pbio_port_get_uart_dev(self->port, &self->uart_dev));
     pb_type_uart_device_set_baudrate(MP_OBJ_FROM_PTR(self), baudrate_in);
     pbdrv_uart_flush(self->uart_dev);


### PR DESCRIPTION
The UARTDevice iodevice is a nice generic way to communicate with external devices using plain uart communciation. When external devices have more power needs than the 3v3 line can deliver (e.g. when driving NeoPixels or Servo motors), it would be nice when such a device can use 8V power coming from one of the power lines P1 or P2.

The PUPDevice iodevice allows for setting power on either P1 or P2 depending how that is negotiatied in the PUP protocol. For I2CDevices, there is a keyword argument powered that allows for powering P1 (not P2). Unfortunately, I2Cdevice is not present for prime hub or technic hub, only for EV3 hub (and there the powered does work, but is not effective, as the P1 pin is connected through a 330Ohm resistor, and the voltage drops sharply when connecting a device that draws some current.)

# Proposed solution
I propose to add a keyword argument power_pin to the UARTDevice __init__ method where the argument can be 0 (no power), 1 (P1 powered) or 2 (P2 powered).

In a pybricks program that would look like:

```
uart = UARTDevice(Port.A, power_pin = 1)
```
resulting in P1 powered and

```
uart = UARTDevice(Port.A, power_pin = 0)
```
resulting in P1 nor P2 powered.

Fixes https://github.com/pybricks/support/issues/2655