### PR TITLE
pbio/sys: Add Build HAT HMI that starts the status light animation.

### DIFF
--- a/bricks/_common/sources.mk
+++ b/bricks/_common/sources.mk
@@ -242,6 +242,7 @@ PBIO_SRC_C = $(addprefix lib/pbio/,\
 	sys/battery.c \
 	sys/command.c \
 	sys/core.c \
+	sys/hmi_buildhat.c \
 	sys/hmi_ev3.c \
 	sys/hmi_ev3_ui.c \
 	sys/hmi_none.c \

--- a/lib/pbio/platform/build_hat/pbsysconfig.h
+++ b/lib/pbio/platform/build_hat/pbsysconfig.h
@@ -10,7 +10,7 @@
 #define PBSYS_CONFIG_BATTERY_CHARGER                (0)
 #define PBSYS_CONFIG_HMI                            (1)
 #define PBSYS_CONFIG_HMI_STOP_BUTTON                (0) // does not exist but pbsys_main() requires this to be defined
-#define PBSYS_CONFIG_HMI_NONE                       (1)
+#define PBSYS_CONFIG_HMI_BUILDHAT                   (1)
 #define PBSYS_CONFIG_HMI_NUM_SLOTS                  (0)
 #define PBSYS_CONFIG_HOST                           (1)
 #define PBSYS_CONFIG_HOST_EVENT_OUT_SIZE            (512)

--- a/lib/pbio/sys/hmi_buildhat.c
+++ b/lib/pbio/sys/hmi_buildhat.c
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2026 The Pybricks Authors
+
+// Provides the Human Machine Interface (HMI) for the Build HAT.
+// There is nothing to select, so the REPL starts right after boot.
+
+#include <pbsys/config.h>
+
+#if PBSYS_CONFIG_HMI_BUILDHAT
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <pbio/button.h>
+#include <pbio/light.h>
+#include <pbio/os.h>
+#include <pbsys/light.h>
+#include <pbsys/main.h>
+#include <pbsys/status.h>
+
+void pbsys_hmi_init(void) {
+}
+
+void pbsys_hmi_deinit(void) {
+}
+
+void pbsys_hmi_stop_animation(void) {
+}
+
+void pbsys_hmi_connection_changed_handler(void) {
+}
+
+pbio_error_t pbsys_hmi_await_program_selection(void) {
+
+    do {
+        if (pbsys_status_test(PBIO_PYBRICKS_STATUS_SHUTDOWN_REQUEST)) {
+            return PBIO_ERROR_CANCELED;
+        }
+        pbio_os_run_processes_and_wait_for_event();
+    } while (pbdrv_button_get_pressed());
+
+    // Start the "ready" animation, same as hmi_pup.c does after program
+    // selection.
+    #if PBSYS_CONFIG_STATUS_LIGHT_STATE_ANIMATIONS
+    pbio_color_light_start_breathe_animation(pbsys_status_light_main, PBSYS_CONFIG_STATUS_LIGHT_STATE_ANIMATIONS_HUE);
+    #elif PBSYS_CONFIG_STATUS_LIGHT
+    pbio_color_light_off(pbsys_status_light_main);
+    #endif
+
+    return pbsys_main_program_request_start(PBIO_PYBRICKS_USER_PROGRAM_ID_REPL, PBSYS_MAIN_PROGRAM_START_REQUEST_TYPE_BOOT);
+}
+
+#endif // PBSYS_CONFIG_HMI_BUILDHAT


### PR DESCRIPTION
The Build HAT used the "none" HMI, which requested the REPL without first starting the status light animation, so the LED stayed off after boot even though the platform enables state animations with a green hue.

Rather than change hmi_none.c, which should stay the variant for hubs with no user interface at all, add hmi_buildhat.c selected by a new PBSYS_CONFIG_HMI_BUILDHAT. It is a copy of hmi_none.c that starts the breathe animation (or turns the light off when animations are disabled) before requesting the REPL, as hmi_pup.c does after program selection. The Build HAT has a status light but no buttons, display, Bluetooth or USB, so its user interface will need its own design later; this only starts the animation that is already configured.

Verified on a Build HAT loaded from a Raspberry Pi 5: the LED breathes green as soon as the firmware is ready.

Firmware size: 152188 -> 152316 bytes (+128).

Fixes https://github.com/pybricks/support/issues/2825

Edited 2026-09-09: reworked after review. The first version changed hmi_none.c directly; this version adds hmi_buildhat.c instead, as suggested in the comments below.
