### PR TITLE
pbio/platform/build_hat: Reclaim bootloader RAM for the GC heap.

### DIFF
--- a/lib/pbio/platform/build_hat/rpi_build_hat.ld
+++ b/lib/pbio/platform/build_hat/rpi_build_hat.ld
@@ -1,7 +1,19 @@
 /*
 Modified from
 pico-sdk/src/rp2_common/pico_standard_link/memmap_no_flash.ld
-to limit RAM use to 240K for use with bootloader.
+for use with the Build HAT bootloader (BHBL).
+
+The firmware runs entirely from RAM. While loading it, BHBL uses the top
+16 KiB of RAM (0x2003C000-0x20040000) for its own stack and data.
+
+Once BHBL hands control to the firmware, it is no longer running, so that
+16 KiB is unused. Thus, the RAM entry in the MEMORY code block in this file ends at
+the end of RAM rather than at 0x2003C000. Since the GC heap runs to the end
+of that entry, the reclaimed 16 KiB becomes heap.
+
+The loaded image (.text through .data) must still end below 0x2003C000, or
+BHBL would overwrite itself during loading. An ASSERT at the end of this
+file checks that at link time.
 */
 /* Based on GCC ARM embedded samples.
    Defines the following symbols for use by code:
@@ -28,7 +40,7 @@ to limit RAM use to 240K for use with bootloader.
 
 MEMORY
 {
-    RAM(rwx) : ORIGIN =  0x20000000, LENGTH = 240k      /* <--- changed here */
+    RAM(rwx) : ORIGIN =  0x20000000, LENGTH = 256k
     SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k
     SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k
 }
@@ -250,6 +262,11 @@ SECTIONS
      * lower demand for memory at runtime.
      */
     ASSERT((pbsys_storage_heap_end - pbsys_storage_heap_start) > 32*1024, "GcHeap is too small")
+
+    /* The loaded image must not reach the RAM that BHBL uses while loading
+     * it. See the comment at the top of this file. */
+    __bootloader_ram_start = 0x2003C000;
+    ASSERT(__data_end__ <= __bootloader_ram_start, "Firmware image is too large: it must end below 0x2003C000 (see the comment at the top of rpi_build_hat.ld). Link aborted, no firmware.bin or firmware.elf created.")
 
     ASSERT( __binary_info_header_end - __logical_binary_start <= 256, "Binary info must be in first 256 bytes of the binary")
     /* todo assert on extra code */


### PR DESCRIPTION
The Build HAT linker script limited RAM to 240k because the bootloader (BHBL) uses the top 16 KiB while it loads the firmware. Once BHBL jumps to the firmware it is no longer running, so the firmware is free to use that RAM.

Checked against the bootloader source (`bhbl-pico/bhbl.ld` in the official firmware repo): BHBL's RAM region is `ORIGIN = 0x2003c000, LENGTH = 0x3f00`.

Changes to `rpi_build_hat.ld`:

- `RAM` becomes `LENGTH = 256k`, so the GC heap, which runs to the end of the RAM region, gains the 16 KiB.
- A link-time `ASSERT(__data_end__ <= 0x2003C000)` makes the build fail if the loaded image (`.text` through `.data`) ever grows into the RAM that BHBL is using while it copies the image in. The `.bss` section and heap may extend above that address since the firmware's own startup code zeroes `.bss` after the jump.
- A header comment explaining the layout, replacing the "limit RAM use to 240K" note.

One region rather than a separate `.bss` region gives the whole 16 KiB to the heap and allows the `.bss` region to be sized as needed.

Verified on a Build HAT loaded from a Raspberry Pi 5: `micropython.mem_info()` GC total 80256 -> 96256 bytes.

Firmware size: 152188 -> 152188 bytes (unchanged).

Fixes https://github.com/pybricks/support/issues/2484

Edit: the first version kept the last 256 bytes out of the heap to preserve the firmware signature BHBL writes there. Dropped after review, since it's not needed.
