### PR TITLE
pybricks/messaging: Shorten BLERadio notice on terse hubs.

### DIFF
--- a/pybricks/messaging/pb_type_ble_radio.c
+++ b/pybricks/messaging/pb_type_ble_radio.c
@@ -586,7 +586,12 @@ static mp_obj_t pb_type_ble_radio_make_new(const mp_obj_type_t *type, size_t n_a
 #if PYBRICKS_PY_MESSAGING_BLE_RADIO_OLD
 mp_obj_t pb_type_BLE_new(mp_obj_t broadcast_channel_in, mp_obj_t observe_channels_in) {
     if (broadcast_channel_in != mp_const_none || observe_channels_in != MP_OBJ_FROM_PTR(&mp_const_empty_tuple_obj)) {
+        #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_NONE
+        // Hubs that drop exception messages to save flash get a short hint too.
+        mp_print_str(&mp_plat_print, "Moved to pybricks.messaging.BLERadio.\n");
+        #else
         mp_printf(&mp_plat_print, "Hub messaging has been moved. You should use:\n\nfrom pybricks.messaging import BLERadio\nradio = BLERadio(broadcast_channel, observe_channels)\n\n");
+        #endif
         return pb_type_ble_radio_init(broadcast_channel_in, observe_channels_in);
     }
     return mp_const_none;


### PR DESCRIPTION
Hubs that drop exception messages entirely should not spend 143 bytes on a deprecation notice, so print a one-line hint there instead. Saves around 90 bytes on Move Hub and nothing anywhere else.