### PR TITLE
pbio/platform: Make ioport pins const.

### DIFF
--- a/lib/pbio/platform/city_hub/platform.c
+++ b/lib/pbio/platform/city_hub/platform.c
@@ -169,7 +169,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_ID_0,
         .external_port_index = 0,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOA, .pin = 1  },
             .p6 = { .bank = GPIOA, .pin = 3  },
             .uart_buf = { .bank = GPIOB, .pin = 5  },
@@ -191,7 +191,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_ID_1,
         .external_port_index = 1,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOA, .pin = 0  },
             .p6 = { .bank = GPIOA, .pin = 2  },
             .uart_buf = { .bank = GPIOB, .pin = 4  },

--- a/lib/pbio/platform/essential_hub/platform.c
+++ b/lib/pbio/platform/essential_hub/platform.c
@@ -225,7 +225,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_A,
         .external_port_index = 0,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOC, .pin = 1 },
             .p6 = { .bank = GPIOC, .pin = 0 },
             .uart_buf = { .bank = GPIOB, .pin = 9 },
@@ -247,7 +247,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .motor_driver_index = 1,
         .external_port_index = 1,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOA, .pin = 5 },
             .p6 = { .bank = GPIOA, .pin = 4 },
             .uart_buf = { .bank = GPIOB, .pin = 8 },

--- a/lib/pbio/platform/ev3/platform.c
+++ b/lib/pbio/platform/ev3/platform.c
@@ -302,7 +302,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART1,
         .external_port_index = 0,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p1 = PBDRV_GPIO_EV3_PIN(18, 31, 28, 8, 10),
             #if PBDRV_CONFIG_IOPORT_HAS_GPIO_P2
             .p2 = PBDRV_GPIO_EV3_PIN(6, 23, 20, 2, 2),
@@ -330,7 +330,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART0,
         .external_port_index = 1,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p1 = PBDRV_GPIO_EV3_PIN(18, 23, 20, 8, 12),
             #if PBDRV_CONFIG_IOPORT_HAS_GPIO_P2
             .p2 = PBDRV_GPIO_EV3_PIN(18, 11, 8, 8, 15),
@@ -354,7 +354,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = PRU0_LINE1,
         .external_port_index = 2,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p1 = PBDRV_GPIO_EV3_PIN(19, 3, 0, 8, 9),
             #if PBDRV_CONFIG_IOPORT_HAS_GPIO_P2
             .p2 = PBDRV_GPIO_EV3_PIN(16, 27, 24, 7, 11),
@@ -378,7 +378,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = PRU0_LINE0,
         .external_port_index = 3,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p1 = PBDRV_GPIO_EV3_PIN(19, 11, 8, 6, 4),
             #if PBDRV_CONFIG_IOPORT_HAS_GPIO_P2
             .p2 = PBDRV_GPIO_EV3_PIN(17, 7, 4, 7, 8),

--- a/lib/pbio/platform/move_hub/platform.c
+++ b/lib/pbio/platform/move_hub/platform.c
@@ -91,7 +91,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .i2c_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
         .uart_driver_index = UART_ID_0,
         .external_port_index = 0,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOB, .pin = 7  },
             .p6 = { .bank = GPIOC, .pin = 15 },
             .uart_buf = { .bank = GPIOB, .pin = 4  },
@@ -113,7 +113,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .i2c_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
         .uart_driver_index = UART_ID_1,
         .external_port_index = 1,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOB, .pin = 10 },
             .p6 = { .bank = GPIOA, .pin = 12 },
             .uart_buf = { .bank = GPIOB, .pin = 0  },

--- a/lib/pbio/platform/nxt/platform.c
+++ b/lib/pbio/platform/nxt/platform.c
@@ -76,7 +76,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
         .external_port_index = 0,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = {.pin = 23},
             .p6 = {.pin = 18},
             .adc_p1 = 0,
@@ -91,7 +91,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
         .external_port_index = 1,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = {.pin = 28},
             .p6 = {.pin = 19},
             .adc_p1 = 1,
@@ -106,7 +106,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
         .external_port_index = 2,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = {.pin = 29},
             .p6 = {.pin = 20},
             .adc_p1 = 2,
@@ -121,7 +121,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
         .external_port_index = 3,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = {.pin = 30},
             .p6 = {.pin = 2},
             .adc_p1 = 3,

--- a/lib/pbio/platform/prime_hub_f4/platform.c
+++ b/lib/pbio/platform/prime_hub_f4/platform.c
@@ -238,7 +238,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_A,
         .external_port_index = 0,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOD, .pin = 7  },
             .p6 = { .bank = GPIOD, .pin = 8  },
             .uart_buf = { .bank = GPIOA, .pin = 10 },
