### PR TITLE
pybricks/common: Add common Powered Up constructor.

### DIFF
--- a/pybricks/common/pb_type_device.c
+++ b/pybricks/common/pb_type_device.c
@@ -13,6 +13,7 @@
 #include <pybricks/pupdevices.h>
 #include <pybricks/common/pb_type_device.h>
 
+#include <pybricks/util_mp/pb_kwarg_helper.h>
 #include <pybricks/util_pb/pb_error.h>
 
 #include <py/runtime.h>
@@ -140,6 +141,29 @@ void pb_device_set_lego_mode(pbio_port_t *port) {
         err = pbio_port_set_mode(port, PBIO_PORT_MODE_LEGO_DCM);
     }
     pb_assert(err);
+}
+
+/**
+ * Common constructor for Powered Up devices that take only a port argument.
+ *
+ * The object is allocated as @p size bytes, so the first member of its type
+ * must be a ::pb_type_device_obj_base_t.
+ *
+ * @param [in]  type      The type of object to create.
+ * @param [in]  n_args    Number of positional arguments.
+ * @param [in]  n_kw      Number of keyword arguments.
+ * @param [in]  args      The positional and keyword arguments.
+ * @param [in]  size      Size of the object to allocate.
+ * @param [in]  valid_id  The device type that is expected on the port.
+ * @return                The new object.
+ */
+void *pb_type_device_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args, size_t size, lego_device_type_id_t valid_id) {
+    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
+        PB_ARG_REQUIRED(port));
+
+    pb_type_device_obj_base_t *self = mp_obj_malloc_helper(size, type);
+    pb_type_device_init_class(self, port_in, valid_id);
+    return self;
 }
 
 lego_device_type_id_t pb_type_device_init_class(pb_type_device_obj_base_t *self, mp_obj_t port_in, lego_device_type_id_t valid_id) {

--- a/pybricks/common/pb_type_device.h
+++ b/pybricks/common/pb_type_device.h
@@ -57,6 +57,7 @@ extern const mp_obj_type_t pb_type_device_method;
 
 mp_obj_t pb_type_device_method_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args);
 mp_obj_t pb_type_pupdevices_method(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args);
+void *pb_type_device_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args, size_t size, lego_device_type_id_t valid_id);
 lego_device_type_id_t pb_type_device_init_class(pb_type_device_obj_base_t *self, mp_obj_t port_in, lego_device_type_id_t valid_id);
 mp_obj_t pb_type_device_set_data(pb_type_device_obj_base_t *sensor, uint8_t mode, const void *data, uint8_t size);
 void *pb_type_device_get_data(mp_obj_t self_in, uint8_t mode);

--- a/pybricks/ev3devices/pb_type_ev3devices_colorsensor.c
+++ b/pybricks/ev3devices/pb_type_ev3devices_colorsensor.c
@@ -21,11 +21,7 @@ typedef struct _ev3devices_ColorSensor_obj_t {
 
 // pybricks.ev3devices.ColorSensor.__init__
 static mp_obj_t ev3devices_ColorSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_REQUIRED(port));
-    ev3devices_ColorSensor_obj_t *self = mp_obj_malloc(ev3devices_ColorSensor_obj_t, type);
-    pb_type_device_init_class(&self->device_base, port_in, LEGO_DEVICE_TYPE_ID_EV3_COLOR_SENSOR);
-    return MP_OBJ_FROM_PTR(self);
+    return pb_type_device_make_new(type, n_args, n_kw, args, sizeof(ev3devices_ColorSensor_obj_t), LEGO_DEVICE_TYPE_ID_EV3_COLOR_SENSOR);
 }
 
 // pybricks.ev3devices.ColorSensor.color

--- a/pybricks/ev3devices/pb_type_ev3devices_infraredsensor.c
+++ b/pybricks/ev3devices/pb_type_ev3devices_infraredsensor.c
@@ -23,11 +23,8 @@ typedef struct _ev3devices_InfraredSensor_obj_t {
 
 // pybricks.ev3devices.InfraredSensor.__init__
 static mp_obj_t ev3devices_InfraredSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_REQUIRED(port));
-
-    ev3devices_InfraredSensor_obj_t *self = mp_obj_malloc(ev3devices_InfraredSensor_obj_t, type);
-    pb_type_device_init_class(&self->device_base, port_in, LEGO_DEVICE_TYPE_ID_EV3_IR_SENSOR);
+    ev3devices_InfraredSensor_obj_t *self = pb_type_device_make_new(type, n_args, n_kw, args,
+        sizeof(ev3devices_InfraredSensor_obj_t), LEGO_DEVICE_TYPE_ID_EV3_IR_SENSOR);
     self->current_channel = 1;
     return MP_OBJ_FROM_PTR(self);
 }

