### PR TITLE
drv/bluetooth: Scan at a 50% duty cycle so broadcasting works.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 - On the Move Hub, `bytes()` and `bytes.find()` now truncate out-of-range
   values instead of raising `ValueError`.
 
+### Fixed
+- Fixed slow broadcasting while observing at the same time ([support#2822]).
+- Fixed slow observing while connected to a computer or app ([support#2822]).
+
+[support#2822]: https://github.com/orgs/pybricks/discussions/2822
+
 [Unreleased]: https://github.com/pybricks/pybricks-micropython/compare/v4.1.0b3...HEAD
 
 ### Fixed

--- a/lib/pbio/drv/bluetooth/bluetooth_btstack.c
+++ b/lib/pbio/drv/bluetooth/bluetooth_btstack.c
@@ -1156,7 +1156,8 @@ pbio_error_t pbdrv_bluetooth_start_broadcasting_func(pbio_os_state_t *state, voi
     }
 
     bd_addr_t null_addr = { };
-    gap_advertisements_set_params(0xA0, 0xA0, PBIO_BLUETOOTH_AD_TYPE_ADV_NONCONN_IND, 0, null_addr, 0x7, 0);
+    // Advertise every 30ms so that other hubs receive broadcasts quickly.
+    gap_advertisements_set_params(0x30, 0x30, PBIO_BLUETOOTH_AD_TYPE_ADV_NONCONN_IND, 0, null_addr, 0x7, 0);
     recorded_events.advertise_enable_complete = false;
     gap_advertisements_enable(true);
 
@@ -1175,7 +1176,10 @@ pbio_error_t pbdrv_bluetooth_start_observing_func(pbio_os_state_t *state, void *
     PBIO_OS_ASYNC_BEGIN(state);
 
     if (!pbdrv_bluetooth_is_observing) {
-        gap_set_scan_params(0, 0x30, 0x30, 0);
+        // 70ms interval, 35ms window. The 50% duty cycle leaves radio time
+        // for broadcasting while observing, and the longer interval spends
+        // less of the radio on starting and ending scans.
+        gap_set_scan_params(0, 0x70, 0x38, 0);
         gap_start_scan();
         pbdrv_bluetooth_is_observing = true;
         // REVISIT: use callback to await operation

--- a/lib/pbio/drv/bluetooth/bluetooth_stm32_bluenrg.c
+++ b/lib/pbio/drv/bluetooth/bluetooth_stm32_bluenrg.c
@@ -587,6 +587,8 @@ pbio_error_t pbdrv_bluetooth_start_broadcasting_func(pbio_os_state_t *state, voi
 
     if (pbdrv_bluetooth_advertising_state != PBDRV_BLUETOOTH_ADVERTISING_STATE_BROADCASTING) {
         PBIO_OS_AWAIT_WHILE(state, write_xfer_size);
+        // This chip cannot broadcast faster than every 100ms, so other hubs
+        // receive from it more slowly than they do from each other.
         aci_gap_set_non_connectable_begin(ADV_NONCONN_IND, STATIC_RANDOM_ADDR);
         PBIO_OS_AWAIT_UNTIL(state, hci_command_complete);
         status = aci_gap_set_non_connectable_end();
@@ -642,7 +644,10 @@ pbio_error_t pbdrv_bluetooth_start_observing_func(pbio_os_state_t *state, void *
     // the observer role which would use more RAM in the Bluetooth chip
 
     PBIO_OS_AWAIT_WHILE(state, write_xfer_size);
-    aci_gap_start_general_conn_establish_proc_begin(PASSIVE_SCAN, 0x30, 0x30, STATIC_RANDOM_ADDR, 0);
+    // 70ms interval, 35ms window. The 50% duty cycle leaves radio time for
+    // broadcasting while observing, and the longer interval spends less of the
+    // radio on starting and ending scans.
+    aci_gap_start_general_conn_establish_proc_begin(PASSIVE_SCAN, 0x70, 0x38, STATIC_RANDOM_ADDR, 0);
     PBIO_OS_AWAIT_UNTIL(state, hci_command_status);
     status = aci_gap_start_general_conn_establish_proc_end();
     if (status == BLE_STATUS_SUCCESS) {

--- a/lib/pbio/drv/bluetooth/bluetooth_stm32_cc2640.c
+++ b/lib/pbio/drv/bluetooth/bluetooth_stm32_cc2640.c
@@ -1562,10 +1562,19 @@ static const struct {
     {TGAP_GEN_DISC_ADV_INT_MAX, 40},
     {TGAP_CONN_ADV_INT_MIN, 40},
     {TGAP_CONN_ADV_INT_MAX, 40},
-    // scan interval general discovery: 48 * 0.625ms = 30ms
-    {TGAP_GEN_DISC_SCAN_INT, 48},
-    // scan window general discovery: 48 * 0.625ms = 30ms
-    {TGAP_GEN_DISC_SCAN_WIND, 48},
+    // Scan interval 112 * 0.625ms = 70ms. Starting and ending a scan costs
+    // radio and scheduler time, so a longer interval leaves more of the radio
+    // for broadcasting. 70ms is not a multiple of any hub's advertising
+    // interval, so reception does not settle into a pattern of missing them.
+    {TGAP_GEN_DISC_SCAN_INT, 112},
+    // Scan window 56 * 0.625ms = 35ms. The 50% duty cycle leaves radio time
+    // for broadcasting while observing.
+    {TGAP_GEN_DISC_SCAN_WIND, 56},
+    // The Bluetooth chip quietly uses these instead of the two above whenever
+    // there is a connection, so they have to match or observing collapses
+    // while connected to Pybricks Code.
+    {TGAP_CONN_SCAN_INT, 112},
+    {TGAP_CONN_SCAN_WIND, 56},
     {TGAP_CONN_EST_INT_MIN, 40},
     {TGAP_CONN_EST_INT_MAX, 40},
     // scan interval connection established: 48 * 0.625ms = 30ms


### PR DESCRIPTION
All three Bluetooth drivers scanned with the window equal to the interval, 30ms of every 30ms, so the radio was never free and a hub that broadcasts while observing could hardly transmit. Measurements in https://github.com/orgs/pybricks/discussions/2822 show a City Hub dropping from 28 packets/s to under 4 when it broadcasts and observes at the same time.

Curiously it was fine when connected to a computer. The reason is that GAP_DeviceDiscoveryRequest() picks TGAP_CONN_SCAN_INT and _WIND when a connection exists and the general discovery parameters when it does not. We only set the latter, so the chip fell back to TI's defaults of 300ms interval and 150ms window, a 50% duty cycle, whenever a computer was connected. Using a 50% duty cycle always is what this does.

The scan interval is also kept shorter than the advertising interval of a peer hub. When the two periods are close, the phase between them drifts slowly, misses come in runs and reception latency is spiky rather than merely averaging out.

Broadcasting on the BTstack hubs went from every 100ms to every 30ms. 100ms was the Bluetooth 4.x minimum for non-connectable advertising, but the CC2564C is 5.1, where the minimum is 20ms, so the old value only limited how quickly other hubs could hear it. The Move Hub keeps 100ms because BlueNRG-MS is a 4.1 controller and cannot go faster; it is the most limited hub, so it is allowed to be the slow one rather than holding the others back.

Expected reception latency is now roughly 50 to 60ms between any pair of hubs, except from the Move Hub at about 200ms.