@@ -260,7 +260,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_B,
         .external_port_index = 1,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOD, .pin = 9  },
             .p6 = { .bank = GPIOD, .pin = 10 },
             .uart_buf = { .bank = GPIOA, .pin = 8  },
@@ -278,7 +278,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_C,
         .external_port_index = 2,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOD, .pin = 11 },
             .p6 = { .bank = GPIOE, .pin = 4  },
             .uart_buf = { .bank = GPIOE, .pin = 5  },
@@ -296,7 +296,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_D,
         .external_port_index = 3,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOC, .pin = 15 },
             .p6 = { .bank = GPIOC, .pin = 14 },
             .uart_buf = { .bank = GPIOB, .pin = 2  },
@@ -314,7 +314,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_E,
         .external_port_index = 4,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOC, .pin = 13 },
             .p6 = { .bank = GPIOE, .pin = 12 },
             .uart_buf = { .bank = GPIOB, .pin = 5  },
@@ -332,7 +332,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_F,
         .external_port_index = 5,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOC, .pin = 11 },
             .p6 = { .bank = GPIOE, .pin = 6  },
             .uart_buf = { .bank = GPIOC, .pin = 5  },

--- a/lib/pbio/platform/prime_hub_h5/platform.c
+++ b/lib/pbio/platform/prime_hub_h5/platform.c
@@ -506,7 +506,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_A,
         .external_port_index = 0,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOD, .pin = 7  },
             .p6 = { .bank = GPIOD, .pin = 13  },
             .uart_buf = { .bank = GPIOA, .pin = 10 },
@@ -528,7 +528,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_B,
         .external_port_index = 1,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOD, .pin = 12 },
             .p6 = { .bank = GPIOD, .pin = 10 },
             .uart_buf = { .bank = GPIOA, .pin = 8 },
@@ -546,7 +546,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_C,
         .external_port_index = 2,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOD, .pin = 11 },
             .p6 = { .bank = GPIOE, .pin = 4 },
             .uart_buf = { .bank = GPIOE, .pin = 5 },
@@ -564,7 +564,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_D,
         .external_port_index = 3,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOC, .pin = 15 },
             .p6 = { .bank = GPIOC, .pin = 14 },
             .uart_buf = { .bank = GPIOB, .pin = 2  },
@@ -582,7 +582,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_E,
         .external_port_index = 4,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOC, .pin = 13 },
             .p6 = { .bank = GPIOE, .pin = 12 },
             .uart_buf = { .bank = GPIOB, .pin = 5 },
@@ -600,7 +600,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_F,
         .external_port_index = 5,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOB, .pin = 12 },
             .p6 = { .bank = GPIOE, .pin = 6 },
             .uart_buf = { .bank = GPIOC, .pin = 5 },

--- a/lib/pbio/platform/technic_hub/platform.c
+++ b/lib/pbio/platform/technic_hub/platform.c
@@ -255,7 +255,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_A,
         .external_port_index = 0,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOC, .pin = 5  },
             .p6 = { .bank = GPIOB, .pin = 2  },
             .uart_buf = { .bank = GPIOH, .pin = 0  },
@@ -277,7 +277,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_B,
         .external_port_index = 1,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOC, .pin = 3  },
             .p6 = { .bank = GPIOC, .pin = 0  },
             .uart_buf = { .bank = GPIOH, .pin = 1  },
@@ -295,7 +295,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_C,
         .external_port_index = 2,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOC, .pin = 4  },
             .p6 = { .bank = GPIOA, .pin = 7  },
             .uart_buf = { .bank = GPIOC, .pin = 8  },
@@ -313,7 +313,7 @@ const pbdrv_ioport_platform_data_t pbdrv_ioport_platform_data[PBDRV_CONFIG_IOPOR
         .uart_driver_index = UART_PORT_D,
         .external_port_index = 3,
         .counter_driver_index = PBDRV_IOPORT_INDEX_NOT_AVAILABLE,
-        .pins = &(pbdrv_ioport_pins_t) {
+        .pins = &(const pbdrv_ioport_pins_t) {
             .p5 = { .bank = GPIOA, .pin = 4  },
             .p6 = { .bank = GPIOA, .pin = 5  },
             .uart_buf = { .bank = GPIOC, .pin = 7  },


### PR DESCRIPTION
These compound literals were not const, so they ended up in RAM instead of flash even though nothing ever writes them. Frees around 100 to 300 bytes of RAM, depending on how many ports the hub has.