### PR TITLE
bricks/_common/common.mk: Exclude unused VfsRom qstrs.

### DIFF
--- a/bricks/_common/common.mk
+++ b/bricks/_common/common.mk
@@ -101,6 +101,15 @@ MICROPY_ROM_TEXT_COMPRESSION ?= 1
 include $(TOP)/py/py.mk
 include $(TOP)/extmod/extmod.mk
 
+# MICROPY_VFS_ROM is enabled so that py/persistentcode.c can reference the
+# bytecode and string data of a downloaded program in place instead of copying
+# it to the heap. MICROPY_VFS is not enabled, so the VfsRom object and its file
+# wrapper are never registered and the linker discards all of their code. Drop
+# the translation units entirely so that their qstrs are not added either.
+UNUSED_EXTMOD_SRC_C = extmod/vfs_rom.c extmod/vfs_rom_file.c
+PY_O := $(filter-out $(addprefix $(BUILD)/,$(UNUSED_EXTMOD_SRC_C:.c=.o)), $(PY_O))
+SRC_QSTR := $(filter-out $(UNUSED_EXTMOD_SRC_C), $(SRC_QSTR))
+
 INC += -I.
 INC += -I$(TOP)
 ifeq ($(PB_MCU_FAMILY),STM32)


### PR DESCRIPTION
MICROPY_VFS_ROM is needed so that downloaded program data can be referenced in place, but MICROPY_VFS is not enabled, so VfsRom itself is never registered. The linker discards the code, but the qstrs are collected from the sources regardless. Saves around 120 bytes.