--- a/pybricks/ev3devices/pb_type_ev3devices_ultrasonicsensor.c
+++ b/pybricks/ev3devices/pb_type_ev3devices_ultrasonicsensor.c
@@ -21,12 +21,7 @@ typedef struct _ev3devices_UltrasonicSensor_obj_t {
 
 // pybricks.ev3devices.UltrasonicSensor.__init__
 static mp_obj_t ev3devices_UltrasonicSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_REQUIRED(port));
-
-    ev3devices_UltrasonicSensor_obj_t *self = mp_obj_malloc(ev3devices_UltrasonicSensor_obj_t, type);
-    pb_type_device_init_class(&self->device_base, port_in, LEGO_DEVICE_TYPE_ID_EV3_ULTRASONIC_SENSOR);
-    return MP_OBJ_FROM_PTR(self);
+    return pb_type_device_make_new(type, n_args, n_kw, args, sizeof(ev3devices_UltrasonicSensor_obj_t), LEGO_DEVICE_TYPE_ID_EV3_ULTRASONIC_SENSOR);
 }
 
 // pybricks.ev3devices.UltrasonicSensor.distance(silent=True)

--- a/pybricks/pupdevices/pb_type_pupdevices_colordistancesensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_colordistancesensor.c
@@ -65,11 +65,8 @@ static mp_obj_t pupdevices_ColorDistanceSensor_light_on(mp_obj_t parent_obj, con
 
 // pybricks.pupdevices.ColorDistanceSensor.__init__
 static mp_obj_t pupdevices_ColorDistanceSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_REQUIRED(port));
-
-    pupdevices_ColorDistanceSensor_obj_t *self = mp_obj_malloc(pupdevices_ColorDistanceSensor_obj_t, type);
-    pb_type_device_init_class(&self->device_base, port_in, LEGO_DEVICE_TYPE_ID_COLOR_DIST_SENSOR);
+    pupdevices_ColorDistanceSensor_obj_t *self = pb_type_device_make_new(type, n_args, n_kw, args,
+        sizeof(pupdevices_ColorDistanceSensor_obj_t), LEGO_DEVICE_TYPE_ID_COLOR_DIST_SENSOR);
 
     // Create an instance of the Light class
     self->light = pb_type_ColorLight_external_obj_new(MP_OBJ_FROM_PTR(self), pupdevices_ColorDistanceSensor_light_on);

--- a/pybricks/pupdevices/pb_type_pupdevices_colorlightmatrix.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_colorlightmatrix.c
@@ -21,13 +21,7 @@ typedef struct _pupdevices_ColorLightMatrix_obj_t {
 
 // pybricks.pupdevices.ColorLightMatrix.__init__
 static mp_obj_t pupdevices_ColorLightMatrix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_REQUIRED(port));
-
-    pupdevices_ColorLightMatrix_obj_t *self = mp_obj_malloc(pupdevices_ColorLightMatrix_obj_t, type);
-    pb_type_device_init_class(&self->device_base, port_in, LEGO_DEVICE_TYPE_ID_TECHNIC_COLOR_LIGHT_MATRIX);
-
-    return MP_OBJ_FROM_PTR(self);
+    return pb_type_device_make_new(type, n_args, n_kw, args, sizeof(pupdevices_ColorLightMatrix_obj_t), LEGO_DEVICE_TYPE_ID_TECHNIC_COLOR_LIGHT_MATRIX);
 }
 
 // pybricks.pupdevices.ColorLightMatrix._get_color_id

--- a/pybricks/pupdevices/pb_type_pupdevices_colorsensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_colorsensor.c
@@ -28,11 +28,8 @@ typedef struct _pupdevices_ColorSensor_obj_t {
 
 // pybricks.pupdevices.ColorSensor.__init__
 static mp_obj_t pupdevices_ColorSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_REQUIRED(port));
-
-    pupdevices_ColorSensor_obj_t *self = mp_obj_malloc(pupdevices_ColorSensor_obj_t, type);
-    pb_type_device_init_class(&self->device_base, port_in, LEGO_DEVICE_TYPE_ID_SPIKE_COLOR_SENSOR);
+    pupdevices_ColorSensor_obj_t *self = pb_type_device_make_new(type, n_args, n_kw, args,
+        sizeof(pupdevices_ColorSensor_obj_t), LEGO_DEVICE_TYPE_ID_SPIKE_COLOR_SENSOR);
 
     // Create an instance of the LightArray class
     self->lights = common_LightArray_obj_make_new(&self->device_base, LEGO_DEVICE_MODE_PUP_COLOR_SENSOR__LIGHT, 3);

