### PR TITLE
pbio/os: Number protothread checkpoints from one.

### DIFF
--- a/lib/pbio/include/pbio/os.h
+++ b/lib/pbio/include/pbio/os.h
@@ -163,11 +163,23 @@ struct _pbio_os_process_t {
  *
  * @param [in]  state    Protothread state.
  */
-#define PBIO_OS_ASYNC_BEGIN(state) { char do_yield_now = 0; (void)do_yield_now; switch (*state) { case 0:
+#define PBIO_OS_ASYNC_BEGIN(state) { enum { pbio_os_checkpoint_base = __COUNTER__ }; char do_yield_now = 0; (void)do_yield_now; switch (*state) { case 0:
+
+// Implementation detail of PBIO_OS_ASYNC_SET_CHECKPOINT. The checkpoint number
+// is taken as an argument so that __COUNTER__ is expanded only once and both
+// occurrences get the same value. PBIO_OS_ASYNC_BEGIN() captures the
+// translation unit wide __COUNTER__ value at the start of the protothread,
+// which is subtracted here so that each protothread numbers its checkpoints
+// from one. This keeps the case labels dense, which lets the compiler emit a
+// compact jump table.
+#define _PBIO_OS_ASYNC_SET_CHECKPOINT(state, n) *state = (n) - pbio_os_checkpoint_base; __attribute__((fallthrough)); case (n) - pbio_os_checkpoint_base:
 
 /**
- * Sets a protothread checkpoint state to the current line number so we can
- * continue from (jump) here later if we yield.
+ * Sets a protothread checkpoint state so we can continue from (jump) here
+ * later if we yield.
+ *
+ * The state value is the index of the checkpoint within the protothread,
+ * counting from one.
  *
  * This is used as part of several other yield-like macros such as yielding
  * until a condition is true. This macro is not typically used directly in user
@@ -177,7 +189,7 @@ struct _pbio_os_process_t {
  *
  * @param [in]  state    Protothread state.
  */
-#define PBIO_OS_ASYNC_SET_CHECKPOINT(state) *state = __LINE__; __attribute__((fallthrough)); case __LINE__:
+#define PBIO_OS_ASYNC_SET_CHECKPOINT(state) _PBIO_OS_ASYNC_SET_CHECKPOINT(state, __COUNTER__)
 
 /**
  * Declare the end of a protothread and returns with given code.


### PR DESCRIPTION
Protothread checkpoints used `__LINE__` as the resume state, so the switch that dispatches to them spanned the whole line range of the function. GCC emits a jump table covering that range, one entry per line, with most entries pointing at the default case. Where the range exceeded 255 the table also doubled in width, since `__gnu_thumb1_case_uqi` can only address a byte.

Use `__COUNTER__` instead, and capture its value in `PBIO_OS_ASYNC_BEGIN()` so that each protothread numbers its checkpoints from one. The case labels are then dense and start at zero, so the compiler indexes the table directly with no range offset.

On the Move Hub this takes the firmware from 105632 to 104112 bytes, which matters because only 864 bytes of the 104K region were left. For example, the dispatch in `init_device_information_service()` goes from a 42 entry table to 15 entries, and the one in `pbdrv_bluetooth_spi_process_thread()` from 79 two byte entries to 12 single byte entries.

This also means source line numbers no longer affect the size of the binary, so adding a comment to a protothread does not move code around.
