### PR TITLE
tools/tag-stm32lib.sh: Don't repeat the pybricks- prefix.

### DIFF
--- a/tools/tag-stm32lib.sh
+++ b/tools/tag-stm32lib.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Creates tag in micropython submodule before rebasing so that we don't break
+# Creates tag in stm32lib submodule before rebasing so that we don't break
 # things.
 
 set -e
@@ -9,7 +9,9 @@ SCRIPT_DIR=$(dirname "$0")
 
 cd "$SCRIPT_DIR/../micropython/lib/stm32lib"
 
-TAG=pybricks-$(git describe --tags)
+# Describe against the upstream vendor tags only, otherwise a previous
+# pybricks- tag is found and the prefix is added a second time.
+TAG=pybricks-$(git describe --tags --exclude 'pybricks-*')
 
 git tag $TAG
 git push origin $TAG


### PR DESCRIPTION
Once we have tagged the fork, git describe finds our own tag and the prefix is added a second time. Describe against the upstream vendor tags only so the name is always relative to the release the fork is based on.