### PR TITLE
bricks/buildhat: Set MICROPY_QSTRDEFS_PORT for shared qstrs.

### DIFF
--- a/bricks/buildhat/CMakeLists.txt
+++ b/bricks/buildhat/CMakeLists.txt
@@ -45,6 +45,11 @@ set(MICROPY_PORT_DIR ${MICROPY_BOARD_DIR})
 
 set(MICROPY_USER_FROZEN_MANIFEST ${MICROPY_FROZEN_MANIFEST})
 
+# Shared Pybricks qstrs (e.g. "pybricks.hubs"). Without this, only the
+# auto-collected "pybricks_dot_hubs" style names exist and
+# "import pybricks.hubs" fails.
+set(MICROPY_QSTRDEFS_PORT ${TOP_DIR}/bricks/_common/qstrdefs.h)
+
 string(TOLOWER ${MICROPY_BOARD} PICO_BOARD)
 
 # Set the amount of C heap, if it's not already set.


### PR DESCRIPTION
The Build HAT is the only CMake-built target. Makefile targets receive the shared Pybricks qstr definitions via QSTR_DEFS in bricks/_common/common.mk, but the CMake build never set the equivalent MICROPY_QSTRDEFS_PORT. The qstr generator then used "pybricks_dot_*" strings for all seven MP_QSTR_pybricks_dot_* identifiers, so "import pybricks.hubs" failed and only the "pybricks_dot_hubs" spelling worked.

Verified on a Build HAT loaded from a Raspberry Pi 5: all seven dotted modules in the build (experimental, geometry, hubs, iodevices, messaging, parameters, tools) now import, and "from pybricks.hubs import BuildHat" works.

Firmware size: 152520 -> 152488 bytes (-32).

Fixes https://github.com/pybricks/support/issues/2824