--- a/pybricks/pupdevices/pb_type_pupdevices_forcesensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_forcesensor.c
@@ -23,16 +23,10 @@ typedef struct _pupdevices_ForceSensor_obj_t {
 
 // pybricks.pupdevices.ForceSensor.__init__
 static mp_obj_t pupdevices_ForceSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_REQUIRED(port));
-
-    pupdevices_ForceSensor_obj_t *self = mp_obj_malloc(pupdevices_ForceSensor_obj_t, type);
-
     // This device only ever uses one mode at runtime, but this class was
     // historically async, so each method returns an awaitable constant in
     // async mode.
-    pb_type_device_init_class(&self->device_base, port_in, LEGO_DEVICE_TYPE_ID_SPIKE_FORCE_SENSOR);
-    return MP_OBJ_FROM_PTR(self);
+    return pb_type_device_make_new(type, n_args, n_kw, args, sizeof(pupdevices_ForceSensor_obj_t), LEGO_DEVICE_TYPE_ID_SPIKE_FORCE_SENSOR);
 }
 
 // pybricks.pupdevices.ForceSensor.touched

--- a/pybricks/pupdevices/pb_type_pupdevices_infraredsensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_infraredsensor.c
@@ -21,11 +21,8 @@ typedef struct _pupdevices_InfraredSensor_obj_t {
 
 // pybricks.pupdevices.InfraredSensor.__init__
 static mp_obj_t pupdevices_InfraredSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_REQUIRED(port));
-
-    pupdevices_InfraredSensor_obj_t *self = mp_obj_malloc(pupdevices_InfraredSensor_obj_t, type);
-    pb_type_device_init_class(&self->device_base, port_in, LEGO_DEVICE_TYPE_ID_WEDO2_MOTION_SENSOR);
+    pupdevices_InfraredSensor_obj_t *self = pb_type_device_make_new(type, n_args, n_kw, args,
+        sizeof(pupdevices_InfraredSensor_obj_t), LEGO_DEVICE_TYPE_ID_WEDO2_MOTION_SENSOR);
 
     // Reset sensor counter and get sensor back in sensing mode
     self->count_offset = *(int32_t *)pb_type_device_get_data_blocking(MP_OBJ_FROM_PTR(self), LEGO_DEVICE_MODE_PUP_WEDO2_MOTION_SENSOR__COUNT);

--- a/pybricks/pupdevices/pb_type_pupdevices_tiltsensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_tiltsensor.c
@@ -20,12 +20,7 @@ typedef struct _pupdevices_TiltSensor_obj_t {
 
 // pybricks.pupdevices.TiltSensor.__init__
 static mp_obj_t pupdevices_TiltSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_REQUIRED(port));
-
-    pupdevices_TiltSensor_obj_t *self = mp_obj_malloc(pupdevices_TiltSensor_obj_t, type);
-    pb_type_device_init_class(&self->device_base, port_in, LEGO_DEVICE_TYPE_ID_WEDO2_TILT_SENSOR);
-    return MP_OBJ_FROM_PTR(self);
+    return pb_type_device_make_new(type, n_args, n_kw, args, sizeof(pupdevices_TiltSensor_obj_t), LEGO_DEVICE_TYPE_ID_WEDO2_TILT_SENSOR);
 }
 
 // pybricks.pupdevices.TiltSensor.tilt

--- a/pybricks/pupdevices/pb_type_pupdevices_ultrasonicsensor.c
+++ b/pybricks/pupdevices/pb_type_pupdevices_ultrasonicsensor.c
@@ -23,11 +23,8 @@ typedef struct _pupdevices_UltrasonicSensor_obj_t {
 
 // pybricks.pupdevices.UltrasonicSensor.__init__
 static mp_obj_t pupdevices_UltrasonicSensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    PB_PARSE_ARGS_CLASS(n_args, n_kw, args,
-        PB_ARG_REQUIRED(port));
-
-    pupdevices_UltrasonicSensor_obj_t *self = mp_obj_malloc(pupdevices_UltrasonicSensor_obj_t, type);
-    pb_type_device_init_class(&self->device_base, port_in, LEGO_DEVICE_TYPE_ID_SPIKE_ULTRASONIC_SENSOR);
+    pupdevices_UltrasonicSensor_obj_t *self = pb_type_device_make_new(type, n_args, n_kw, args,
+        sizeof(pupdevices_UltrasonicSensor_obj_t), LEGO_DEVICE_TYPE_ID_SPIKE_ULTRASONIC_SENSOR);
 
     // Create an instance of the LightArray class
     self->lights = common_LightArray_obj_make_new(&self->device_base, LEGO_DEVICE_MODE_PUP_ULTRASONIC_SENSOR__LIGHT, 4);


### PR DESCRIPTION
Every Powered Up sensor class parses the same port argument, allocates its object, and initializes the device, so share one function for it. Saves around 380 bytes on the Move Hub.